### PR TITLE
[OCL-77] Executor desativado: rejeição no MCP + some do seletor

### DIFF
--- a/apps/web/src/app/settings/settings-client.tsx
+++ b/apps/web/src/app/settings/settings-client.tsx
@@ -26,6 +26,7 @@ import {
   CUSTOM_EXECUTOR_ID,
   EXECUTOR_CATALOG,
   cardapioLabel,
+  modelsForCli,
   resolveCatalogCli,
 } from "../../lib/executors";
 import { LANGUAGES, dict, type Dict } from "../../lib/i18n";
@@ -265,16 +266,7 @@ export function SettingsClient({
       ? [{ id: CUSTOM_EXECUTOR_ID, label: sel.customName.trim() || "Custom" }]
       : []),
   ];
-  const modelsFor = (cli: string | null): string[] => {
-    if (!cli) {
-      const all = cliOptions.flatMap((o) => sel.enabled[o.id] ?? []);
-      return [...new Set(all)];
-    }
-    if (cli === CUSTOM_EXECUTOR_ID) return ["generic-mcp"];
-    return sel.enabled[cli]?.length
-      ? sel.enabled[cli]
-      : (sel.models[cli] ?? EXECUTOR_CATALOG.find((d) => d.id === cli)?.models ?? []);
-  };
+  const modelsFor = (cli: string | null): string[] => modelsForCli(sel, cli);
   const setRow = (i: number, patch: Partial<CardapioRow>) => {
     setRows(rows.map((r, j) => {
       if (j !== i) return r;

--- a/apps/web/src/lib/executors.test.ts
+++ b/apps/web/src/lib/executors.test.ts
@@ -7,6 +7,7 @@ import {
   cardapioLabel,
   isPairInConfig,
   learnedExecutorDefs,
+  modelsForCli,
   removeModelFromSelection,
   resolveCatalogCli,
   selectionFromConfig,
@@ -120,6 +121,36 @@ describe("editable model catalog", () => {
     const removed = removeModelFromSelection(base, "grok", "grok-4.6");
     expect(removed.models.grok).not.toContain("grok-4.6");
     expect(removed.enabled.grok).toEqual(["grok-4.5"]);
+  });
+});
+
+describe("modelsForCli (OCL-77)", () => {
+  it("offers nothing for a CLI that is switched off", () => {
+    const sel = selectionFromConfig([
+      { id: "claude-code", label: "Claude Code", enabled: true, models: ["sonnet-5"] },
+      { id: "codex", label: "Codex", enabled: false, models: ["gpt-5.6-sol"] },
+    ]);
+    expect(modelsForCli(sel, "codex")).toEqual([]);
+  });
+
+  it("still offers an enabled CLI's checked models", () => {
+    const sel = selectionFromConfig([
+      { id: "codex", label: "Codex", enabled: true, models: ["gpt-5.6-sol"] },
+    ]);
+    expect(modelsForCli(sel, "codex")).toEqual(["gpt-5.6-sol"]);
+  });
+
+  it("excludes a disabled CLI's models from the no-preference union", () => {
+    const sel = selectionFromConfig([
+      { id: "claude-code", label: "Claude Code", enabled: true, models: ["sonnet-5"] },
+      { id: "codex", label: "Codex", enabled: false, models: ["gpt-5.6-sol"] },
+    ]);
+    expect(modelsForCli(sel, null)).toEqual(["sonnet-5"]);
+  });
+
+  it("keeps the custom executor's fixed model regardless of enabled state", () => {
+    const sel = selectionFromConfig([]);
+    expect(modelsForCli(sel, CUSTOM_EXECUTOR_ID)).toEqual(["generic-mcp"]);
   });
 });
 

--- a/apps/web/src/lib/executors.ts
+++ b/apps/web/src/lib/executors.ts
@@ -208,6 +208,25 @@ export function learnedExecutorDefs(sel: ExecutorSelection): ExecutorDef[] {
 }
 
 /**
+ * Models the harness policy chain selector may offer for `cli`. A CLI
+ * missing from `sel.enabled` is switched off and offers nothing here
+ * (OCL-77): a disabled executor's models never appear as a normal,
+ * selectable choice, matching the guard task_create/task_update enforce
+ * over MCP for the same case. `null` (no CLI preference) unions every model
+ * of every currently enabled executor.
+ */
+export function modelsForCli(sel: ExecutorSelection, cli: string | null): string[] {
+  if (!cli) {
+    return [...new Set(Object.values(sel.enabled).flat())];
+  }
+  if (cli === CUSTOM_EXECUTOR_ID) return ["generic-mcp"];
+  if (!(cli in sel.enabled)) return [];
+  return sel.enabled[cli]?.length
+    ? sel.enabled[cli]
+    : (sel.models[cli] ?? EXECUTOR_CATALOG.find((d) => d.id === cli)?.models ?? []);
+}
+
+/**
  * Adds a free-text model to one CLI's editable list. Trims the input, ignores
  * empties and duplicates, and checks the model when the CLI is already on.
  */

--- a/apps/web/src/mcp/executors.integration.test.ts
+++ b/apps/web/src/mcp/executors.integration.test.ts
@@ -5,6 +5,7 @@ import {
   HarnessRecommendOutputSchema,
   TaskClaimOutputSchema,
   TaskCreateFullOutputSchema as TaskCreateOutputSchema,
+  TaskSearchOutputSchema,
   toolContracts,
 } from "@agent-board/mcp-core";
 import { eq } from "drizzle-orm";
@@ -500,7 +501,7 @@ describe("harness_recommend falls back across CLIs when a policy's own executor 
     });
   });
 
-  it("accepts task_create citing a disabled executor's model with a warning instead of blocking it", async () => {
+  it("rejects task_create/task_update citing a disabled executor's model, with the fallback in the error (OCL-77)", async () => {
     world = await createTestWorld();
     const addedCodex = await invokeTool(world.db, manager(), "executors_update", {
       cli: "codex",
@@ -514,9 +515,10 @@ describe("harness_recommend falls back across CLIs when a policy's own executor 
     });
     expect(disabled.ok).toBe(true);
 
-    // 4. task_create with a harness citing a disabled executor is accepted,
-    // not blocked, and says so with an explicit warning.
-    const created = await invokeTool(world.db, worker(), "task_create", {
+    // 4. task_create with a harness citing a disabled executor is a typed
+    // rejection, never a silent accept, and the error already carries the
+    // fallback harness_recommend would give for this activity type.
+    const rejected = await invokeTool(world.db, worker(), "task_create", {
       project_id: world.projectId,
       title: "Card pinned to a disabled executor",
       type: "feature",
@@ -526,20 +528,79 @@ describe("harness_recommend falls back across CLIs when a policy's own executor 
       origem: { cli: "codex" },
       harness: { cli: "codex", model: "gpt-5.6-sol", effort: "high" },
     });
+    expect(rejected.ok).toBe(false);
+    if (rejected.ok) return;
+    expect(rejected.error.code).toBe("INVALID_ARGUMENT");
+    expect(rejected.error.message).toContain("codex");
+    expect(rejected.error.message).toContain("disabled");
+    expect(rejected.error.message).toContain("opus-5");
+
+    // No half-created card left behind by the rejected write.
+    const search = await invokeTool(world.db, worker(), "task_search", {
+      q: "Card pinned to a disabled executor",
+    });
+    expect(search.ok).toBe(true);
+    if (search.ok) expect(TaskSearchOutputSchema.parse(search.value).tasks).toHaveLength(0);
+
+    // task_update citing the same disabled executor is rejected the same
+    // way; other fields on an existing card stay editable (OCL-77 item 4).
+    const created = await invokeTool(world.db, worker(), "task_create", {
+      project_id: world.projectId,
+      title: "Card without a pinned harness",
+      type: "feature",
+      o_que: "x",
+      por_que: "y",
+      como_confirmo: [{ step: "a", expected: "b" }],
+      origem: { cli: "codex" },
+    });
     expect(created.ok).toBe(true);
     if (!created.ok) return;
-    const out = TaskCreateOutputSchema.parse(created.value);
-    expect(out.task.harness).toMatchObject({ cli: "codex", model: "gpt-5.6-sol" });
-    expect(out.harness_warning).toContain("codex");
-    expect(out.harness_warning).toContain("disabled");
+    const card = TaskCreateOutputSchema.parse(created.value).task;
 
-    // task_update citing the same disabled executor is likewise accepted.
-    const updated = await invokeTool(world.db, worker(), "task_update", {
-      task_id: out.task.short_id,
+    const rejectedUpdate = await invokeTool(world.db, worker(), "task_update", {
+      task_id: card.short_id,
       harness: { cli: "codex", model: "gpt-5.6-sol", effort: "high" },
     });
-    expect(updated.ok).toBe(true);
-    if (!updated.ok) return;
-    expect(updated.value).toHaveProperty("harness_warning");
+    expect(rejectedUpdate.ok).toBe(false);
+    if (rejectedUpdate.ok) return;
+    expect(rejectedUpdate.error.code).toBe("INVALID_ARGUMENT");
+    expect(rejectedUpdate.error.message).toContain("disabled");
+
+    const commented = await invokeTool(world.db, worker(), "task_update", {
+      task_id: card.short_id,
+      comment: "still editable without touching the harness",
+    });
+    expect(commented.ok).toBe(true);
+
+    // 5. Re-enabling codex makes the same explicit harness a normal accept
+    // again, on both task_create and task_update.
+    const reenabled = await invokeTool(world.db, manager(), "executors_update", {
+      cli: "codex",
+      enabled: true,
+    });
+    expect(reenabled.ok).toBe(true);
+
+    const acceptedCreate = await invokeTool(world.db, worker(), "task_create", {
+      project_id: world.projectId,
+      title: "Card pinned to a re-enabled executor",
+      type: "feature",
+      o_que: "x",
+      por_que: "y",
+      como_confirmo: [{ step: "a", expected: "b" }],
+      origem: { cli: "codex" },
+      harness: { cli: "codex", model: "gpt-5.6-sol", effort: "high" },
+    });
+    expect(acceptedCreate.ok).toBe(true);
+    if (!acceptedCreate.ok) return;
+    expect(TaskCreateOutputSchema.parse(acceptedCreate.value).task.harness).toMatchObject({
+      cli: "codex",
+      model: "gpt-5.6-sol",
+    });
+
+    const acceptedUpdate = await invokeTool(world.db, worker(), "task_update", {
+      task_id: card.short_id,
+      harness: { cli: "codex", model: "gpt-5.6-sol", effort: "high" },
+    });
+    expect(acceptedUpdate.ok).toBe(true);
   });
 });

--- a/apps/web/src/mcp/tools.integration.test.ts
+++ b/apps/web/src/mcp/tools.integration.test.ts
@@ -2320,7 +2320,7 @@ describe("MCP tool edge cases against a test db", () => {
     if (!badCli.ok) expect(badCli.error.code).toBe("INVALID_ARGUMENT");
   });
 
-  it("accepts a harness naming a disabled executor's model, with a warning instead of a block (OCL-75)", async () => {
+  it("rejects a harness naming a disabled executor's model instead of blocking (OCL-77, refines OCL-75)", async () => {
     world = await createTestWorld();
     const off = await invokeTool(world.db, { ...ctx(), canManage: true }, "executors_update", {
       cli: "claude-code",
@@ -2342,21 +2342,28 @@ describe("MCP tool edge cases against a test db", () => {
     if (!created.ok) return;
     const card = TaskCreateOutputSchema.parse(created.value).task;
 
-    // haiku-4-5 exists on claude-code, which is off; the write still applies.
+    // haiku-4-5 exists on claude-code, but claude-code is off: the write is
+    // a typed rejection, not a silent accept with a warning.
     const updated = await invokeTool(world.db, ctx(), "task_update", {
       task_id: card.id,
       harness: { cli: "claude-code", model: "haiku-4-5", effort: "low" },
     });
-    expect(updated.ok).toBe(true);
-    if (!updated.ok) return;
-    const out = TaskUpdateOutputSchema.parse(updated.value);
-    expect(out.task.harness).toEqual({
-      cli: "claude-code",
-      model: "haiku-4-5",
-      effort: "low",
+    expect(updated.ok).toBe(false);
+    if (updated.ok) return;
+    expect(updated.error.code).toBe("INVALID_ARGUMENT");
+    expect(updated.error.message).toContain("claude-code");
+    expect(updated.error.message).toContain("disabled");
+
+    // The card's harness is untouched by the rejected write, and other
+    // fields on it stay editable (OCL-77 item 4).
+    const reread = await invokeTool(world.db, ctx(), "task_update", {
+      task_id: card.id,
+      comment: "still editable without touching the harness",
     });
-    expect(out.harness_warning).toContain("claude-code");
-    expect(out.harness_warning).toContain("disabled");
+    expect(reread.ok).toBe(true);
+    if (!reread.ok) return;
+    const out = TaskUpdateOutputSchema.parse(reread.value);
+    expect(out.task.harness).toEqual(card.harness);
   });
 
   it("returns NOT_FOUND when deleting a card that does not exist", async () => {

--- a/apps/web/src/mcp/tools.ts
+++ b/apps/web/src/mcp/tools.ts
@@ -2306,15 +2306,22 @@ async function taskCreate(
   const rec = await recommendFor(db, ctx.workspaceId, input.type, input.harness);
   if (!rec.ok) return rec;
 
+  // A disabled executor is the owner's emergency stop: naming its model by
+  // hand is rejected, with the fallback the caller can resend instead
+  // (OCL-77). An entirely unconfigured model is left alone here; that case
+  // already has its own divergence text from recommendHarness above.
+  if (input.harness && rec.value.available === false) {
+    const rejection = await explicitHarnessRejection(
+      db,
+      ctx.workspaceId,
+      input.type,
+      input.harness,
+    );
+    if (rejection) return rejection;
+  }
+
   const reviewer = reviewerToColumns(input.devolve_para);
   const harness = harnessToDb(rec.value.harness);
-  // The explicit path never blocks on an unavailable model, only the chain
-  // lookup does: a creator naming a disabled executor by hand still gets the
-  // card, just told why it will not run yet.
-  const harnessWarning =
-    input.harness && rec.value.available === false
-      ? await explicitHarnessWarning(db, ctx.workspaceId, input.harness)
-      : undefined;
 
   return db.transaction(async (tx) => {
     const original = input.supersedes
@@ -2436,7 +2443,6 @@ async function taskCreate(
       return {
         task: mapTask(created, proj),
         subtasks: children.map((child) => mapTask(child, proj)),
-        ...(harnessWarning ? { harness_warning: harnessWarning } : {}),
       };
     }
 
@@ -2450,7 +2456,6 @@ async function taskCreate(
       ...(children.length
         ? { subtasks: children.map((child) => child.shortId) }
         : {}),
-      ...(harnessWarning ? { harness_warning: harnessWarning } : {}),
     };
     return taskWriteAck(created, changed);
   });
@@ -3157,7 +3162,6 @@ async function taskUpdate(
     }
   }
 
-  let harnessWarning: string | undefined;
   if (input.harness) {
     const resolved = await resolveHarnessAgainstExecutors(
       db,
@@ -3165,7 +3169,19 @@ async function taskUpdate(
       input.harness,
     );
     if (!resolved.ok) return resolved;
-    harnessWarning = resolved.value.warning;
+    // A disabled executor's warning is the OCL-75 resolution; OCL-77 turns it
+    // into a rejection here too, with harness_recommend's own fallback in the
+    // error so the caller can resend in one step. Other fields on this card
+    // stay editable — this only blocks writing the harness itself.
+    if (resolved.value.warning) {
+      const rejection = await explicitHarnessRejection(
+        db,
+        ctx.workspaceId,
+        nextRow.tipo as CardapioTaskType,
+        input.harness,
+      );
+      if (rejection) return rejection;
+    }
     const [updated] = await db
       .update(task)
       .set({ harness: harnessToDb(resolved.value) })
@@ -3299,7 +3315,6 @@ async function taskUpdate(
   if (usageRecorded) changed.usage_recorded = true;
   if (subtasksMoved !== null) changed.subtasks_moved = subtasksMoved;
   if (projectMove) changed.project_move = projectMove;
-  if (harnessWarning) changed.harness_warning = harnessWarning;
 
   if (input.return !== "full") {
     return taskWriteAck(nextRow, changed);
@@ -3315,7 +3330,6 @@ async function taskUpdate(
     ...(usageRecorded ? { usage_recorded: true } : {}),
     ...(subtasksMoved !== null ? { subtasks_moved: subtasksMoved } : {}),
     ...(projectMove ? { project_move: projectMove } : {}),
-    ...(harnessWarning ? { harness_warning: harnessWarning } : {}),
   };
 }
 
@@ -3522,16 +3536,22 @@ function disabledExecutorWarning(model: string, executorId: string): string {
 }
 
 /**
- * Explains an unavailable explicit harness on task_create, when the reason is
- * a disabled executor rather than a model the workspace never configured at
- * all. Returns undefined for the latter: that case already has its own,
- * more specific divergence text from recommendHarness.
+ * Rejects a task_create/task_update write whose explicit harness names a
+ * model that only exists on a disabled executor, instead of the OCL-75
+ * warning-and-accept: the disable switch is the owner's emergency stop, so a
+ * write naming its model does not get quietly saved anyway (OCL-77). The
+ * error carries harness_recommend's own fallback for that activity type, so
+ * the caller can resend with a working harness in one step. Returns
+ * undefined when the model is not on any executor at all, disabled or not:
+ * that case already has its own, more specific divergence text from
+ * recommendHarness and is left alone.
  */
-async function explicitHarnessWarning(
+async function explicitHarnessRejection(
   db: McpDatabase,
   workspaceId: string,
+  type: CardapioTaskType,
   harness: Harness,
-): Promise<string | undefined> {
+): Promise<Result<never> | undefined> {
   const model = harness.model?.trim();
   if (!model) return undefined;
   const [ws] = await db
@@ -3545,7 +3565,18 @@ async function explicitHarnessWarning(
     harness.cli?.trim().toLowerCase(),
     model.toLowerCase(),
   );
-  return disabledMatch ? disabledExecutorWarning(model, disabledMatch.id) : undefined;
+  if (!disabledMatch) return undefined;
+  const fallback = await recommendFor(db, workspaceId, type);
+  const suggestion =
+    fallback.ok && fallback.value.harness.model
+      ? ` Fallback available: '${fallback.value.harness.model}'${
+          fallback.value.harness.cli ? ` (${fallback.value.harness.cli})` : ""
+        }.`
+      : " Call harness_recommend for a working alternative.";
+  return err(
+    "INVALID_ARGUMENT",
+    `Model '${model}' is configured on executor '${disabledMatch.id}', which is currently disabled.${suggestion} Re-enable the executor, or resend with the fallback harness.`,
+  );
 }
 
 /**

--- a/packages/mcp-core/src/schemas/tools.ts
+++ b/packages/mcp-core/src/schemas/tools.ts
@@ -672,12 +672,6 @@ export const TaskCreateInputSchema = z
 export const TaskCreateFullOutputSchema = z.object({
   task: TaskSchema,
   subtasks: z.array(TaskSchema),
-  /**
-   * Present when the declared harness names a model that exists only on a
-   * disabled executor. The card is still created with that harness: this
-   * says so instead of silently pointing it at something that cannot run.
-   */
-  harness_warning: z.string().optional(),
 });
 
 export const TaskCreateOutputSchema = z.union([
@@ -877,12 +871,6 @@ export const TaskUpdateFullOutputSchema = z.object({
    * project the card is already in, because nothing was restamped.
    */
   project_move: ProjectMoveSchema.optional(),
-  /**
-   * Present when the declared harness names a model that exists only on a
-   * disabled executor. The write still applies: this says so instead of
-   * silently pointing the card at something that cannot run yet.
-   */
-  harness_warning: z.string().optional(),
 });
 
 export const TaskUpdateOutputSchema = z.union([


### PR DESCRIPTION
## Summary
- task_create/task_update with an explicit harness naming a model that only exists on a **disabled** executor now returns a typed `INVALID_ARGUMENT` rejection instead of accepting with a warning (OCL-75's behavior). The error already carries harness_recommend's own fallback for that activity type, so the caller can resend in one step. Other fields on an existing card stay editable — only writing the disabled harness is blocked.
- Settings' harness policy chain selector had a matching bug: picking a specific CLI whose executor is off still listed its full model catalog as normal, selectable options. Fixed by extracting `modelsForCli` (lib/executors.ts), unit-tested in isolation.
- Removed the now-dead `harness_warning` field from the task_create/task_update output schemas (nothing sets it anymore).

## Test plan
- [x] `pnpm test` in `packages/mcp-core` (107 tests) and `apps/web` (450 tests) — all green
- [x] `pnpm exec tsc --noEmit` in `apps/web` — clean
- [x] New/updated tests cover: task_create rejection with fallback suggestion, no half-created card left behind, task_update rejection while other fields stay editable, re-enable restores acceptance, `modelsForCli` omits a disabled CLI's models

🤖 Generated with [Claude Code](https://claude.com/claude-code)