### PR TITLE
fix: gate release image on production build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches: [main]
   pull_request:
+  workflow_call:
 
 permissions:
   contents: read
@@ -32,9 +33,9 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
-      # apps/web imports @agent-board/mcp-core from dist/, so the package has to
-      # be compiled before its consumers are tested.
-      - run: pnpm --filter @agent-board/mcp-core build
+      # Build from the clean checkout before tests. This catches incomplete
+      # commits that unit tests can miss but the release image cannot compile.
+      - run: pnpm build
 
       # No database service: the integration tests boot an in-memory PGlite.
       - run: pnpm test

--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -12,7 +12,11 @@ permissions:
   packages: write
 
 jobs:
+  verify:
+    uses: ./.github/workflows/ci.yml
+
   publish:
+    needs: verify
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## What changed

- make the existing CI workflow reusable through `workflow_call`
- run the full production build before the test suite
- require that workflow to pass before `release-image` publishes to GHCR

## Why

The `v0.1.10`, `v0.1.11`, and `v0.1.12` image workflows failed during the Next.js TypeScript build even though the repository test suite was green. The tagged source referenced tool contracts and a cardapio row shape that were not present in the clean checkout.

The image build failed safely, but the problem was discovered only after each release was tagged. Running `pnpm build` on pull requests and `main` moves that signal earlier. Calling the same workflow from `release-image` also prevents publishing unless both the production build and tests pass for the tagged commit.

## Impact

- incomplete clean-clone builds fail on the PR instead of after tagging
- tag publication is gated by the same build and test workflow
- no application or runtime behavior changes

This does not repair the existing `v0.1.12` tag; a new release is still required after this lands.

## Validation

- `npx --yes pnpm@9.15.9 build`
- `npx --yes pnpm@9.15.9 test` — 532 passed
- `git diff --check`
- [fork GitHub Actions](https://github.com/obrunogonzaga/overclick/actions/runs/32204563259) — clean checkout, `pnpm build`, and `pnpm test` green in 1m48s

## Branch name

I do not have access to the upstream OverClick board, so I did not invent an `OCL-` card ID. Happy to align the branch or PR with a real card.
