### PR TITLE
fix(auth): AUTH_SECRET is held to the 32 characters the docs require

### DIFF
--- a/apps/web/src/lib/session.test.ts
+++ b/apps/web/src/lib/session.test.ts
@@ -18,6 +18,17 @@ describe("session token", () => {
     expect(session).toEqual({ userId: "user-1", email: "admin@local" });
   });
 
+  // Every document and the deploy path asks for 32: .env.example, CONTRIBUTING,
+  // deploy/README, getting-started, and the cloud compose file, which refuses
+  // to start without it. The signing key for every board session should not be
+  // allowed to be half of what the operator was told to provide.
+  it("refuses a secret shorter than the 32 characters the docs require", async () => {
+    process.env.AUTH_SECRET = "a".repeat(31);
+    await expect(
+      signSession({ userId: "user-1", email: "a@b.c" }),
+    ).rejects.toThrow(/32/);
+  });
+
   it("rejects a tampered token", async () => {
     process.env.AUTH_SECRET = SECRET;
     const token = await signSession({ userId: "user-1", email: "a@b.c" });

--- a/apps/web/src/lib/session.ts
+++ b/apps/web/src/lib/session.ts
@@ -8,10 +8,17 @@ export type SessionPayload = {
   email: string;
 };
 
+// 32 is the floor every document and the deploy path already state, and the
+// cloud compose file refuses to boot without it. This is the key that signs
+// every session, so the code enforces what the operator was told to provide.
+const MIN_SECRET_LENGTH = 32;
+
 function secretKey(): Uint8Array {
   const secret = process.env.AUTH_SECRET;
-  if (!secret || secret.length < 16) {
-    throw new Error("AUTH_SECRET must be set (16+ characters)");
+  if (!secret || secret.length < MIN_SECRET_LENGTH) {
+    throw new Error(
+      `AUTH_SECRET must be set (${MIN_SECRET_LENGTH}+ characters)`,
+    );
   }
   return new TextEncoder().encode(secret);
 }


### PR DESCRIPTION
## What

`apps/web/src/lib/session.ts` rejected an `AUTH_SECRET` only below **16** characters, and
said "16+ characters" in its own error. Everything else in the repo asks for **32**:

- `.env.example`
- `CONTRIBUTING.md`
- `deploy/README.md`
- `docs/getting-started.md`
- `deploy/docker-compose.cloud.yml`, which refuses to start with
  `set AUTH_SECRET in deploy/.env (32+ chars)`

So an operator who read the docs supplied 32, and an operator who did not could run a
board whose session signing key was half the published floor with nothing reporting it.

## Approach

Test first. A 31 character secret signed a token happily before this change and throws
after it. The limit is named once as `MIN_SECRET_LENGTH` instead of being repeated in the
error string, so the check and the message cannot drift apart again.

## Breaking change, stated plainly

An instance already running a 16 to 31 character `AUTH_SECRET` will refuse to start until
the secret is lengthened, and lengthening it rotates sessions and signs everyone out once.

Both values shipped in the repo already clear the floor: `docker-compose.yml` at 36
characters and `.env.example` at 51. The quickstart and the compose path are unaffected.

This is your call to make. If you would rather keep existing instances booting, the
alternative is to lower the docs to 16 everywhere, and I am happy to send that instead.

## Verification

`pnpm test` green: 267 tests in `apps/web` including the new one, 454 across the repo.

## Note on the branch name

No `AGB-` prefix: no board access, and inventing a card ID would collide with a real one.
