### PR TITLE
fix(mcp): unknown keys are refused, not dropped in silence

### DIFF
--- a/packages/mcp-core/src/schemas/tools.ts
+++ b/packages/mcp-core/src/schemas/tools.ts
@@ -31,7 +31,7 @@ import {
 
 export const MissionListInputSchema = z.object({
   status: MissionStatusSchema.optional(),
-});
+}).strict();
 
 export const MissionListOutputSchema = z.object({
   missions: z.array(MissionSummarySchema),
@@ -39,7 +39,7 @@ export const MissionListOutputSchema = z.object({
 
 export const MissionGetInputSchema = z.object({
   mission_id: z.string().min(1),
-});
+}).strict();
 
 export const MissionGetOutputSchema = z.object({
   mission: MissionSchema,
@@ -55,7 +55,7 @@ export const MissionCreateInputSchema = z.object({
   objective: z.string().optional(),
   context: z.string().optional(),
   status: MissionStatusSchema.optional(),
-});
+}).strict();
 
 export const MissionCreateOutputSchema = z.object({
   mission: MissionSchema,
@@ -72,7 +72,7 @@ export const MissionUpdateInputSchema = z.object({
   objective: z.string().optional(),
   context: z.string().optional(),
   status: MissionStatusSchema.optional(),
-});
+}).strict();
 
 export const MissionUpdateOutputSchema = z.object({
   mission: MissionSchema,
@@ -90,7 +90,7 @@ export const MissionDeleteInputSchema = z.object({
     .describe(
       "Deletes the mission even when it holds cards, detaching them first. Omitted or false, a mission with cards is refused with the count that blocks it.",
     ),
-});
+}).strict();
 
 export const MissionDeleteOutputSchema = z.object({
   deleted: z.literal(true),
@@ -106,7 +106,7 @@ const ProjectRefSchema = z
     "Project uuid or its card prefix (e.g. AGB). Resolved in the token workspace; call project_list to see both.",
   );
 
-export const ProjectListInputSchema = z.object({});
+export const ProjectListInputSchema = z.object({}).strict();
 
 export const ProjectListOutputSchema = z.object({
   projects: z.array(ProjectSchema),
@@ -125,7 +125,7 @@ const ProjectVersionSchema = z.string().max(200);
 
 export const ProjectGetInputSchema = z.object({
   project_id: ProjectRefSchema,
-});
+}).strict();
 
 export const ProjectGetOutputSchema = z.object({
   project: ProjectDetailSchema,
@@ -149,7 +149,7 @@ export const ProjectCreateInputSchema = z.object({
     .describe(
       "Card prefix, 2 to 4 letters or digits (e.g. AGB). Derived from the name when omitted.",
     ),
-});
+}).strict();
 
 export const ProjectCreateOutputSchema = z.object({
   project: ProjectDetailSchema,
@@ -181,7 +181,7 @@ export const ProjectUpdateInputSchema = z
       .describe(
         "New card prefix, 2 to 4 letters or digits. Only accepted while the project has no cards.",
       ),
-  })
+  }).strict()
   .refine(
     (value) =>
       value.name !== undefined ||
@@ -214,7 +214,7 @@ export const ProjectDeleteInputSchema = z.object({
     .describe(
       "Deletes the project even when it holds cards, destroying every card in it. Omitted or false, a project with cards is refused with the count that blocks it.",
     ),
-});
+}).strict();
 
 export const ProjectDeleteOutputSchema = z.object({
   deleted: z.literal(true),
@@ -234,7 +234,7 @@ export const TaskListInputSchema = z.object({
   priority: PrioritySchema.optional(),
   type: TaskTypeSchema.optional(),
   awaiting_review_by: z.union([z.literal("me"), z.string().min(1)]).optional(),
-});
+}).strict();
 
 export const TaskListOutputSchema = z.object({
   tasks: z.array(TaskSummarySchema),
@@ -249,7 +249,7 @@ const TaskIdSchema = z
 
 export const TaskGetInputSchema = z.object({
   task_id: TaskIdSchema,
-});
+}).strict();
 
 /**
  * The board's recipe for measuring a run on this CLI. It rides in the briefing
@@ -307,7 +307,7 @@ export const TaskSearchInputSchema = z.object({
   status: z.union([CardStatusSchema, z.array(CardStatusSchema)]).optional(),
   /** Hits to return, best match first. Default 5, at most 20. */
   limit: z.number().int().min(1).max(20).optional(),
-});
+}).strict();
 
 /** One search hit: enough to decide "same thing or not" without a task_get. */
 export const TaskSearchHitSchema = z.object({
@@ -356,7 +356,7 @@ export const TaskCreateInputSchema = z
     devolve_para: ReviewerSchema.optional(),
     harness: HarnessSchema.optional(),
     origem: OrigemSchema,
-  })
+  }).strict()
   .superRefine((value, ctx) => {
     if (value.inherit && !value.supersedes) {
       ctx.addIssue({
@@ -412,7 +412,7 @@ export const TaskClaimInputSchema = z.object({
    * when the usage recipe has printed it.
    */
   transcript: TranscriptRefSchema.optional(),
-});
+}).strict();
 
 export const HarnessDivergenceSchema = z.object({
   recommended: HarnessSchema,
@@ -436,7 +436,7 @@ export const TaskClaimOutputSchema = z.object({
 export const TaskReleaseInputSchema = z.object({
   task_id: TaskIdSchema,
   reason: z.string().trim().min(1).max(1_000),
-});
+}).strict();
 
 export const TaskReleaseOutputSchema = z.object({
   task: TaskSchema,
@@ -446,7 +446,7 @@ export const TaskReleaseOutputSchema = z.object({
 /** Extends the lease of a long-running executor without adding timeline prose. */
 export const TaskHeartbeatInputSchema = z.object({
   task_id: TaskIdSchema,
-});
+}).strict();
 
 export const TaskHeartbeatOutputSchema = z.object({
   task_id: z.string().min(1),
@@ -506,7 +506,7 @@ export const TaskUpdateInputSchema = z
     /** Discard an in-execution card, optionally linking its existing continuation. */
     status: z.literal("descartado").optional(),
     superseded_by: TaskIdSchema.optional(),
-  })
+  }).strict()
   .refine(
     (value) =>
       value.comment !== undefined ||
@@ -606,7 +606,7 @@ export const TaskDeliverInputSchema = z.object({
    * omit keep whatever the claim recorded.
    */
   transcript: TranscriptRefSchema.optional(),
-});
+}).strict();
 
 export const TaskDeliverOutputSchema = z.object({
   task: TaskSchema,
@@ -628,7 +628,7 @@ export const TaskDeliverOutputSchema = z.object({
  */
 export const TaskDeleteInputSchema = z.object({
   task_id: TaskIdSchema,
-});
+}).strict();
 
 export const TaskDeleteOutputSchema = z.object({
   deleted: z.literal(true),
@@ -641,7 +641,7 @@ export const TaskDeleteOutputSchema = z.object({
 export const BranchRegisterInputSchema = z.object({
   task_id: TaskIdSchema,
   branch: z.string().min(1),
-});
+}).strict();
 
 export const BranchRegisterOutputSchema = z.object({
   task: TaskSchema,
@@ -649,7 +649,7 @@ export const BranchRegisterOutputSchema = z.object({
 
 export const HarnessRecommendInputSchema = z.object({
   type: CardapioTaskTypeSchema,
-});
+}).strict();
 
 export const HarnessRecommendOutputSchema = z.object({
   harness: z.object({
@@ -712,7 +712,7 @@ export const HarnessSetInputSchema = z
      */
     chain: z.array(z.string().min(1)).min(1).max(8).optional(),
     effort: EffortSchema,
-  })
+  }).strict()
   .refine((input) => Boolean(input.model) || Boolean(input.chain?.length), {
     message: "Send a model, a chain, or both.",
     path: ["model"],
@@ -749,7 +749,7 @@ export const ModelPriceSchema = z.object({
   updated_at: z.string().nullable(),
 });
 
-export const HarnessListInputSchema = z.object({});
+export const HarnessListInputSchema = z.object({}).strict();
 
 export const HarnessListOutputSchema = z.object({
   policy: z.array(CardapioPolicyEntrySchema),
@@ -782,7 +782,7 @@ export const ExecutorsUpdateInputSchema = z
     add_models: z.array(z.string().min(1)).optional(),
     remove_models: z.array(z.string().min(1)).optional(),
     remove: z.boolean().optional(),
-  })
+  }).strict()
   .superRefine((value, ctx) => {
     if (
       value.remove &&
@@ -959,7 +959,7 @@ export const InsightsQueryInputSchema = z.object({
     .datetime()
     .optional()
     .describe("ISO timestamp; attempts that finished after it are excluded."),
-});
+}).strict();
 
 export const InsightsQueryOutputSchema = z.object({
   period: z.object({

--- a/packages/mcp-core/tests/schemas.test.ts
+++ b/packages/mcp-core/tests/schemas.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   TaskDeliverInputSchema,
+  TaskUpdateInputSchema,
   MCP_TOOL_NAMES,
   MissionCreateInputSchema,
   MissionDeleteInputSchema,
@@ -421,5 +422,40 @@ describe("task_deliver usage and artifacts", () => {
     expect(
       isTelemetryIncomplete({ tokens_in: 10, tokens_out: 20, turns: 2 }),
     ).toBe(true);
+  });
+
+  it("refuses an unknown key instead of dropping it", () => {
+    // The historical case: docs/mcp.md called the flag "reviewed" while the
+    // field is "revisado". Without strict the key vanished, the card was
+    // never marked, and nothing anywhere said so.
+    const typo = TaskUpdateInputSchema.safeParse({
+      task_id: "AGB-1",
+      reviewed: true,
+    });
+    expect(typo.success).toBe(false);
+
+    // The same shape with the real field is accepted, so strict costs the
+    // caller nothing when the caller is right.
+    const correct = TaskUpdateInputSchema.safeParse({
+      task_id: "AGB-1",
+      revisado: true,
+    });
+    expect(correct.success).toBe(true);
+  });
+
+  it("keeps every tool contract strict, so no surface drifts back", () => {
+    for (const name of MCP_TOOL_NAMES) {
+      // A schema can carry several refinements, and each one wraps the
+      // last, so unwrap until the object itself shows up. That is where
+      // strict lives.
+      let object: unknown = toolContracts[name].input;
+      while ((object as { _def?: { schema?: unknown } })._def?.schema) {
+        object = (object as { _def: { schema: unknown } })._def.schema;
+      }
+      expect(
+        (object as { _def: { unknownKeys?: string } })._def.unknownKeys,
+        `${name} must be strict`,
+      ).toBe("strict");
+    }
   });
 });


### PR DESCRIPTION
## Rewritten after your fix

This PR originally carried two commits: one adding `comment_kind` to `task_update`,
and one making the input schemas strict. You landed `comment_kind` yourself, with the
same shape I had proposed, so that commit is dropped and this PR is now only the
second half.

Rebased on current `main`, so it covers all 26 tools rather than the 21 there were
when I opened it.

## What this does

Every tool input object accepted keys it did not declare and threw them away without
a word, which is the opposite of the typed errors the surface promises. The cost is
not theoretical, it has been paid twice:

- `docs/mcp.md` documented the flag as `reviewed` while the field is `revisado`. An
  agent that followed the doc had its key dropped, the card was never marked, and
  nothing came back to say so. (Fixed in the docs by PR #2.)
- `comment_kind` reached `task_search` before it reached `task_update`, so the key
  vanished and `reports_count` could only ever be zero. The suite caught that one;
  nothing else did, because the drop is silent by construction.

Strict turns the second class of failure into `INVALID_ARGUMENT` naming the key.

## Implementation note worth a look in review

On the refined schemas, `.strict()` goes on the object, before the refinements. A
schema can carry several refinements and each one wraps the last: `task_update`
already carries three. Putting strict on the object means it survives however many
it grows.

The guard test unwraps refinements in a loop for the same reason. My first version
unwrapped a single level, and it failed on `task_update` precisely because of that
third refinement, which is how I noticed.

Worth saying explicitly, since it was my first suspicion and it turned out to be
wrong: **the published JSON Schema is fine today**. I checked `tools/list` against a
running board on clean `main`. `inputSchemaFor` unwraps only one level, but
`zod-to-json-schema` recurses through the effects on its own, so `task_update`
publishes its full property set. There is no bug there to fix.

## Tests

- the historical `reviewed`/`revisado` typo is refused, while the real field still passes
- a guard walks `MCP_TOOL_NAMES` and names any contract that drifts back to non-strict

I verified the guard by removing `.strict()` from one schema and confirming it fails
with `task_get must be strict: expected 'strip' to be 'strict'`.

`pnpm test` green: 88 + 122 + 324 = 534.

## Breaking change

A caller sending a field the tool never declared used to look like it worked, and did
not. It now gets `INVALID_ARGUMENT`. That is the point of the change, but it is a
behaviour change and deserves a line in the release notes.

## Note on the branch name

No `OCL-` prefix: no board access here, and an invented card ID would collide with a
real one. Happy to rebase onto one you assign.
