### PR TITLE
fix(auth): an unknown or inactive e-mail costs the same as a known one

### DIFF
--- a/apps/web/src/actions/auth.ts
+++ b/apps/web/src/actions/auth.ts
@@ -12,7 +12,11 @@ import { clearSession, setSession } from "../lib/cookies";
 import { db } from "../lib/db";
 import { dict } from "../lib/i18n";
 import { countUsers, ensureWorkspace } from "../lib/instance";
-import { hashPassword, verifyPassword } from "../lib/password";
+import {
+  ABSENT_USER_HASH,
+  hashPassword,
+  verifyPassword,
+} from "../lib/password";
 
 export type AuthState = { error: string } | null;
 
@@ -91,11 +95,15 @@ export async function loginAction(
     .where(eq(user.email, email))
     .limit(1);
 
-  if (
-    !found ||
-    !found.active ||
-    !(await verifyPassword(password, found.passwordHash))
-  ) {
+  // Same work on every branch. Short-circuiting on `found` or on `active`
+  // skipped scrypt entirely, and answering that much sooner told a caller
+  // which addresses have an account, and which of those are switched off,
+  // however generic the message is.
+  const passwordOk = await verifyPassword(
+    password,
+    found?.passwordHash ?? ABSENT_USER_HASH,
+  );
+  if (!found || !found.active || !passwordOk) {
     return { error: (await authCopy()).errCredentials };
   }
 

--- a/apps/web/src/lib/password.test.ts
+++ b/apps/web/src/lib/password.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { hashPassword, verifyPassword } from "./password";
+import { ABSENT_USER_HASH, hashPassword, verifyPassword } from "./password";
 
 describe("local password hash", () => {
   it("verifies the same password and rejects a wrong one", async () => {
@@ -11,5 +11,43 @@ describe("local password hash", () => {
 
   it("rejects a malformed stored value without throwing", async () => {
     expect(await verifyPassword("anything", "not-a-hash")).toBe(false);
+  });
+describe("the decoy for an address with no account", () => {
+    // The login verifies against this when it finds no user, and when the
+    // user it finds is inactive, so those answers cost the same scrypt call
+    // a real account costs. The shape is the whole point: verifyPassword
+    // bails before hashing on a record it cannot parse, and a decoy that
+    // bailed early would spend nothing and leave the timing gap where it was.
+    it("is shaped like a record verifyPassword hashes rather than rejects", () => {
+      const [algo, salt, hash] = ABSENT_USER_HASH.split(":");
+      expect(algo).toBe("scrypt");
+      expect(salt).toBeTruthy();
+      expect(hash).toBeTruthy();
+      // The key length is the check standing between the parse and the
+      // compare; get it wrong and verifyPassword returns before hashing.
+      expect(Buffer.from(hash as string, "hex")).toHaveLength(64);
+    });
+
+    it("matches no password", async () => {
+      expect(await verifyPassword("", ABSENT_USER_HASH)).toBe(false);
+      expect(await verifyPassword("hunter2", ABSENT_USER_HASH)).toBe(false);
+    });
+
+    it("costs about what a real verification costs", async () => {
+      // Loose on purpose: a smoke check that the decoy path hashes at all,
+      // not a benchmark. A decoy that returned early would land orders of
+      // magnitude below a real hash, nowhere near this ratio. Timing is not
+      // asserted tightly anywhere, because a wall-clock assertion on a shared
+      // runner is a flaky test, and a flaky test in an auth path is worse
+      // than none.
+      const real = await hashPassword("some-password");
+      const t0 = performance.now();
+      await verifyPassword("some-password", real);
+      const knownCost = performance.now() - t0;
+      const t1 = performance.now();
+      await verifyPassword("some-password", ABSENT_USER_HASH);
+      const unknownCost = performance.now() - t1;
+      expect(unknownCost).toBeGreaterThan(knownCost / 10);
+    });
   });
 });

--- a/apps/web/src/lib/password.ts
+++ b/apps/web/src/lib/password.ts
@@ -10,6 +10,19 @@ export async function hashPassword(password: string): Promise<string> {
   return `scrypt:${salt}:${buf.toString("hex")}`;
 }
 
+/**
+ * A well-formed record no password can match, for the branches where there
+ * is no account to check against. Verifying against it costs the same scrypt
+ * call a real account costs, so the answer takes the same time either way.
+ *
+ * It has to stay well formed: verifyPassword returns early on a record it
+ * cannot parse, and an early return here would spend nothing and leave the
+ * gap exactly where it was. The tests hold it to that shape.
+ */
+export const ABSENT_USER_HASH = `scrypt:${"0".repeat(32)}:${"0".repeat(
+  KEYLEN * 2,
+)}`;
+
 export async function verifyPassword(
   password: string,
   stored: string,


### PR DESCRIPTION
Reported privately first as **GHSA-rrc7-jvcm-35r5** (severity low). Opening the fix
publicly at the requester's direction; the advisory carries the full write-up and
measurements.

## What

`loginAction` short-circuits on `found` and on `found.active`, so an address with no
account, and an address whose account is switched off, both return without ever calling
scrypt.

```ts
if (
  !found ||
  !found.active ||
  !(await verifyPassword(password, found.passwordHash))
) {
```

The error message is already generic. The clock is not: on my machine a known address
costs about 52 ms and a short-circuit costs about 0.03 ms. That difference is trivially
measurable over a network, and it says which e-mails have accounts here, and which of
those are disabled.

## Fix

Compute the verification before the branch, against a decoy record when there is no
usable hash, so all three paths spend the same scrypt call. After the change the two
paths land within a fraction of a millisecond of each other.

## The part worth reviewing

**The decoy has to stay well formed.** `verifyPassword` returns early on a record it
cannot parse, so a malformed decoy would spend nothing and leave the gap exactly where
it was, while looking like a fix. `ABSENT_USER_HASH` keeps the `scrypt:salt:hash` shape
with a 64 byte key, and a test holds it to both, because that length check is what stands
between the parse and the compare.

**Timing is not asserted tightly.** A wall-clock assertion on a shared runner is a flaky
test, and a flaky test in an auth path is worse than no test. The suite checks the shape
structurally and adds one loose smoke check that would catch a decoy that stopped hashing
altogether. The numbers belong in the advisory, not in CI.

## Adjacent, deliberately not fixed here

There is no rate limiting or lockout on the login, so an address that has been enumerated
can then be guessed against without any budget. scrypt makes each attempt cost about
50 ms, which is a brake but not a limit. That is a product decision about how a
self-hosted board should behave, so I left it alone rather than bundling it.

## Verification

`tsc --noEmit` clean. The auth, session and password suites pass (14 tests, including
three new ones).

## Note on the branch name

No `OCL-` prefix: no board access here, and an invented card ID would collide with a real
one. Happy to rebase onto one you assign.
