### PR TITLE
test(mcp): guard the tool surface against drifting back into Portuguese

### DIFF
--- a/apps/web/src/mcp/surface-language.integration.test.ts
+++ b/apps/web/src/mcp/surface-language.integration.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { handleMcpRequest } from "./http";
+import { closeTestWorld, createTestWorld, type TestWorld } from "./test-db";
+
+/**
+ * The tool descriptions are the prompt a connected agent reads to choose a
+ * tool, and they are written by hand, one line per tool. Most of them were
+ * Portuguese while the newer ones were English, and the split reappeared
+ * twice while that was being closed, because every new tool is a fresh line
+ * somebody types.
+ *
+ * This reads them the way an agent does, over tools/list, instead of reading
+ * the constant: what ships is what matters.
+ */
+
+/**
+ * Accented letters Portuguese uses and English does not.
+ *
+ * Two things this deliberately is not:
+ *
+ * - not "any non-ASCII". The surface already carries em dashes, and a test
+ *   that complains about punctuation is a test everyone learns to skip.
+ * - not a word list. "cardapio" is the name of the routing table, in the
+ *   schema, in the domain module and in the tool descriptions; it is a
+ *   proper noun here, not untranslated prose, and matching on it would fail
+ *   an English sentence for using the project's own vocabulary.
+ *
+ * Accents are the honest signal: every description that was Portuguese
+ * carried them, because whoever writes Portuguese types it properly.
+ */
+const PORTUGUESE_LETTERS = /[ãõçáàâéêíóôúü]/i;
+
+describe("the MCP surface speaks one language", () => {
+  let world: TestWorld;
+
+  afterEach(async () => {
+    if (world) await closeTestWorld(world);
+  });
+
+  it("publishes every tool description in English", async () => {
+    world = await createTestWorld();
+    const response = await handleMcpRequest(
+      new Request("http://board.local/mcp", {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${world.secret}`,
+          Accept: "application/json, text/event-stream",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "tools/list",
+          params: {},
+        }),
+      }),
+      { db: world.db },
+    );
+
+    const json = (await response.json()) as {
+      result: { tools: { name: string; description: string }[] };
+    };
+    const tools = json.result.tools;
+    expect(tools.length).toBeGreaterThan(0);
+
+    // Name the offenders: "a description is Portuguese" is not actionable on
+    // a surface this size.
+    const offenders = tools
+      .filter((tool) => PORTUGUESE_LETTERS.test(tool.description))
+      .map((tool) => tool.name);
+
+    expect(offenders).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What

A test that fails if any tool description drifts back into Portuguese, now that #1 has
made the surface English.

## Why it needs a guard at all

The descriptions are the prompt a connected agent reads to choose a tool, and they are
hand-written, one line per tool. That is exactly the shape of thing that drifts: while
#1 was open, the split came back **twice**, because `task_search` and then
`mission_update`, `task_release` and `task_heartbeat` each arrived as a fresh line
somebody typed. Nothing catches it today.

## How it checks

It reads the descriptions the way an agent does, over `tools/list` against a board booted
on PGlite, rather than reading the constant. What ships is what matters, and this is the
same probe I used to verify #1.

The failure names the offending tools. "A description is Portuguese" is not actionable on
a 26-tool surface.

## What the check deliberately is not

**Not "any non-ASCII".** The surface already carries four em dashes. A test that
complains about punctuation is a test people learn to skip, and then it guards nothing.

**Not a word list.** My first version used one and immediately failed `harness_recommend`
for the word `cardapio` — which is the name of the routing table, in the schema, in
`packages/db/src/domain/cardapio.ts` and in the descriptions themselves. It is a proper
noun in this project, not untranslated prose, and matching on it would fail an English
sentence for using your own vocabulary.

So the check is accented letters only. That is the honest signal: every description that
was Portuguese carried accents, because whoever writes Portuguese types it properly.

## Verification

Passes on current `main`. I confirmed it actually guards something by putting one
description back into Portuguese and watching it fail with `[ 'branch_register' ]`.

Costs about 2.5s, the same PGlite boot every other integration test here pays.

## Note on the branch name

No `OCL-` prefix: no board access here, and an invented card ID would collide with a real
one. Happy to rebase onto one you assign.
