### PR TITLE
[OCL-99] fix(auth): an unknown or inactive e-mail costs the same as a known one

### DIFF
--- a/apps/web/src/actions/auth.test.ts
+++ b/apps/web/src/actions/auth.test.ts
@@ -1,0 +1,104 @@
+import { user } from "@agent-board/db";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { ABSENT_USER_HASH, hashPassword, verifyPassword } from "../lib/password";
+import { createTestWorld, type TestWorld } from "../mcp/test-db";
+
+let world: TestWorld;
+let storedHash: string;
+
+vi.mock("../lib/db", () => ({
+  db: () => world.db,
+  getDatabaseUrl: () => "pglite://test",
+}));
+
+vi.mock("../lib/password", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../lib/password")>();
+  return { ...actual, verifyPassword: vi.fn(actual.verifyPassword) };
+});
+
+const { loginAction } = await import("./auth");
+
+const PASSWORD = "correct-horse-battery";
+
+function credentials(email: string, password: string): FormData {
+  const form = new FormData();
+  form.set("email", email);
+  form.set("password", password);
+  return form;
+}
+
+/**
+ * GHSA-rrc7-jvcm-35r5: loginAction used to short-circuit on `found` and on
+ * `found.active`, so an address with no account and an address whose account
+ * is switched off both answered without ever calling scrypt — about 0.4ms
+ * against about 20ms for a real account on this machine. The message was
+ * already generic; the clock was not, and the gap enumerated which addresses
+ * have an account here and which of those are disabled.
+ *
+ * These assert the invariant structurally — exactly one verification per
+ * failing path, and the decoy standing in when there is no hash to check
+ * against — rather than by wall clock. A timing assertion on a shared CI
+ * runner is flaky, and a flaky test on an auth path is worse than none; the
+ * measurements live in the advisory. What a structural check buys is the
+ * thing a wall-clock check would miss anyway: it fails the moment someone
+ * reintroduces a `return` above the verification.
+ */
+describe("loginAction costs one password verification on every failing path", () => {
+  beforeAll(async () => {
+    world = await createTestWorld();
+    storedHash = await hashPassword(PASSWORD);
+    await world.db.insert(user).values([
+      { email: "active@local.test", passwordHash: storedHash },
+      { email: "off@local.test", passwordHash: storedHash, active: false },
+    ]);
+  });
+
+  beforeEach(() => {
+    vi.mocked(verifyPassword).mockClear();
+  });
+
+  it("verifies against the decoy when the address has no account", async () => {
+    const result = await loginAction(
+      null,
+      credentials("ghost@local.test", PASSWORD),
+    );
+
+    expect(result?.error).toBeTruthy();
+    expect(verifyPassword).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(verifyPassword).mock.calls[0]?.[1]).toBe(ABSENT_USER_HASH);
+  });
+
+  it("verifies against the stored hash when the account is switched off", async () => {
+    const result = await loginAction(
+      null,
+      credentials("off@local.test", PASSWORD),
+    );
+
+    // The password is the right one: only `active` turns this away, and it
+    // has to turn it away *after* paying for the verification.
+    expect(result?.error).toBeTruthy();
+    expect(verifyPassword).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(verifyPassword).mock.calls[0]?.[1]).toBe(storedHash);
+  });
+
+  it("verifies against the stored hash when the password is wrong", async () => {
+    const result = await loginAction(
+      null,
+      credentials("active@local.test", "not-the-password"),
+    );
+
+    expect(result?.error).toBeTruthy();
+    expect(verifyPassword).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(verifyPassword).mock.calls[0]?.[1]).toBe(storedHash);
+  });
+
+  it("answers all three with the same words", async () => {
+    const answers = await Promise.all([
+      loginAction(null, credentials("ghost@local.test", PASSWORD)),
+      loginAction(null, credentials("off@local.test", PASSWORD)),
+      loginAction(null, credentials("active@local.test", "not-the-password")),
+    ]);
+
+    expect(new Set(answers.map((answer) => answer?.error)).size).toBe(1);
+  });
+});

--- a/apps/web/src/actions/auth.ts
+++ b/apps/web/src/actions/auth.ts
@@ -12,7 +12,11 @@ import { clearSession, setSession } from "../lib/cookies";
 import { db } from "../lib/db";
 import { dict } from "../lib/i18n";
 import { countUsers, ensureWorkspace } from "../lib/instance";
-import { hashPassword, verifyPassword } from "../lib/password";
+import {
+  ABSENT_USER_HASH,
+  hashPassword,
+  verifyPassword,
+} from "../lib/password";
 
 export type AuthState = { error: string } | null;
 
@@ -91,11 +95,15 @@ export async function loginAction(
     .where(eq(user.email, email))
     .limit(1);
 
-  if (
-    !found ||
-    !found.active ||
-    !(await verifyPassword(password, found.passwordHash))
-  ) {
+  // Same work on every branch. Short-circuiting on `found` or on `active`
+  // skipped scrypt entirely, and answering that much sooner told a caller
+  // which addresses have an account, and which of those are switched off,
+  // however generic the message is.
+  const passwordOk = await verifyPassword(
+    password,
+    found?.passwordHash ?? ABSENT_USER_HASH,
+  );
+  if (!found || !found.active || !passwordOk) {
     return { error: (await authCopy()).errCredentials };
   }
 

--- a/apps/web/src/lib/password.test.ts
+++ b/apps/web/src/lib/password.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { hashPassword, verifyPassword } from "./password";
+import { ABSENT_USER_HASH, hashPassword, verifyPassword } from "./password";
 
 describe("local password hash", () => {
   it("verifies the same password and rejects a wrong one", async () => {
@@ -11,5 +11,43 @@ describe("local password hash", () => {
 
   it("rejects a malformed stored value without throwing", async () => {
     expect(await verifyPassword("anything", "not-a-hash")).toBe(false);
+  });
+describe("the decoy for an address with no account", () => {
+    // The login verifies against this when it finds no user, and when the
+    // user it finds is inactive, so those answers cost the same scrypt call
+    // a real account costs. The shape is the whole point: verifyPassword
+    // bails before hashing on a record it cannot parse, and a decoy that
+    // bailed early would spend nothing and leave the timing gap where it was.
+    it("is shaped like a record verifyPassword hashes rather than rejects", () => {
+      const [algo, salt, hash] = ABSENT_USER_HASH.split(":");
+      expect(algo).toBe("scrypt");
+      expect(salt).toBeTruthy();
+      expect(hash).toBeTruthy();
+      // The key length is the check standing between the parse and the
+      // compare; get it wrong and verifyPassword returns before hashing.
+      expect(Buffer.from(hash as string, "hex")).toHaveLength(64);
+    });
+
+    it("matches no password", async () => {
+      expect(await verifyPassword("", ABSENT_USER_HASH)).toBe(false);
+      expect(await verifyPassword("hunter2", ABSENT_USER_HASH)).toBe(false);
+    });
+
+    it("costs about what a real verification costs", async () => {
+      // Loose on purpose: a smoke check that the decoy path hashes at all,
+      // not a benchmark. A decoy that returned early would land orders of
+      // magnitude below a real hash, nowhere near this ratio. Timing is not
+      // asserted tightly anywhere, because a wall-clock assertion on a shared
+      // runner is a flaky test, and a flaky test in an auth path is worse
+      // than none.
+      const real = await hashPassword("some-password");
+      const t0 = performance.now();
+      await verifyPassword("some-password", real);
+      const knownCost = performance.now() - t0;
+      const t1 = performance.now();
+      await verifyPassword("some-password", ABSENT_USER_HASH);
+      const unknownCost = performance.now() - t1;
+      expect(unknownCost).toBeGreaterThan(knownCost / 10);
+    });
   });
 });

--- a/apps/web/src/lib/password.ts
+++ b/apps/web/src/lib/password.ts
@@ -10,6 +10,19 @@ export async function hashPassword(password: string): Promise<string> {
   return `scrypt:${salt}:${buf.toString("hex")}`;
 }
 
+/**
+ * A well-formed record no password can match, for the branches where there
+ * is no account to check against. Verifying against it costs the same scrypt
+ * call a real account costs, so the answer takes the same time either way.
+ *
+ * It has to stay well formed: verifyPassword returns early on a record it
+ * cannot parse, and an early return here would spend nothing and leave the
+ * gap exactly where it was. The tests hold it to that shape.
+ */
+export const ABSENT_USER_HASH = `scrypt:${"0".repeat(32)}:${"0".repeat(
+  KEYLEN * 2,
+)}`;
+
 export async function verifyPassword(
   password: string,
   stored: string,


### PR DESCRIPTION
Carries **#18** by @EduardoxDev verbatim (authorship untouched), plus one commit adding the
regression test the fix was missing. Reported privately first as **GHSA-rrc7-jvcm-35r5**
(severity low). Reviewed as **OCL-99**; full audit in
https://github.com/ustoppble/overclick/pull/18#issuecomment-5356598947.

## The bug

`loginAction` short-circuited on `found` and on `found.active`, so an address with no
account and an address whose account is switched off both answered without ever calling
scrypt. The error message was already generic; the clock was not, and the gap said which
addresses have an account here and which of those are disabled.

## The fix (ecba74d, @EduardoxDev)

Verify before the branch, against a well-formed decoy record when there is no usable hash,
so all three failing paths spend the same scrypt call. The decoy has to stay parseable with
a 64 byte key — `verifyPassword` returns early otherwise, which would spend nothing and
leave the gap exactly where it was while looking like a fix.

## The addition (e445fde)

Nothing in the suite would have noticed the fix being undone. `apps/web/src/actions/auth.test.ts`
asserts one verification per failing path — against the decoy when there is no account,
against the stored hash when the account is off or the password is wrong. Structural, not
wall-clock: a timing assertion on a shared runner is flaky, and a flaky test on an auth path
is worse than none. Verified it fails against `ecba74d^`.

## Measured

Three failing paths through `loginAction` against a PGlite database, 25 samples each after
warmup, medians:

| path | before | after |
|---|---|---|
| no account | 0.46 ms | 21.62 ms |
| account switched off | 0.41 ms | 21.33 ms |
| wrong password | 19.50 ms | 20.93 ms |

~42× gap before; within 0.7 ms with overlapping ranges after.

## Verification

`tsc --noEmit` clean · `pnpm build` clean · `pnpm test` green — 709 tests (470 `apps/web`,
126 `packages/db`, 113 `packages/mcp-core`).

## Not bundled

No rate limiting or lockout on the login. This change also makes an unknown address cost
~21 ms of scrypt on the libuv threadpool where it used to cost ~0.4 ms — the standard trade
every constant-time login makes, but it earns rate limiting its own card. Filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
