### PR TITLE
ci: typecheck the workspace, which the test job never did

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,5 +36,9 @@ jobs:
       # be compiled before its consumers are tested.
       - run: pnpm --filter @agent-board/mcp-core build
 
+      # vitest transpiles with esbuild, which strips types without checking them,
+      # so a type error reaches main unless tsc is asked separately.
+      - run: pnpm -r --if-present typecheck
+
       # No database service: the integration tests boot an in-memory PGlite.
       - run: pnpm test

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -6,6 +6,7 @@
     "dev": "NEXT_TELEMETRY_DISABLED=1 next dev",
     "build": "NEXT_TELEMETRY_DISABLED=1 next build",
     "start": "NEXT_TELEMETRY_DISABLED=1 next start --hostname 0.0.0.0 --port 3000",
+    "typecheck": "tsc --noEmit",
     "test": "vitest run"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "db:generate": "pnpm --filter @agent-board/db generate",
     "db:migrate": "pnpm --filter @agent-board/db migrate",
     "db:seed": "pnpm --filter @agent-board/db seed",
+    "typecheck": "pnpm -r --if-present typecheck",
     "lint": "pnpm -r --if-present lint",
     "check:topbar": "node scripts/topbar-one-line.mjs",
     "check:sheet": "node scripts/detail-sheet.mjs"

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -12,6 +12,7 @@
     "generate": "drizzle-kit generate",
     "migrate": "tsx src/migrate.ts",
     "seed": "tsx src/seed.ts",
+    "typecheck": "tsc --noEmit",
     "test": "vitest run"
   },
   "dependencies": {

--- a/packages/mcp-core/package.json
+++ b/packages/mcp-core/package.json
@@ -18,6 +18,7 @@
   ],
   "scripts": {
     "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest"
   },


### PR DESCRIPTION
## What

The `ci` job installs, builds `mcp-core` and runs `pnpm test`. That leaves types
unchecked almost everywhere.

`vitest` transpiles with esbuild, which strips type annotations without looking at
them. `apps/web/vitest.config.ts` does not enable vitest's own `typecheck` option
either, so no amount of green tests says anything about whether the code typechecks.

The one package that was covered, `mcp-core`, was covered by accident: its `build`
script happens to be `tsc`. `apps/web` and `packages/db` were never checked by anything
in CI, and `apps/web` is where most of the code lives.

## What this adds

- a `typecheck` script (`tsc --noEmit`) in `apps/web`, `packages/db` and `mcp-core`
- a root `typecheck` shortcut, matching the `lint` and `test` ones already there
- one CI step: `pnpm -r --if-present typecheck`

All three packages are clean today, so this starts green and only ever speaks up about
new work.

## Ordering detail worth a look in review

The step sits **after** the `mcp-core` build on purpose. `apps/web` resolves that
package to its `dist/` types, so checking before the build would fail on a missing
`dist` rather than on anything real. Same reason the build already had to come before
`pnpm test`.

## Verified before opening this

Ran it on a PR in my own fork first, same as I did for the CI job itself. Green in
1m46s, with the new step in place:

```
✓ Run pnpm --filter @agent-board/mcp-core build
✓ Run pnpm -r --if-present typecheck
✓ Run pnpm test
```

Locally, `pnpm typecheck` exits 0 across all three packages.

## Why I bothered

I hit exactly this gap while working on other changes in this repo: a refactor widened
an inferred `ok: true` to `boolean` and broke a discriminated union. Every test still
passed. `tsc --noEmit` was the only thing that said anything, and it was not running
anywhere automatic.

## Note on the branch name

No `OCL-` prefix on the branch or commit: I do not have access to the board and did not
want to invent a card ID that collides with a real one. Happy to rebase onto one.
