### PR TITLE
feat(mcp): task_list answers a page, and says when there is more

### DIFF
--- a/apps/web/src/mcp/server.ts
+++ b/apps/web/src/mcp/server.ts
@@ -71,7 +71,7 @@ const DESCRIPTIONS: Record<McpToolName, string> = {
   mission_delete:
     "Deletes an empty mission shell. A mission with cards is refused with its count unless force: true explicitly detaches those cards first.",
   task_list:
-    "Fila de cards do workspace. Filtros: projeto, missão, status, prioridade, awaiting_review_by.",
+    "Fila de cards do workspace. Filtros: projeto, missão, status, prioridade, awaiting_review_by, limit (default 50, máx 200). A resposta traz truncated: true quando o board tem mais cards do que coube.",
   task_get:
     "Card autocontido: contrato + harness + missão + convenção de branch (markdown).",
   task_search:

--- a/apps/web/src/mcp/tools.integration.test.ts
+++ b/apps/web/src/mcp/tools.integration.test.ts
@@ -1685,6 +1685,46 @@ describe("MCP tool edge cases against a test db", () => {
     expect(byAgent.ok).toBe(true);
   });
 
+  it("cuts task_list to a limit and says when the board holds more", async () => {
+    world = await createTestWorld();
+    // The seeded world already holds a card, so this makes the board bigger
+    // than the limit under test either way.
+    for (let i = 0; i < 4; i++) {
+      const made = await invokeTool(world.db, ctx(), "task_create", {
+        project_id: world.projectId,
+        title: `Card number ${i}`,
+        type: "feature",
+        o_que: "x",
+        por_que: "y",
+        como_confirmo: [{ step: "a", expected: "b" }],
+        origem: { session_id: "sess_limit", cli: "overclock" },
+      });
+      expect(made.ok).toBe(true);
+    }
+
+    const cut = await invokeTool(world.db, ctx(), "task_list", { limit: 2 });
+    expect(cut.ok).toBe(true);
+    if (!cut.ok) return;
+    const cutOut = TaskListOutputSchema.parse(cut.value);
+    expect(cutOut.tasks).toHaveLength(2);
+    expect(cutOut.limit).toBe(2);
+    // The point of the flag: two cards is not the board.
+    expect(cutOut.truncated).toBe(true);
+
+    const whole = await invokeTool(world.db, ctx(), "task_list", { limit: 200 });
+    expect(whole.ok).toBe(true);
+    if (!whole.ok) return;
+    const wholeOut = TaskListOutputSchema.parse(whole.value);
+    expect(wholeOut.truncated).toBe(false);
+    expect(wholeOut.tasks.length).toBeGreaterThan(2);
+
+    // Oldest first still holds, so a limit takes the head of the queue and
+    // not an arbitrary slice of it.
+    expect(cutOut.tasks.map((t) => t.id)).toEqual(
+      wholeOut.tasks.slice(0, 2).map((t) => t.id),
+    );
+  });
+
   it("tells the agent to claim before delivering an open card", async () => {
     world = await createTestWorld();
     const created = await invokeTool(world.db, ctx(), "task_create", {

--- a/apps/web/src/mcp/tools.ts
+++ b/apps/web/src/mcp/tools.ts
@@ -116,6 +116,12 @@ import type { AuthContext, McpDatabase } from "./types";
 type Tx = McpDatabase;
 
 /**
+ * Cards task_list returns when the caller names no limit. The answer lands
+ * whole in an agent's context, so the default is a page, not a board.
+ */
+const DEFAULT_TASK_LIST_LIMIT = 50;
+
+/**
  * Ends the active run without erasing its telemetry and links the old and new
  * cards. The caller holds a row lock on `original`, so create + discard can
  * live in one transaction without a zombie window.
@@ -955,8 +961,10 @@ async function taskList(
     priority?: Task["priority"];
     type?: Task["type"];
     awaiting_review_by?: "me" | string;
+    limit?: number;
   },
 ) {
+  const limit = input.limit ?? DEFAULT_TASK_LIST_LIMIT;
   const filters = [eq(project.workspaceId, ctx.workspaceId)];
   if (input.project_id) {
     const proj = await findProject(db, ctx.workspaceId, input.project_id);
@@ -1001,15 +1009,22 @@ async function taskList(
     filters.push(inArray(task.status, statuses));
   }
 
+  // One past the limit: enough to know another card exists without paying
+  // for a second count query on every call.
   const rows = await db
     .select({ task, project })
     .from(task)
     .innerJoin(project, eq(task.projectId, project.id))
     .where(and(...filters))
-    .orderBy(asc(task.createdAt));
+    .orderBy(asc(task.createdAt))
+    .limit(limit + 1);
+
+  const truncated = rows.length > limit;
 
   return {
-    tasks: rows.map((row) => {
+    truncated,
+    limit,
+    tasks: rows.slice(0, limit).map((row) => {
       const mapped = mapTask(row.task, row.project);
       return {
         id: mapped.id,

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -49,7 +49,8 @@ context are listed there with a short excerpt and a pointer to `project_get`.
 | `mission_create` | creates a mission (`title`, objective/context markdown, `status`) and returns its id |
 | `mission_update` | partially edits a mission (`title`, objective/context markdown, `status`); omitted fields stay unchanged. Put conventions for one round in mission context and update them here |
 | `mission_delete` | removes an empty mission shell. A mission holding cards is refused with its count; `force: true` detaches those cards (`mission_id: null`) and returns `tasks_detached` before deleting the mission |
-| `task_list` | the queue (project, `mission_id`, status, priority, `awaiting_review_by`) |
+| `task_list` | the queue (project, `mission_id`, status, priority, `awaiting_review_by`, `limit`) |
+| | `limit` defaults to 50 and caps at 200. The response carries `truncated` and the `limit` it used, so a caller can tell a full queue from a cut one instead of reading a page as the whole board |
 | `task_get` | self-contained md briefing (contract + harness + mission + complete project context + branch), plus the latest attempt's frozen `cost_usd`, `cost_source`, `cost_status` and `cost_unpriced_models` |
 | `task_create` | creates the card (`mission` is an existing mission id, `mode` solo\|team, origin); `supersedes` atomically discards an in-execution predecessor, and `inherit: true` reuses its contract without copying comments |
 | | `project_id` takes the project uuid **or** its card prefix (`AGB`), so an agent that just called `project_list` never needs the uuid |

--- a/packages/mcp-core/src/schemas/tools.ts
+++ b/packages/mcp-core/src/schemas/tools.ts
@@ -234,10 +234,24 @@ export const TaskListInputSchema = z.object({
   priority: PrioritySchema.optional(),
   type: TaskTypeSchema.optional(),
   awaiting_review_by: z.union([z.literal("me"), z.string().min(1)]).optional(),
+  /**
+   * Cards to return, oldest first. Default 50, at most 200. The whole answer
+   * goes into the caller's context, so an unbounded board would spend it on
+   * cards nobody asked about.
+   */
+  limit: z.number().int().min(1).max(200).optional(),
 });
 
 export const TaskListOutputSchema = z.object({
   tasks: z.array(TaskSummarySchema),
+  /**
+   * True when the board holds more cards than were returned. Say it out
+   * loud: a caller that cannot tell a full answer from a cut one will read
+   * a truncated queue as the whole queue.
+   */
+  truncated: z.boolean(),
+  /** The limit the answer was cut to, whether asked for or the default. */
+  limit: z.number().int(),
 });
 
 const TaskIdSchema = z


### PR DESCRIPTION
## What

`task_list` runs without a limit, so it returns every card in the workspace.

## Why it matters more here than in a normal list endpoint

That answer lands whole in the caller's context, and `task_list` is the first call in
the flow the README documents: *"grab the next task from the board."* On a board that
has been running a while, the first thing an agent does is spend its context on cards
nobody asked about. On a product whose thesis is measuring what a run costs in tokens,
that felt worth fixing.

`task_search` already takes a `limit`, default 5 and cap 20. This is the same idea on
the older tool, sized for a queue rather than a search: **default 50, cap 200**.

## Saying it out loud

The response now carries `truncated` and the `limit` it used. Cutting silently would
be the worse bug: a caller that cannot tell a page from the whole board will read
fifty cards as the whole board, and conclude that a card it cannot see does not exist.

The query asks for one row past the limit and drops it, which is enough to know
another card exists without paying for a count query on every call. That is also why
there is no `total`: it would cost a second query on a call that runs constantly, and
`truncated` already answers the question that changes what a caller does next. Say if
you want the count anyway and I will add it.

Ordering is unchanged, oldest first, so a limit takes the head of the queue and not an
arbitrary slice. The test asserts that too.

## Breaking change

A caller that relied on getting everything now gets 50 unless it asks for more, and is
told so.

**The default is the one number here worth arguing about.** 50 is a guess at what a
queue-reading agent wants in one bite. If you would rather have 20, or 100, or no
default at all with the cap only, say so and I will change it.

## Verification

`pnpm test` green: 86 + 122 + 325 = 533.

## Note on the branch name

No `OCL-` prefix: no board access here, and an invented card ID would collide with a
real one. Happy to rebase onto one you assign.
