### PR TITLE
docs: resolve merge conflict markers committed in mcp.md

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -128,7 +128,6 @@ edit it in place with `mission_update` instead of repeating it on every card. Em
 mission shells can be removed with `mission_delete`; occupied missions require an
 explicit move/detach or `force: true`.
 
-<<<<<<< HEAD
 Project and mission markdown is shared live state. A granular operation has the
 shape `{op, heading, text}` (with `line` as the old line for `replace_line`):
 `replace_section`, `append_section`, `delete_section`, `append_line` and
@@ -139,7 +138,7 @@ sections do not overwrite each other. Send `context` or `objective` only for
 an intentional full rewrite; `expected_len` or the SHA-256 `expected_hash`
 turns a stale legacy rewrite into a clear argument error instead of silently
 discarding another agent's edit.
-=======
+
 ## Mission orchestration telemetry
 
 The orchestrator is mission work, not card work. Keep its cost in one
@@ -216,7 +215,6 @@ If the orchestrator also executes a card, declare the shared session and keep
 the scopes non-overlapping. OCL-11 marks overlapping usage `suspect` rather than
 counting the same session twice. The card's deliver reports only card execution;
 planning and dispatch belong to the mission attempt.
->>>>>>> c7e29c1
 
 `task_claim` always returns the complete briefing; `task_get` is compact unless its
 caller opts into the heavy sections. The executor needs no other source of context


### PR DESCRIPTION
## What

`docs/mcp.md` on `main` carries three unresolved Git conflict markers:

| Line | Marker |
|---|---|
| 131 | `<<<<<<< HEAD` |
| 142 | `=======` |
| 219 | `>>>>>>> c7e29c1` |

They render as literal text on GitHub, and the `## Mission orchestration telemetry`
heading is swallowed inside the conflict block instead of opening a section.

They came in with `7c9f815` ("Merge commit 'c7e29c1' into
`ocl-50-plugin-oficial-overclick-v1-...`") and survived four later commits that
touched the file, so this is not a local artifact — `git status` is clean and the
markers are present in `origin/main`.

## The resolution keeps both sides

Neither side is a superset of the other, so nothing is dropped:

- **HEAD** — the `context_ops` / `expected_len` / `expected_hash` paragraph on
  granular markdown edits.
- **c7e29c1 (OCL-68)** — the `## Mission orchestration telemetry` section.

The `=======` line becomes the blank line the heading needs after the preceding
paragraph, so the entire content change is the removal of the three markers:
**1 insertion, 3 deletions.**

I deliberately did not reorder anything. The prose that follows the telemetry
section reads like it continues the `## Tools` discussion rather than the
telemetry one, but that arrangement already existed in `c7e29c1` itself, so
moving it is your call, not a conflict resolution.

## Testing

Ran per `CONTRIBUTING.md` (`pnpm install`, `pnpm --filter @agent-board/mcp-core build`, then the suites):

| Package | Result |
|---|---|
| `packages/mcp-core` | 113/113 passing |
| `apps/web` | 463/463 passing (51 files) |
| `packages/db` | 14/15 files passing |

**576 passing.** The 4 failures in `packages/db` are `src/domain/usage-recipe.test.ts`,
which shells out to the Codex usage recipe — a **Python** script. Python is not
installed on my Windows machine. I confirmed they are pre-existing by stashing this
change and re-running: the same 4 fail identically. This PR touches no `.ts` file.

## Checklist

- [x] `pnpm test` passes, except 4 pre-existing environment failures explained above
- [ ] `pnpm check:topbar` — not applicable, no top bar change
- [ ] `pnpm check:sheet` — not applicable, no card detail change
- [x] No schema changes
- [x] No telemetry, analytics, or phone-home

I used a conventional-commit branch and message rather than the card-ID convention,
matching the other external PRs — I have no card on your board. Happy to rename if
you would rather this map to one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)