### PR TITLE
[OCL-76] install.sh: persistent git clone for Claude plugin source + real post-install verification

### DIFF
--- a/docs/design/plugin.md
+++ b/docs/design/plugin.md
@@ -64,6 +64,22 @@ their native plugin managers. The stable package copy and a mode-600 config live
 the user's configuration area. Provider MCP config is updated idempotently; Codex gets
 an explicit `[mcp_servers.overclick]` block and merged global hooks.
 
+When install.sh runs without a local checkout to reuse (the `curl | bash` case),
+it clones the plugin package with plain `git` into a persistent
+`<config root>/overclick/plugin-src` checkout instead of an ephemeral `gh repo
+clone`. Re-running install.sh fetches and hard-resets that checkout to
+`origin/HEAD` — **updating the plugin is re-running install.sh**, nothing else.
+This checkout, not a `source github` marketplace entry, is what Claude's
+native marketplace add points at: a `source github` entry can register and
+report success without ever materializing a cache (confirmed 2026-08-19 on
+the owner's machine), while a local directory marketplace served from this
+checkout works. install.sh never uses `source github` for this reason.
+Because "successfully installed" only means the CLI accepted the command,
+install.sh also asks `claude plugin list --json` for the enabled overclick
+entry's `installPath` and checks that `OVERCLICK.md` actually exists there;
+if not, the run exits non-zero after configuring everything else, instead of
+reporting completion for a plugin that isn't really there.
+
 Claude receives an `@` import inside `<!-- overclick:start -->` and
 `<!-- overclick:end -->`. A CLI without native plugin support receives one AGENTS.md
 reference line inside the same markers. Re-running the installer replaces the marked

--- a/install.sh
+++ b/install.sh
@@ -60,29 +60,43 @@ else
   mcp_url="$instance_url/mcp"
 fi
 
-temporary_checkout=""
-cleanup() {
-  if [[ -n "$temporary_checkout" && -d "$temporary_checkout" ]]; then
-    rm -rf -- "$temporary_checkout"
-  fi
-}
-trap cleanup EXIT
+plugin_src="$overclick_root/plugin-src"
 
 script_dir=$(CDPATH='' cd -- "$(dirname -- "${BASH_SOURCE[0]}")" 2>/dev/null && pwd || true)
 if [[ -f "$script_dir/plugin/OVERCLICK.md" ]]; then
   source_root=$script_dir
 elif [[ -n "${OVERCLICK_PLUGIN_DIR:-}" && -f "$OVERCLICK_PLUGIN_DIR/OVERCLICK.md" ]]; then
   source_root=$(CDPATH='' cd -- "$OVERCLICK_PLUGIN_DIR/.." && pwd)
-elif command -v gh >/dev/null 2>&1; then
-  temporary_checkout=$(mktemp -d)
-  if ! gh repo clone "$plugin_source" "$temporary_checkout/repository" -- --depth 1 >/dev/null 2>&1; then
-    printf '%s\n' "Could not retrieve the OverClick plugin package." >&2
+else
+  # A `source github` marketplace entry can register without ever fetching the
+  # package (Claude CLI accepts it, marks it enabled, never materializes a
+  # cache). A plain git checkout served as a local directory marketplace is
+  # what actually works, so this installer keeps that checkout itself and
+  # re-running install.sh doubles as the update path (git pull, not a fresh
+  # ephemeral clone every run).
+  if ! command -v git >/dev/null 2>&1; then
+    printf '%s\n' "git is required to fetch the OverClick plugin package." >&2
     exit 1
   fi
-  source_root="$temporary_checkout/repository"
-else
-  printf '%s\n' "Run this installer from a checkout or install the repository client first." >&2
-  exit 1
+  case "$plugin_source" in
+    http://*|https://*|git@*|file://*) clone_url=$plugin_source ;;
+    *) clone_url="https://github.com/$plugin_source.git" ;;
+  esac
+  mkdir -p "$overclick_root"
+  if [[ -d "$plugin_src/.git" ]]; then
+    if ! git -C "$plugin_src" fetch --depth 1 origin >/dev/null 2>&1 || \
+      ! git -C "$plugin_src" reset --hard origin/HEAD >/dev/null 2>&1; then
+      printf '%s\n' "Could not update the local OverClick plugin checkout at $plugin_src." >&2
+      exit 1
+    fi
+  else
+    rm -rf -- "$plugin_src"
+    if ! git clone --depth 1 "$clone_url" "$plugin_src" >/dev/null 2>&1; then
+      printf '%s\n' "Could not clone the OverClick plugin package." >&2
+      exit 1
+    fi
+  fi
+  source_root="$plugin_src"
 fi
 
 if [[ ! -f "$source_root/plugin/.codex-plugin/plugin.json" || ! -f "$source_root/plugin/OVERCLICK.md" ]]; then
@@ -287,6 +301,46 @@ quiet_try() {
   fi
 }
 
+# "Successfully installed" only means the CLI accepted the command; the
+# github-source bug this fixes accepted it and never materialized anything.
+# Ask the CLI what it actually has on disk instead of trusting exit codes.
+verify_claude_plugin() {
+  local listing
+  listing=$(claude plugin list --json 2>/dev/null) || return 1
+  if command -v python3 >/dev/null 2>&1; then
+    printf '%s' "$listing" | python3 -c '
+import json, sys
+try:
+    plugins = json.load(sys.stdin)
+except Exception:
+    sys.exit(1)
+for entry in plugins:
+    if str(entry.get("id", "")).startswith("overclick@") and entry.get("enabled"):
+        print(entry.get("installPath", ""))
+        sys.exit(0)
+sys.exit(1)
+'
+    return $?
+  fi
+  if command -v node >/dev/null 2>&1; then
+    printf '%s' "$listing" | node -e '
+let data = "";
+process.stdin.on("data", chunk => { data += chunk; });
+process.stdin.on("end", () => {
+  let plugins;
+  try { plugins = JSON.parse(data); } catch { process.exit(1); }
+  const found = plugins.find(p => String(p.id || "").startsWith("overclick@") && p.enabled);
+  if (!found) process.exit(1);
+  process.stdout.write(String(found.installPath || ""));
+});
+'
+    return $?
+  fi
+  return 1
+}
+
+validation_failed=0
+
 if has_cli claude; then
   if claude plugin marketplace add "$native_marketplace" --scope user >/dev/null 2>&1 || \
     claude plugin marketplace update overclick >/dev/null 2>&1; then
@@ -305,6 +359,14 @@ if has_cli claude; then
     --header "Authorization: Bearer $token" overclick "$mcp_url"
   claude_block=$(printf '%s\n' '<!-- overclick:start -->' "@$plugin_target/OVERCLICK.md" '<!-- overclick:end -->')
   replace_marked_block "$install_home/.claude/CLAUDE.md" "$claude_block"
+
+  claude_install_path=$(verify_claude_plugin) || claude_install_path=""
+  if [[ -n "$claude_install_path" && -f "$claude_install_path/OVERCLICK.md" ]]; then
+    printf '%s\n' "Claude plugin verified: enabled and materialized at $claude_install_path."
+  else
+    printf '%s\n' "Claude plugin did not materialize: 'claude plugin list --json' shows no enabled overclick entry with OVERCLICK.md on disk. Do not trust the earlier \"configured\" messages; retry or install manually." >&2
+    validation_failed=1
+  fi
 fi
 
 if has_cli codex; then
@@ -365,6 +427,11 @@ if [[ "${OVERCLICK_AGENTS_FALLBACK:-0}" = "1" ]] || \
   agents_block=$(printf '%s\n' '<!-- overclick:start -->' "Read and follow $plugin_target/OVERCLICK.md for all OverClick board work." '<!-- overclick:end -->')
   replace_marked_block "$project_dir/AGENTS.md" "$agents_block"
   printf '%s\n' "No plugin-capable CLI was detected; the AGENTS.md fallback was installed."
+fi
+
+if [[ "$validation_failed" = "1" ]]; then
+  printf '%s\n' "OverClick plugin installation finished with unverified components; see warnings above. Credentials were stored privately and were not displayed." >&2
+  exit 1
 fi
 
 printf '%s\n' "OverClick plugin installation complete. Credentials were stored privately and were not displayed."

--- a/plugin/OVERCLICK.md
+++ b/plugin/OVERCLICK.md
@@ -113,6 +113,12 @@ instance addresses, or organization-specific policies in this package.
   current card.
 - `/overclick:release <tag>` stamps the current card with an exact release tag.
 
+## Updating the plugin
+
+Re-run `install.sh`. It keeps its own persistent checkout of this package and
+fetches the latest version from there before reinstalling; there is no
+separate update command.
+
 ## Hook defaults
 
 `SessionStart`, the post-delivery remote check, and local claim-marker updates

--- a/scripts/test-plugin-package.sh
+++ b/scripts/test-plugin-package.sh
@@ -18,10 +18,14 @@ test -x "$REPO_ROOT/plugin/hooks/claim-guard.sh"
 test "$(find "$REPO_ROOT/plugin/commands" -name '*.md' | wc -l | tr -d ' ')" -eq 5
 test "$(find "$REPO_ROOT/plugin" "$REPO_ROOT/skills" -name SKILL.md | wc -l | tr -d ' ')" -eq 1
 
-mkdir -p "$TEST_ROOT/bin" "$TEST_ROOT/home/.codex" "$TEST_ROOT/project"
+mkdir -p "$TEST_ROOT/bin" "$TEST_ROOT/home/.codex" "$TEST_ROOT/project" "$TEST_ROOT/claude-cache"
+touch "$TEST_ROOT/claude-cache/OVERCLICK.md"
 cat >"$TEST_ROOT/bin/agent-stub" <<'SH'
 #!/bin/sh
 printf '%s:%s:%s\n' "$(basename -- "$0")" "${1:-}" "${2:-}" >>"$OC_TEST_NATIVE_LOG"
+if [ "$(basename -- "$0")" = "claude" ] && [ "${1:-}" = "plugin" ] && [ "${2:-}" = "list" ]; then
+  printf '[{"id":"overclick@overclick","enabled":true,"installPath":"%s"}]' "$OC_TEST_CLAUDE_CACHE"
+fi
 exit 0
 SH
 chmod +x "$TEST_ROOT/bin/agent-stub"
@@ -45,6 +49,7 @@ JSON
 run_installer() {
   PATH="$TEST_ROOT/bin:$PATH" \
   OC_TEST_NATIVE_LOG="$TEST_ROOT/native.log" \
+  OC_TEST_CLAUDE_CACHE="$TEST_ROOT/claude-cache" \
   OVERCLICK_INSTALL_HOME="$TEST_ROOT/home" \
   OVERCLICK_PROJECT_DIR="$TEST_ROOT/project" \
   OVERCLICK_INSTANCE_URL="$FIXTURE_URL" \
@@ -72,6 +77,69 @@ test "$(stat -f '%Lp' "$TEST_ROOT/home/.config/overclick/config" 2>/dev/null || 
 sed -i.bak 's/enforce_claim=0/enforce_claim=1/' "$TEST_ROOT/home/.config/overclick/config"
 run_installer
 test "$(grep -c '^enforce_claim=1$' "$TEST_ROOT/home/.config/overclick/config")" -eq 1
+
+# "Successfully installed" is not proof of anything: a marketplace entry that
+# never fetched its package still exits 0. The installer must ask the CLI
+# what it actually has on disk and fail loudly when that comes up empty.
+mkdir -p "$TEST_ROOT/claude-cache-empty"
+if PATH="$TEST_ROOT/bin:$PATH" \
+  OC_TEST_NATIVE_LOG="$TEST_ROOT/native-unverified.log" \
+  OC_TEST_CLAUDE_CACHE="$TEST_ROOT/claude-cache-empty" \
+  OVERCLICK_INSTALL_HOME="$TEST_ROOT/home-unverified" \
+  OVERCLICK_PROJECT_DIR="$TEST_ROOT/project" \
+  OVERCLICK_INSTANCE_URL="$FIXTURE_URL" \
+  OVERCLICK_TOKEN="fixture" \
+  OVERCLICK_CLIS="claude" \
+    "$REPO_ROOT/install.sh" >"$TEST_ROOT/unverified.out" 2>"$TEST_ROOT/unverified.err"; then
+  echo "installer should fail loudly when the Claude plugin never materializes" >&2
+  exit 1
+fi
+grep -Fq 'did not materialize' "$TEST_ROOT/unverified.err"
+
+# The github-source bug this fixes never gives install.sh a local checkout to
+# reuse. Exercise that path directly: a bare install.sh copy, no plugin/ next
+# to it, sourcing a local git remote instead of network github.
+mkdir -p "$TEST_ROOT/plugin-remote/plugin/.codex-plugin" \
+  "$TEST_ROOT/plugin-remote/.claude-plugin" "$TEST_ROOT/plugin-remote/.grok-plugin"
+git init -q "$TEST_ROOT/plugin-remote"
+git -C "$TEST_ROOT/plugin-remote" config user.name fixture
+git -C "$TEST_ROOT/plugin-remote" config user.email fixture@invalid
+printf 'package v1\n' >"$TEST_ROOT/plugin-remote/plugin/OVERCLICK.md"
+printf '{}' >"$TEST_ROOT/plugin-remote/plugin/.codex-plugin/plugin.json"
+printf '{}' >"$TEST_ROOT/plugin-remote/.claude-plugin/marketplace.json"
+printf '{}' >"$TEST_ROOT/plugin-remote/.grok-plugin/marketplace.json"
+git -C "$TEST_ROOT/plugin-remote" add -A
+git -C "$TEST_ROOT/plugin-remote" commit -q -m v1
+
+mkdir -p "$TEST_ROOT/isolated-installer" "$TEST_ROOT/clone-cache"
+cp "$REPO_ROOT/install.sh" "$TEST_ROOT/isolated-installer/install.sh"
+chmod +x "$TEST_ROOT/isolated-installer/install.sh"
+touch "$TEST_ROOT/clone-cache/OVERCLICK.md"
+
+run_clone_installer() {
+  PATH="$TEST_ROOT/bin:$PATH" \
+  OC_TEST_NATIVE_LOG="$TEST_ROOT/clone-native.log" \
+  OC_TEST_CLAUDE_CACHE="$TEST_ROOT/clone-cache" \
+  OVERCLICK_INSTALL_HOME="$TEST_ROOT/clone-home" \
+  OVERCLICK_PROJECT_DIR="$TEST_ROOT/project" \
+  OVERCLICK_INSTANCE_URL="$FIXTURE_URL" \
+  OVERCLICK_TOKEN="fixture" \
+  OVERCLICK_CLIS="claude" \
+  OVERCLICK_PLUGIN_SOURCE="file://$TEST_ROOT/plugin-remote" \
+    "$TEST_ROOT/isolated-installer/install.sh" >"$TEST_ROOT/clone.out" 2>"$TEST_ROOT/clone.err"
+}
+
+run_clone_installer
+plugin_src="$TEST_ROOT/clone-home/.config/overclick/plugin-src"
+test -d "$plugin_src/.git"
+grep -Fq 'package v1' "$plugin_src/plugin/OVERCLICK.md"
+
+printf 'package v2\n' >"$TEST_ROOT/plugin-remote/plugin/OVERCLICK.md"
+git -C "$TEST_ROOT/plugin-remote" add -A
+git -C "$TEST_ROOT/plugin-remote" commit -q -m v2
+
+run_clone_installer
+grep -Fq 'package v2' "$plugin_src/plugin/OVERCLICK.md"
 
 OVERCLICK_INSTALL_HOME="$TEST_ROOT/home-fallback" \
 OVERCLICK_PROJECT_DIR="$TEST_ROOT/project" \


### PR DESCRIPTION
## Summary
- install.sh no longer relies on an ephemeral `gh repo clone`/github-source marketplace add for Claude Code — that path can register a marketplace entry and report success without ever materializing a cache (real incident, 2026-08-19).
- It now clones/pulls a persistent local checkout at `<config root>/overclick/plugin-src` (plain `git`, no `gh` dependency) and points the existing directory-based marketplace at it. Re-running install.sh doubles as the update mechanism.
- After configuring Claude, it verifies via `claude plugin list --json` that the enabled `overclick@` entry's `installPath` actually contains `OVERCLICK.md` on disk, instead of trusting exit codes. If it doesn't, the run exits non-zero after configuring everything else.
- Documented the update-is-rerun-install.sh contract in `plugin/OVERCLICK.md` and `docs/design/plugin.md`.
- Extended `scripts/test-plugin-package.sh` with a loud-failure test (materialization missing) and a persistent-clone/update test (local git remote, v1 → v2 content bump).

## Test plan
- [x] `bash -n install.sh`
- [x] `shellcheck -x install.sh scripts/test-plugin-package.sh`
- [x] `bash scripts/test-plugin-package.sh` (all scenarios pass, including the two new ones)

🤖 Generated with [Claude Code](https://claude.com/claude-code)