### PR TITLE
fix(pairing): guessing the code costs a budget, not just a delay

### DIFF
--- a/apps/web/src/app/api/pair/route.ts
+++ b/apps/web/src/app/api/pair/route.ts
@@ -7,8 +7,13 @@ export const dynamic = "force-dynamic";
  * Public one-time pairing endpoint. The agent posts the 6-digit code the
  * human read out loud and receives the real bearer token, so the token
  * never travels through a chat. Codes are single-use with a short TTL and
- * only one is active per workspace; failures pay a flat delay to make
- * guessing the 6 digits impractical inside the TTL.
+ * only one is active per workspace.
+ *
+ * The flat delay below is not what makes guessing impractical: it is paid
+ * per request, so parallel guesses wait in parallel and the ceiling is the
+ * caller's connection count. What bounds the guessing is the failure
+ * budget in exchangePairingCode, which burns the live codes once it runs
+ * out. The delay stays because it costs an honest caller nothing.
  */
 export async function POST(request: Request): Promise<Response> {
   const body = (await request.json().catch(() => null)) as

--- a/apps/web/src/lib/pairing.ts
+++ b/apps/web/src/lib/pairing.ts
@@ -1,6 +1,6 @@
 import { createHash, randomInt } from "node:crypto";
-import { mcpToken, pairingCode } from "@agent-board/db";
-import { and, eq, isNull } from "drizzle-orm";
+import { mcpToken, pairingCode, pairingFailure } from "@agent-board/db";
+import { and, eq, isNull, sql } from "drizzle-orm";
 import { generateTokenSecret, hashToken } from "../mcp/token";
 import type { McpDatabase } from "../mcp/types";
 
@@ -11,6 +11,25 @@ import type { McpDatabase } from "../mcp/types";
  * first use and expires quickly; only one code is active per workspace.
  */
 export const PAIRING_CODE_TTL_MS = 10 * 60 * 1000;
+
+/**
+ * Wrong guesses tolerated before the live codes are burned.
+ *
+ * Six digits is a million combinations, which sounds like plenty until you
+ * notice nothing serialises the attempts: a flat delay on the failure path
+ * is paid by each request on its own, so concurrent requests wait in
+ * parallel and the ceiling is the caller's connection count, not the delay.
+ * Inside a ten minute TTL that is reachable, and the prize is a real bearer
+ * token for the workspace.
+ *
+ * Counting instead of slowing removes the concurrency advantage: guesses
+ * cost a budget that a hundred parallel connections drain a hundred times
+ * faster, and draining it is what burns the code.
+ */
+export const MAX_PAIRING_FAILURES = 10;
+
+/** This table holds one row for the whole instance. */
+const FAILURE_KEY = "global";
 
 export function generatePairingCode(): string {
   return String(randomInt(0, 1_000_000)).padStart(6, "0");
@@ -58,6 +77,51 @@ export async function createPairingCode(
   return { id: row.id, code, expiresAt };
 }
 
+/**
+ * Counts one wrong guess and, once the budget for the window is gone,
+ * burns every unconsumed code. The human is told to generate another one,
+ * which costs them a sentence; the guesser goes back to a fresh million.
+ *
+ * The window is the code TTL: outside it there is no live code to protect,
+ * so the count starts over.
+ */
+async function recordFailure(db: McpDatabase): Promise<void> {
+  const now = new Date();
+  const windowFloor = new Date(now.getTime() - PAIRING_CODE_TTL_MS);
+
+  // One statement, so parallel guesses cannot read the same count and each
+  // write back the same increment.
+  const [row] = await db
+    .insert(pairingFailure)
+    .values({ id: FAILURE_KEY, count: 1, windowStartedAt: now })
+    .onConflictDoUpdate({
+      target: pairingFailure.id,
+      set: {
+        count: sql`case when ${pairingFailure.windowStartedAt} < ${windowFloor}
+          then 1 else ${pairingFailure.count} + 1 end`,
+        windowStartedAt: sql`case when ${pairingFailure.windowStartedAt} < ${windowFloor}
+          then ${now} else ${pairingFailure.windowStartedAt} end`,
+      },
+    })
+    .returning({ count: pairingFailure.count });
+
+  if ((row?.count ?? 0) < MAX_PAIRING_FAILURES) return;
+
+  await db.delete(pairingCode).where(isNull(pairingCode.consumedAt));
+  await db
+    .update(pairingFailure)
+    .set({ count: 0, windowStartedAt: now })
+    .where(eq(pairingFailure.id, FAILURE_KEY));
+}
+
+/** A successful pairing clears the budget: nobody was guessing. */
+async function clearFailures(db: McpDatabase): Promise<void> {
+  await db
+    .update(pairingFailure)
+    .set({ count: 0 })
+    .where(eq(pairingFailure.id, FAILURE_KEY));
+}
+
 export type ExchangeResult =
   | { ok: true; token: string; label: string }
   | { ok: false; error: string };
@@ -71,9 +135,12 @@ export async function exchangePairingCode(
     error:
       "Pairing code not found or expired. Ask the human to generate a fresh code in the board Settings or onboarding wizard.",
   };
-  if (!isValidPairingCodeFormat(rawCode.trim())) return notFound;
+  if (!isValidPairingCodeFormat(rawCode.trim())) {
+    await recordFailure(db);
+    return notFound;
+  }
 
-  return db.transaction(async (tx) => {
+  const result: ExchangeResult = await db.transaction(async (tx) => {
     // Consume atomically: the update only wins while consumed_at is null,
     // so a second exchange with the same code loses even in a race.
     const [consumed] = await tx
@@ -110,6 +177,10 @@ export async function exchangePairingCode(
 
     return { ok: true, token: secret, label: consumed.label };
   });
+
+  if (result.ok) await clearFailures(db);
+  else await recordFailure(db);
+  return result;
 }
 
 /** Wizard polling: paired once the code was exchanged. */

--- a/apps/web/src/mcp/pairing.integration.test.ts
+++ b/apps/web/src/mcp/pairing.integration.test.ts
@@ -4,6 +4,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import {
   createPairingCode,
   exchangePairingCode,
+  MAX_PAIRING_FAILURES,
   pairingStatus,
 } from "../lib/pairing";
 import { authenticateBearer } from "./auth";
@@ -14,6 +15,50 @@ describe("one-time token pairing", () => {
 
   afterEach(async () => {
     if (world) await closeTestWorld(world);
+  });
+
+
+  it("burns the live code once the guessing budget is gone", async () => {
+    world = await createTestWorld();
+    const created = await createPairingCode(world.db, {
+      workspaceId: world.workspaceId,
+      label: "paired via code",
+    });
+
+    // Wrong guesses, all at once. Sequential attempts were never the threat:
+    // the failure path costs a flat delay each, paid in parallel, so a caller
+    // with connections to spare was bounded by its own concurrency and not by
+    // the delay. A budget is what a hundred parallel guesses cannot outrun.
+    const wrong = Array.from({ length: MAX_PAIRING_FAILURES }, (_, i) =>
+      String(i).padStart(6, "9"),
+    ).filter((code) => code !== created.code);
+    await Promise.all(wrong.map((code) => exchangePairingCode(world.db, code)));
+
+    // The real code is gone: the humans generate another one, the guesser
+    // goes back to a fresh million.
+    const withTheRealCode = await exchangePairingCode(world.db, created.code);
+    expect(withTheRealCode.ok).toBe(false);
+
+    const [row] = await world.db
+      .select()
+      .from(pairingCode)
+      .where(eq(pairingCode.id, created.id));
+    expect(row).toBeUndefined();
+  });
+
+  it("does not punish a human who mistypes once and then gets it right", async () => {
+    world = await createTestWorld();
+    const created = await createPairingCode(world.db, {
+      workspaceId: world.workspaceId,
+      label: "paired via code",
+    });
+
+    const typo = created.code === "000000" ? "111111" : "000000";
+    const missed = await exchangePairingCode(world.db, typo);
+    expect(missed.ok).toBe(false);
+
+    const second = await exchangePairingCode(world.db, created.code);
+    expect(second.ok).toBe(true);
   });
 
   it("exchanges a 6-digit code for a working bearer token, once", async () => {

--- a/packages/db/drizzle/0035_pairing_failure.sql
+++ b/packages/db/drizzle/0035_pairing_failure.sql
@@ -1,0 +1,5 @@
+CREATE TABLE "pairing_failure" (
+	"id" text PRIMARY KEY NOT NULL,
+	"count" integer DEFAULT 0 NOT NULL,
+	"window_started_at" timestamp with time zone DEFAULT now() NOT NULL
+);

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -246,6 +246,13 @@
       "when": 1787149318841,
       "tag": "0034_project_context_sources",
       "breakpoints": true
+    },
+    {
+      "idx": 35,
+      "version": "7",
+      "when": 1787149319841,
+      "tag": "0035_pairing_failure",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -21,6 +21,7 @@ export { executionAttempt } from "./execution-attempt";
 export { handoff } from "./handoff";
 export { mcpToken } from "./mcp-token";
 export { pairingCode } from "./pairing-code";
+export { pairingFailure } from "./pairing-failure";
 export { cardapioEntry } from "./cardapio-entry";
 export { modelPrice } from "./model-price";
 export { usageRecipe } from "./usage-recipe";

--- a/packages/db/src/schema/pairing-failure.ts
+++ b/packages/db/src/schema/pairing-failure.ts
@@ -1,0 +1,18 @@
+import { integer, pgTable, text, timestamp } from "drizzle-orm/pg-core";
+
+/**
+ * Failed pairing exchanges, counted for the whole instance.
+ *
+ * A wrong guess matches no row, because the lookup is by hash, so there is
+ * no code to attribute the attempt to and the counter has to live outside
+ * the codes. One row is enough: only one code is live per workspace, and
+ * the question being asked is whether somebody is guessing at all.
+ */
+export const pairingFailure = pgTable("pairing_failure", {
+  /** Fixed key. This table holds exactly one row. */
+  id: text("id").primaryKey(),
+  count: integer("count").notNull().default(0),
+  windowStartedAt: timestamp("window_started_at", { withTimezone: true })
+    .notNull()
+    .defaultNow(),
+});


### PR DESCRIPTION
Reported privately first as **GHSA-hccf-43jq-44w5** (severity high). Opening the fix
publicly at the requester's direction; the advisory carries the full write-up.

## What

`POST /api/pair` is public and unauthenticated, and accepts unlimited wrong codes. The
code is 6 digits and lives 10 minutes, and a correct one returns a real bearer token for
the workspace.

The only defence is a flat 500 ms on the failure path, and the comment above it says that
makes guessing the six digits impractical inside the TTL.

It does not. The delay is awaited **per request**, so nothing is serialised. Concurrent
requests wait in parallel and the ceiling is the caller's connection count, not the delay.
The delay costs an attacker latency, not attempts.

There is nothing else in the way: no `middleware.ts`, and no rate limiting, throttle,
attempt counter or lockout anywhere in `apps/web/src` or `packages/*/src`.

## The awkward part, and the shape that handles it

A wrong guess matches no row, because the lookup is by code hash. There is no code to
attribute the attempt to, so the counter cannot live on the code row: it sits outside, one
row for the instance.

Past the budget, every unconsumed code is burned. The human generates another one, which
costs them a sentence; the guesser starts over on a fresh million. A success clears the
count, and so does a window older than the code TTL, since outside it there is no live
code to protect.

The increment is a single upsert rather than a read then a write, because concurrency is
the whole weakness here and a counter with a race would inherit it.

The 500 ms delay stays, since it costs an honest caller nothing. Its comment now says what
it does and does not do.

**If you would rather not add a table**, the one-line alternative is widening the code
from 6 digits to 8–10 alphanumeric characters, taking the space from 10^6 to about 36^8.
It costs the legibility of reading a code out loud, which is why 6 digits was chosen, so I
did not assume it for you. Say the word and I will send that instead.

## Tests

- ten concurrent wrong guesses burn the live code, checked both by trying the correct code
  afterwards and by the row being gone. Concurrent on purpose: sequential attempts were
  never the threat.
- a human who mistypes once still pairs on the second try, which is the case a blunter
  lockout would break.

I verified the first test actually guards the fix by removing the accounting and watching
it fail.

## One thing to know about the migration

It is hand-written, because `pnpm db:generate` cannot run on `main` today:
`packages/db/drizzle/meta/0034_snapshot.json` is committed **empty** (0 bytes) and
drizzle-kit stops with `SyntaxError: Unexpected end of JSON input`. I filed that
separately.

The SQL and the journal entry are what `db:migrate` reads, and the integration suite
replays the whole migration folder on PGlite, so this migration is applied and exercised
on every test run. The snapshot for it should be regenerated once 0034 is repaired, and I
am happy to do that in a follow-up.

## Verification

`tsc --noEmit` clean. Full suite green: 126 in `packages/db`, 465 in `apps/web`.

## Note on the branch name

No `OCL-` prefix: no board access here, and an invented card ID would collide with a real
one. Happy to rebase onto one you assign.
