### PR TITLE
[OCL-101] pairing: gate the guess on the budget, and scope the budget to who spent it (extends #19)

### DIFF
--- a/apps/web/src/app/api/pair/route.ts
+++ b/apps/web/src/app/api/pair/route.ts
@@ -4,6 +4,32 @@ import { exchangePairingCode } from "../../../lib/pairing";
 export const dynamic = "force-dynamic";
 
 /**
+ * Who is guessing, as far as this deployment can honestly tell.
+ *
+ * A forwarded-for header is written by whatever sits in front, and on a
+ * directly exposed instance that is the caller itself: trusting it there
+ * would hand a guesser a fresh budget per request just by varying a string,
+ * which is worse than having no scope at all. So it counts only where the
+ * deploy declares it is behind a proxy, and then only the last hop — the
+ * entry our own proxy appended, which the caller cannot write past.
+ *
+ * Undeclared, everyone shares one bucket. That still refuses a burst and
+ * still destroys nothing; what it loses is the ability to tell the guesser
+ * apart from the honest agent, which is why the hosted overlay sets the
+ * flag and the quickstart, which nobody should expose, does not.
+ */
+function guessOrigin(request: Request): string | null {
+  if (process.env.OVERCLICK_TRUSTED_PROXY !== "1") return null;
+  const forwarded = request.headers.get("x-forwarded-for");
+  if (!forwarded) return request.headers.get("x-real-ip");
+  const hops = forwarded
+    .split(",")
+    .map((hop) => hop.trim())
+    .filter(Boolean);
+  return hops.at(-1) ?? null;
+}
+
+/**
  * Public one-time pairing endpoint. The agent posts the 6-digit code the
  * human read out loud and receives the real bearer token, so the token
  * never travels through a chat. Codes are single-use with a short TTL and
@@ -11,9 +37,11 @@ export const dynamic = "force-dynamic";
  *
  * The flat delay below is not what makes guessing impractical: it is paid
  * per request, so parallel guesses wait in parallel and the ceiling is the
- * caller's connection count. What bounds the guessing is the failure
- * budget in exchangePairingCode, which burns the live codes once it runs
- * out. The delay stays because it costs an honest caller nothing.
+ * caller's connection count. What bounds the guessing is the attempt budget
+ * in exchangePairingCode, which stops evaluating codes for an origin that
+ * has spent it. The delay stays because it costs an honest caller nothing
+ * and because paying it on every refusal is what keeps the two kinds of
+ * refusal — wrong code, and no budget left to look — indistinguishable.
  */
 export async function POST(request: Request): Promise<Response> {
   const body = (await request.json().catch(() => null)) as
@@ -21,7 +49,7 @@ export async function POST(request: Request): Promise<Response> {
     | null;
   const code = typeof body?.code === "string" ? body.code.trim() : "";
 
-  const result = await exchangePairingCode(db(), code);
+  const result = await exchangePairingCode(db(), code, guessOrigin(request));
   if (!result.ok) {
     await new Promise((resolve) => setTimeout(resolve, 500));
     return Response.json({ error: result.error }, { status: 404 });

--- a/apps/web/src/app/api/pair/route.ts
+++ b/apps/web/src/app/api/pair/route.ts
@@ -7,8 +7,13 @@ export const dynamic = "force-dynamic";
  * Public one-time pairing endpoint. The agent posts the 6-digit code the
  * human read out loud and receives the real bearer token, so the token
  * never travels through a chat. Codes are single-use with a short TTL and
- * only one is active per workspace; failures pay a flat delay to make
- * guessing the 6 digits impractical inside the TTL.
+ * only one is active per workspace.
+ *
+ * The flat delay below is not what makes guessing impractical: it is paid
+ * per request, so parallel guesses wait in parallel and the ceiling is the
+ * caller's connection count. What bounds the guessing is the failure
+ * budget in exchangePairingCode, which burns the live codes once it runs
+ * out. The delay stays because it costs an honest caller nothing.
  */
 export async function POST(request: Request): Promise<Response> {
   const body = (await request.json().catch(() => null)) as

--- a/apps/web/src/lib/pairing.ts
+++ b/apps/web/src/lib/pairing.ts
@@ -13,7 +13,8 @@ import type { McpDatabase } from "../mcp/types";
 export const PAIRING_CODE_TTL_MS = 10 * 60 * 1000;
 
 /**
- * Wrong guesses tolerated before the live codes are burned.
+ * Wrong guesses one origin may spend inside a window before the endpoint
+ * stops looking at its codes at all.
  *
  * Six digits is a million combinations, which sounds like plenty until you
  * notice nothing serialises the attempts: a flat delay on the failure path
@@ -22,14 +23,31 @@ export const PAIRING_CODE_TTL_MS = 10 * 60 * 1000;
  * Inside a ten minute TTL that is reachable, and the prize is a real bearer
  * token for the workspace.
  *
- * Counting instead of slowing removes the concurrency advantage: guesses
- * cost a budget that a hundred parallel connections drain a hundred times
- * faster, and draining it is what burns the code.
+ * Counting instead of slowing removes the concurrency advantage: an attempt
+ * costs budget before anyone looks at the code it carries, so a hundred
+ * parallel guesses drain the budget a hundred times faster and then get
+ * refused unread.
  */
 export const MAX_PAIRING_FAILURES = 10;
 
-/** This table holds one row for the whole instance. */
-const FAILURE_KEY = "global";
+/**
+ * Which bucket an attempt is charged to.
+ *
+ * A wrong guess matches no row, because the lookup is by hash, so there is
+ * no code to attribute it to and the budget has to live outside the codes.
+ * One bucket for the whole instance would work as a brake and fail as a
+ * design: ten anonymous requests would then be enough to freeze the pairing
+ * of every workspace at once, which is a denial of service handed to any
+ * stranger. So the bucket is the origin the deployment can honestly name,
+ * and callers that cannot be told apart share the fallback one.
+ *
+ * The escape hatch out of a drained bucket is not time, it is the human:
+ * see `createPairingCode`.
+ */
+function pairingFailureScope(origin?: string | null): string {
+  const named = origin?.trim().slice(0, 100);
+  return `origin:${named || "unknown"}`;
+}
 
 export function generatePairingCode(): string {
   return String(randomInt(0, 1_000_000)).padStart(6, "0");
@@ -41,6 +59,46 @@ export function hashPairingCode(code: string): string {
 
 export function isValidPairingCodeFormat(code: string): boolean {
   return /^\d{6}$/.test(code);
+}
+
+/**
+ * Charges one attempt to the scope and says whether it may be evaluated.
+ *
+ * A single statement, so a burst cannot have every request read the same
+ * count and write back the same increment; concurrency was the whole
+ * weakness, so the accounting is the one place it may not leak. The count
+ * comes back from the statement that spent it, which is what lets the
+ * caller decide *before* it looks at the code: past the budget the guess is
+ * refused without ever being hashed or compared, so the thousandth guess of
+ * a burst cannot win even when it happens to be right.
+ *
+ * The window is the code TTL: outside it there was no live code to protect,
+ * so the count starts over.
+ */
+async function spendAttempt(db: McpDatabase, scope: string): Promise<boolean> {
+  const now = new Date();
+  const windowFloor = new Date(now.getTime() - PAIRING_CODE_TTL_MS);
+
+  const [row] = await db
+    .insert(pairingFailure)
+    .values({ id: scope, count: 1, windowStartedAt: now })
+    .onConflictDoUpdate({
+      target: pairingFailure.id,
+      set: {
+        count: sql`case when ${pairingFailure.windowStartedAt} < ${windowFloor}
+          then 1 else ${pairingFailure.count} + 1 end`,
+        windowStartedAt: sql`case when ${pairingFailure.windowStartedAt} < ${windowFloor}
+          then ${now} else ${pairingFailure.windowStartedAt} end`,
+      },
+    })
+    .returning({ count: pairingFailure.count });
+
+  return (row?.count ?? 1) <= MAX_PAIRING_FAILURES;
+}
+
+/** A successful pairing clears the budget: nobody there was guessing. */
+async function clearAttempts(db: McpDatabase, scope: string): Promise<void> {
+  await db.delete(pairingFailure).where(eq(pairingFailure.id, scope));
 }
 
 export async function createPairingCode(
@@ -61,6 +119,14 @@ export async function createPairingCode(
       ),
     );
 
+  // Generating a code is a signed-in human saying "I am here now", and it
+  // is what reopens a drained bucket. Without this a guesser could leave
+  // the endpoint refusing the very attempt the legitimate agent is about
+  // to make. What it costs is bounded and small: at most the budget's worth
+  // of evaluated guesses per origin against a brand new number out of a
+  // million, and the guesser cannot trigger it — only the human can.
+  await db.delete(pairingFailure);
+
   const [row] = await db
     .insert(pairingCode)
     .values({
@@ -77,51 +143,6 @@ export async function createPairingCode(
   return { id: row.id, code, expiresAt };
 }
 
-/**
- * Counts one wrong guess and, once the budget for the window is gone,
- * burns every unconsumed code. The human is told to generate another one,
- * which costs them a sentence; the guesser goes back to a fresh million.
- *
- * The window is the code TTL: outside it there is no live code to protect,
- * so the count starts over.
- */
-async function recordFailure(db: McpDatabase): Promise<void> {
-  const now = new Date();
-  const windowFloor = new Date(now.getTime() - PAIRING_CODE_TTL_MS);
-
-  // One statement, so parallel guesses cannot read the same count and each
-  // write back the same increment.
-  const [row] = await db
-    .insert(pairingFailure)
-    .values({ id: FAILURE_KEY, count: 1, windowStartedAt: now })
-    .onConflictDoUpdate({
-      target: pairingFailure.id,
-      set: {
-        count: sql`case when ${pairingFailure.windowStartedAt} < ${windowFloor}
-          then 1 else ${pairingFailure.count} + 1 end`,
-        windowStartedAt: sql`case when ${pairingFailure.windowStartedAt} < ${windowFloor}
-          then ${now} else ${pairingFailure.windowStartedAt} end`,
-      },
-    })
-    .returning({ count: pairingFailure.count });
-
-  if ((row?.count ?? 0) < MAX_PAIRING_FAILURES) return;
-
-  await db.delete(pairingCode).where(isNull(pairingCode.consumedAt));
-  await db
-    .update(pairingFailure)
-    .set({ count: 0, windowStartedAt: now })
-    .where(eq(pairingFailure.id, FAILURE_KEY));
-}
-
-/** A successful pairing clears the budget: nobody was guessing. */
-async function clearFailures(db: McpDatabase): Promise<void> {
-  await db
-    .update(pairingFailure)
-    .set({ count: 0 })
-    .where(eq(pairingFailure.id, FAILURE_KEY));
-}
-
 export type ExchangeResult =
   | { ok: true; token: string; label: string }
   | { ok: false; error: string };
@@ -129,16 +150,24 @@ export type ExchangeResult =
 export async function exchangePairingCode(
   db: McpDatabase,
   rawCode: string,
+  origin?: string | null,
 ): Promise<ExchangeResult> {
   const notFound: ExchangeResult = {
     ok: false,
     error:
       "Pairing code not found or expired. Ask the human to generate a fresh code in the board Settings or onboarding wizard.",
   };
-  if (!isValidPairingCodeFormat(rawCode.trim())) {
-    await recordFailure(db);
-    return notFound;
-  }
+  const scope = pairingFailureScope(origin);
+
+  // The gate, and the whole point of it: the budget is spent and read
+  // before the code is looked at, so a drained bucket refuses the attempt
+  // without evaluating it. Nothing downstream of here runs on a guess the
+  // budget did not pay for. The answer is the same one a wrong code gets,
+  // so the refusal is not an oracle either — and it already tells the
+  // caller the way out, which is to ask the human for a fresh code.
+  if (!(await spendAttempt(db, scope))) return notFound;
+
+  if (!isValidPairingCodeFormat(rawCode.trim())) return notFound;
 
   const result: ExchangeResult = await db.transaction(async (tx) => {
     // Consume atomically: the update only wins while consumed_at is null,
@@ -178,8 +207,7 @@ export async function exchangePairingCode(
     return { ok: true, token: secret, label: consumed.label };
   });
 
-  if (result.ok) await clearFailures(db);
-  else await recordFailure(db);
+  if (result.ok) await clearAttempts(db, scope);
   return result;
 }
 

--- a/apps/web/src/lib/pairing.ts
+++ b/apps/web/src/lib/pairing.ts
@@ -1,6 +1,6 @@
 import { createHash, randomInt } from "node:crypto";
-import { mcpToken, pairingCode } from "@agent-board/db";
-import { and, eq, isNull } from "drizzle-orm";
+import { mcpToken, pairingCode, pairingFailure } from "@agent-board/db";
+import { and, eq, isNull, sql } from "drizzle-orm";
 import { generateTokenSecret, hashToken } from "../mcp/token";
 import type { McpDatabase } from "../mcp/types";
 
@@ -11,6 +11,25 @@ import type { McpDatabase } from "../mcp/types";
  * first use and expires quickly; only one code is active per workspace.
  */
 export const PAIRING_CODE_TTL_MS = 10 * 60 * 1000;
+
+/**
+ * Wrong guesses tolerated before the live codes are burned.
+ *
+ * Six digits is a million combinations, which sounds like plenty until you
+ * notice nothing serialises the attempts: a flat delay on the failure path
+ * is paid by each request on its own, so concurrent requests wait in
+ * parallel and the ceiling is the caller's connection count, not the delay.
+ * Inside a ten minute TTL that is reachable, and the prize is a real bearer
+ * token for the workspace.
+ *
+ * Counting instead of slowing removes the concurrency advantage: guesses
+ * cost a budget that a hundred parallel connections drain a hundred times
+ * faster, and draining it is what burns the code.
+ */
+export const MAX_PAIRING_FAILURES = 10;
+
+/** This table holds one row for the whole instance. */
+const FAILURE_KEY = "global";
 
 export function generatePairingCode(): string {
   return String(randomInt(0, 1_000_000)).padStart(6, "0");
@@ -58,6 +77,51 @@ export async function createPairingCode(
   return { id: row.id, code, expiresAt };
 }
 
+/**
+ * Counts one wrong guess and, once the budget for the window is gone,
+ * burns every unconsumed code. The human is told to generate another one,
+ * which costs them a sentence; the guesser goes back to a fresh million.
+ *
+ * The window is the code TTL: outside it there is no live code to protect,
+ * so the count starts over.
+ */
+async function recordFailure(db: McpDatabase): Promise<void> {
+  const now = new Date();
+  const windowFloor = new Date(now.getTime() - PAIRING_CODE_TTL_MS);
+
+  // One statement, so parallel guesses cannot read the same count and each
+  // write back the same increment.
+  const [row] = await db
+    .insert(pairingFailure)
+    .values({ id: FAILURE_KEY, count: 1, windowStartedAt: now })
+    .onConflictDoUpdate({
+      target: pairingFailure.id,
+      set: {
+        count: sql`case when ${pairingFailure.windowStartedAt} < ${windowFloor}
+          then 1 else ${pairingFailure.count} + 1 end`,
+        windowStartedAt: sql`case when ${pairingFailure.windowStartedAt} < ${windowFloor}
+          then ${now} else ${pairingFailure.windowStartedAt} end`,
+      },
+    })
+    .returning({ count: pairingFailure.count });
+
+  if ((row?.count ?? 0) < MAX_PAIRING_FAILURES) return;
+
+  await db.delete(pairingCode).where(isNull(pairingCode.consumedAt));
+  await db
+    .update(pairingFailure)
+    .set({ count: 0, windowStartedAt: now })
+    .where(eq(pairingFailure.id, FAILURE_KEY));
+}
+
+/** A successful pairing clears the budget: nobody was guessing. */
+async function clearFailures(db: McpDatabase): Promise<void> {
+  await db
+    .update(pairingFailure)
+    .set({ count: 0 })
+    .where(eq(pairingFailure.id, FAILURE_KEY));
+}
+
 export type ExchangeResult =
   | { ok: true; token: string; label: string }
   | { ok: false; error: string };
@@ -71,9 +135,12 @@ export async function exchangePairingCode(
     error:
       "Pairing code not found or expired. Ask the human to generate a fresh code in the board Settings or onboarding wizard.",
   };
-  if (!isValidPairingCodeFormat(rawCode.trim())) return notFound;
+  if (!isValidPairingCodeFormat(rawCode.trim())) {
+    await recordFailure(db);
+    return notFound;
+  }
 
-  return db.transaction(async (tx) => {
+  const result: ExchangeResult = await db.transaction(async (tx) => {
     // Consume atomically: the update only wins while consumed_at is null,
     // so a second exchange with the same code loses even in a race.
     const [consumed] = await tx
@@ -110,6 +177,10 @@ export async function exchangePairingCode(
 
     return { ok: true, token: secret, label: consumed.label };
   });
+
+  if (result.ok) await clearFailures(db);
+  else await recordFailure(db);
+  return result;
 }
 
 /** Wizard polling: paired once the code was exchanged. */

--- a/apps/web/src/mcp/pairing.integration.test.ts
+++ b/apps/web/src/mcp/pairing.integration.test.ts
@@ -4,6 +4,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import {
   createPairingCode,
   exchangePairingCode,
+  MAX_PAIRING_FAILURES,
   pairingStatus,
 } from "../lib/pairing";
 import { authenticateBearer } from "./auth";
@@ -14,6 +15,50 @@ describe("one-time token pairing", () => {
 
   afterEach(async () => {
     if (world) await closeTestWorld(world);
+  });
+
+
+  it("burns the live code once the guessing budget is gone", async () => {
+    world = await createTestWorld();
+    const created = await createPairingCode(world.db, {
+      workspaceId: world.workspaceId,
+      label: "paired via code",
+    });
+
+    // Wrong guesses, all at once. Sequential attempts were never the threat:
+    // the failure path costs a flat delay each, paid in parallel, so a caller
+    // with connections to spare was bounded by its own concurrency and not by
+    // the delay. A budget is what a hundred parallel guesses cannot outrun.
+    const wrong = Array.from({ length: MAX_PAIRING_FAILURES }, (_, i) =>
+      String(i).padStart(6, "9"),
+    ).filter((code) => code !== created.code);
+    await Promise.all(wrong.map((code) => exchangePairingCode(world.db, code)));
+
+    // The real code is gone: the humans generate another one, the guesser
+    // goes back to a fresh million.
+    const withTheRealCode = await exchangePairingCode(world.db, created.code);
+    expect(withTheRealCode.ok).toBe(false);
+
+    const [row] = await world.db
+      .select()
+      .from(pairingCode)
+      .where(eq(pairingCode.id, created.id));
+    expect(row).toBeUndefined();
+  });
+
+  it("does not punish a human who mistypes once and then gets it right", async () => {
+    world = await createTestWorld();
+    const created = await createPairingCode(world.db, {
+      workspaceId: world.workspaceId,
+      label: "paired via code",
+    });
+
+    const typo = created.code === "000000" ? "111111" : "000000";
+    const missed = await exchangePairingCode(world.db, typo);
+    expect(missed.ok).toBe(false);
+
+    const second = await exchangePairingCode(world.db, created.code);
+    expect(second.ok).toBe(true);
   });
 
   it("exchanges a 6-digit code for a working bearer token, once", async () => {

--- a/apps/web/src/mcp/pairing.integration.test.ts
+++ b/apps/web/src/mcp/pairing.integration.test.ts
@@ -1,4 +1,4 @@
-import { pairingCode } from "@agent-board/db";
+import { mcpToken, pairingCode, workspace } from "@agent-board/db";
 import { eq } from "drizzle-orm";
 import { afterEach, describe, expect, it } from "vitest";
 import {
@@ -10,6 +10,20 @@ import {
 import { authenticateBearer } from "./auth";
 import { closeTestWorld, createTestWorld, type TestWorld } from "./test-db";
 
+/** Two callers the endpoint can tell apart, as a proxy in front would. */
+const GUESSER = "203.0.113.9";
+const AGENT = "198.51.100.4";
+
+/** Well-formed codes that are not any of the live ones. */
+function wrongGuesses(count: number, real: string[]): string[] {
+  const out: string[] = [];
+  for (let i = 0; out.length < count; i++) {
+    const code = String(i % 1_000_000).padStart(6, "0");
+    if (!real.includes(code)) out.push(code);
+  }
+  return out;
+}
+
 describe("one-time token pairing", () => {
   let world: TestWorld;
 
@@ -17,8 +31,7 @@ describe("one-time token pairing", () => {
     if (world) await closeTestWorld(world);
   });
 
-
-  it("burns the live code once the guessing budget is gone", async () => {
+  it("stops looking at codes once the budget is spent, instead of consuming them", async () => {
     world = await createTestWorld();
     const created = await createPairingCode(world.db, {
       workspaceId: world.workspaceId,
@@ -29,22 +42,70 @@ describe("one-time token pairing", () => {
     // the failure path costs a flat delay each, paid in parallel, so a caller
     // with connections to spare was bounded by its own concurrency and not by
     // the delay. A budget is what a hundred parallel guesses cannot outrun.
-    const wrong = Array.from({ length: MAX_PAIRING_FAILURES }, (_, i) =>
-      String(i).padStart(6, "9"),
-    ).filter((code) => code !== created.code);
-    await Promise.all(wrong.map((code) => exchangePairingCode(world.db, code)));
+    const wrong = wrongGuesses(MAX_PAIRING_FAILURES, [created.code]);
+    await Promise.all(
+      wrong.map((code) => exchangePairingCode(world.db, code, GUESSER)),
+    );
 
-    // The real code is gone: the humans generate another one, the guesser
-    // goes back to a fresh million.
-    const withTheRealCode = await exchangePairingCode(world.db, created.code);
-    expect(withTheRealCode.ok).toBe(false);
+    // Now the right code, from the caller that spent the budget. It loses,
+    // and the interesting part is how: the row is untouched. A budget read
+    // after the exchange would have consumed the code before noticing, and
+    // burning the live codes on the way out would have deleted it.
+    const buried = await exchangePairingCode(world.db, created.code, GUESSER);
+    expect(buried.ok).toBe(false);
 
     const [row] = await world.db
       .select()
       .from(pairingCode)
       .where(eq(pairingCode.id, created.id));
-    expect(row).toBeUndefined();
+    expect(row).toBeDefined();
+    expect(row?.consumedAt).toBeNull();
+    expect(row?.secret).not.toBe("");
+
+    // The same code, from the agent the human is actually pairing, works
+    // right now: the budget belongs to whoever spent it.
+    const honest = await exchangePairingCode(world.db, created.code, AGENT);
+    expect(honest.ok).toBe(true);
   });
+
+  it.each([50, 200, 1000])(
+    "buries the real code at the end of a %i-guess burst and never evaluates it",
+    async (burst) => {
+      world = await createTestWorld();
+      const created = await createPairingCode(world.db, {
+        workspaceId: world.workspaceId,
+        label: "paired via code",
+      });
+
+      // The real code goes last, which is exactly where a budget counted
+      // after the exchange still lets it through: by then the guesser has
+      // spent many times the budget, so the only thing that saves the code
+      // is refusing to look at it.
+      const codes = [
+        ...wrongGuesses(burst - 1, [created.code]),
+        created.code,
+      ];
+      const results = await Promise.all(
+        codes.map((code) => exchangePairingCode(world.db, code, GUESSER)),
+      );
+      expect(results.some((result) => result.ok)).toBe(false);
+
+      const [row] = await world.db
+        .select()
+        .from(pairingCode)
+        .where(eq(pairingCode.id, created.id));
+      expect(row?.consumedAt).toBeNull();
+
+      // Nothing was minted either: no token carries the label the code
+      // would have handed out.
+      const minted = await world.db
+        .select()
+        .from(mcpToken)
+        .where(eq(mcpToken.label, "paired via code"));
+      expect(minted).toHaveLength(0);
+    },
+    60_000,
+  );
 
   it("does not punish a human who mistypes once and then gets it right", async () => {
     world = await createTestWorld();
@@ -54,11 +115,76 @@ describe("one-time token pairing", () => {
     });
 
     const typo = created.code === "000000" ? "111111" : "000000";
-    const missed = await exchangePairingCode(world.db, typo);
+    const missed = await exchangePairingCode(world.db, typo, AGENT);
     expect(missed.ok).toBe(false);
 
-    const second = await exchangePairingCode(world.db, created.code);
+    const second = await exchangePairingCode(world.db, created.code, AGENT);
     expect(second.ok).toBe(true);
+  });
+
+  it("keeps a burst against one code away from another workspace's", async () => {
+    world = await createTestWorld();
+    const [neighbour] = await world.db
+      .insert(workspace)
+      .values({ name: "Neighbour" })
+      .returning({ id: workspace.id });
+    if (!neighbour) throw new Error("failed to insert neighbour workspace");
+
+    const mine = await createPairingCode(world.db, {
+      workspaceId: world.workspaceId,
+      label: "mine",
+    });
+    const theirs = await createPairingCode(world.db, {
+      workspaceId: neighbour.id,
+      label: "theirs",
+    });
+
+    const wrong = wrongGuesses(MAX_PAIRING_FAILURES * 20, [
+      mine.code,
+      theirs.code,
+    ]);
+    await Promise.all(
+      wrong.map((code) => exchangePairingCode(world.db, code, GUESSER)),
+    );
+
+    // Both codes are still there. Burning every unconsumed code once the
+    // budget ran out made ten anonymous requests enough to take out the
+    // pairing of a workspace the guesser had never heard of.
+    const live = await world.db.select().from(pairingCode);
+    expect(live).toHaveLength(2);
+
+    // And the neighbour pairs while the burst is still charged to the
+    // caller that made it.
+    const paired = await exchangePairingCode(world.db, theirs.code, AGENT);
+    expect(paired.ok).toBe(true);
+  });
+
+  it("lets the human reopen pairing a guesser drained when no origin is known", async () => {
+    world = await createTestWorld();
+    const created = await createPairingCode(world.db, {
+      workspaceId: world.workspaceId,
+      label: "paired via code",
+    });
+
+    // No proxy in front, so nobody can be told apart and everyone shares
+    // one bucket. A burst still drains it, and still destroys nothing.
+    const wrong = wrongGuesses(MAX_PAIRING_FAILURES * 5, [created.code]);
+    await Promise.all(
+      wrong.map((code) => exchangePairingCode(world.db, code)),
+    );
+    const refused = await exchangePairingCode(world.db, created.code);
+    expect(refused.ok).toBe(false);
+
+    // The way out is the human, not the clock: generating a code is a
+    // signed-in action no guesser can reach, and it clears the budget. What
+    // that costs is bounded — a budget's worth of guesses against a brand
+    // new number out of a million.
+    const fresh = await createPairingCode(world.db, {
+      workspaceId: world.workspaceId,
+      label: "paired via code",
+    });
+    const paired = await exchangePairingCode(world.db, fresh.code);
+    expect(paired.ok).toBe(true);
   });
 
   it("exchanges a 6-digit code for a working bearer token, once", async () => {

--- a/deploy/docker-compose.cloud.yml
+++ b/deploy/docker-compose.cloud.yml
@@ -39,6 +39,14 @@ services:
       # they show ./deploy/deploy.sh, never the quickstart's raw compose
       # command (that mismatch is what took the board down in OCL-43).
       OVERCLICK_DEPLOY_MODE: hosted
+      # GHSA-hccf: the pairing endpoint charges guesses to the caller's
+      # origin, and the only way it learns one is from the proxy in front.
+      # Set here because every hosted deploy has one; it requires a proxy
+      # that APPENDS the peer to x-forwarded-for (traefik, nginx's
+      # $proxy_add_x_forwarded_for, caddy all do) rather than passing a
+      # client-supplied header through. Never set it on an instance that
+      # takes connections directly: the caller would be naming itself.
+      OVERCLICK_TRUSTED_PROXY: "1"
     volumes:
       - update-trigger:/update-trigger
     # Bound to loopback: the reverse proxy is the only way in from outside.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,14 @@ services:
       # OCL-73: tells the update banner/panel which command to show. Never
       # "hosted" here — that value is reserved for deploy/docker-compose.cloud.yml.
       OVERCLICK_DEPLOY_MODE: quickstart
+      # GHSA-hccf: the pairing endpoint charges wrong guesses to the origin
+      # they came from, and the only way it learns one is from a proxy that
+      # APPENDS the peer to x-forwarded-for. Off here because this file
+      # publishes port 3000 directly, and a caller that reaches the app
+      # itself would just be naming itself. Turn it on only when something
+      # of yours sits in front:
+      #   OVERCLICK_TRUSTED_PROXY=1 docker compose up
+      OVERCLICK_TRUSTED_PROXY: "${OVERCLICK_TRUSTED_PROXY:-0}"
     volumes:
       - update-trigger:/update-trigger
     ports:

--- a/packages/db/drizzle/0035_pairing_failure.sql
+++ b/packages/db/drizzle/0035_pairing_failure.sql
@@ -1,0 +1,5 @@
+CREATE TABLE "pairing_failure" (
+	"id" text PRIMARY KEY NOT NULL,
+	"count" integer DEFAULT 0 NOT NULL,
+	"window_started_at" timestamp with time zone DEFAULT now() NOT NULL
+);

--- a/packages/db/drizzle/meta/0035_snapshot.json
+++ b/packages/db/drizzle/meta/0035_snapshot.json
@@ -1,0 +1,2597 @@
+{
+  "id": "6091e81c-6ad7-4a41-886b-561636886858",
+  "prevId": "836290f6-8141-44dc-957b-abeb975b5021",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.cardapio_entry": {
+      "name": "cardapio_entry",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_type": {
+          "name": "activity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cli": {
+          "name": "cli",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chain": {
+          "name": "chain",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effort": {
+          "name": "effort",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "cardapio_entry_workspace_idx": {
+          "name": "cardapio_entry_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cardapio_entry_workspace_id_workspace_id_fk": {
+          "name": "cardapio_entry_workspace_id_workspace_id_fk",
+          "tableFrom": "cardapio_entry",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cardapio_entry_workspace_type": {
+          "name": "cardapio_entry_workspace_type",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workspace_id",
+            "activity_type"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.execution_attempt": {
+      "name": "execution_attempt",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "executor": {
+          "name": "executor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_source": {
+          "name": "model_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transcript": {
+          "name": "transcript",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_segments": {
+          "name": "usage_segments",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens_in": {
+          "name": "tokens_in",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens_out": {
+          "name": "tokens_out",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens_cache": {
+          "name": "tokens_cache",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reported_cost_usd": {
+          "name": "reported_cost_usd",
+          "type": "numeric(12, 6)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "numeric(12, 6)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_source": {
+          "name": "cost_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_status": {
+          "name": "cost_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_unpriced_models": {
+          "name": "cost_unpriced_models",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_breakdown": {
+          "name": "cost_breakdown",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "server_duration_ms": {
+          "name": "server_duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "turns": {
+          "name": "turns",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_estimated": {
+          "name": "usage_estimated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "usage_suspect": {
+          "name": "usage_suspect",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "usage_suspect_reason": {
+          "name": "usage_suspect_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_unverified": {
+          "name": "delivery_unverified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "delivery_verification": {
+          "name": "delivery_verification",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_warning": {
+          "name": "delivery_warning",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result_note": {
+          "name": "result_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "execution_attempt_task_idx": {
+          "name": "execution_attempt_task_idx",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "execution_attempt_task_id_task_id_fk": {
+          "name": "execution_attempt_task_id_task_id_fk",
+          "tableFrom": "execution_attempt",
+          "tableTo": "task",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.handoff": {
+      "name": "handoff",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt_id": {
+          "name": "attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidences": {
+          "name": "evidences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "artifacts": {
+          "name": "artifacts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "how_to_verify": {
+          "name": "how_to_verify",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_url": {
+          "name": "pr_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_hash": {
+          "name": "commit_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_unverified": {
+          "name": "delivery_unverified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "delivery_verification": {
+          "name": "delivery_verification",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_warning": {
+          "name": "delivery_warning",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage": {
+          "name": "usage",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "handoff_task_idx": {
+          "name": "handoff_task_idx",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "handoff_task_id_task_id_fk": {
+          "name": "handoff_task_id_task_id_fk",
+          "tableFrom": "handoff",
+          "tableTo": "task",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "handoff_attempt_id_execution_attempt_id_fk": {
+          "name": "handoff_attempt_id_execution_attempt_id_fk",
+          "tableFrom": "handoff",
+          "tableTo": "execution_attempt",
+          "columnsFrom": [
+            "attempt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_token": {
+      "name": "mcp_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "can_manage": {
+          "name": "can_manage",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "revoked": {
+          "name": "revoked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mcp_token_hash_idx": {
+          "name": "mcp_token_hash_idx",
+          "columns": [
+            {
+              "expression": "hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_token_workspace_id_workspace_id_fk": {
+          "name": "mcp_token_workspace_id_workspace_id_fk",
+          "tableFrom": "mcp_token",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_token_created_by_user_id_user_id_fk": {
+          "name": "mcp_token_created_by_user_id_user_id_fk",
+          "tableFrom": "mcp_token",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mcp_token_workspace_label": {
+          "name": "mcp_token_workspace_label",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workspace_id",
+            "label"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mission": {
+      "name": "mission",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "objective": {
+          "name": "objective",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "context": {
+          "name": "context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "status": {
+          "name": "status",
+          "type": "mission_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ativa'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "mission_workspace_id_workspace_id_fk": {
+          "name": "mission_workspace_id_workspace_id_fk",
+          "tableFrom": "mission",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mission_attempt": {
+      "name": "mission_attempt",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "mission_id": {
+          "name": "mission_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "executor": {
+          "name": "executor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_source": {
+          "name": "model_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transcript": {
+          "name": "transcript",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "mission_attempt_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'aberto'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_segments": {
+          "name": "usage_segments",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens_in": {
+          "name": "tokens_in",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens_out": {
+          "name": "tokens_out",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens_cache": {
+          "name": "tokens_cache",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reported_cost_usd": {
+          "name": "reported_cost_usd",
+          "type": "numeric(12, 6)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "numeric(12, 6)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_source": {
+          "name": "cost_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_status": {
+          "name": "cost_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_unpriced_models": {
+          "name": "cost_unpriced_models",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_breakdown": {
+          "name": "cost_breakdown",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "server_duration_ms": {
+          "name": "server_duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "turns": {
+          "name": "turns",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_estimated": {
+          "name": "usage_estimated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "usage_suspect": {
+          "name": "usage_suspect",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "usage_suspect_reason": {
+          "name": "usage_suspect_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result_note": {
+          "name": "result_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_report_sequence": {
+          "name": "last_report_sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "mission_attempt_mission_idx": {
+          "name": "mission_attempt_mission_idx",
+          "columns": [
+            {
+              "expression": "mission_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mission_attempt_project_idx": {
+          "name": "mission_attempt_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mission_attempt_session_idx": {
+          "name": "mission_attempt_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mission_attempt_open_mission_uidx": {
+          "name": "mission_attempt_open_mission_uidx",
+          "columns": [
+            {
+              "expression": "mission_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"mission_attempt\".\"status\" = 'aberto'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mission_attempt_mission_id_mission_id_fk": {
+          "name": "mission_attempt_mission_id_mission_id_fk",
+          "tableFrom": "mission_attempt",
+          "tableTo": "mission",
+          "columnsFrom": [
+            "mission_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mission_attempt_project_id_project_id_fk": {
+          "name": "mission_attempt_project_id_project_id_fk",
+          "tableFrom": "mission_attempt",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "mission_attempt_status_finished_ck": {
+          "name": "mission_attempt_status_finished_ck",
+          "value": "(\"mission_attempt\".\"status\" = 'aberto' AND \"mission_attempt\".\"finished_at\" IS NULL) OR (\"mission_attempt\".\"status\" <> 'aberto' AND \"mission_attempt\".\"finished_at\" IS NOT NULL)"
+        },
+        "mission_attempt_suspect_reason_ck": {
+          "name": "mission_attempt_suspect_reason_ck",
+          "value": "\"mission_attempt\".\"usage_suspect\" = false OR \"mission_attempt\".\"usage_suspect_reason\" IS NOT NULL"
+        },
+        "mission_attempt_last_report_sequence_ck": {
+          "name": "mission_attempt_last_report_sequence_ck",
+          "value": "\"mission_attempt\".\"last_report_sequence\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.mission_attempt_report": {
+      "name": "mission_attempt_report",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "mission_attempt_id": {
+          "name": "mission_attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "checkpoint": {
+          "name": "checkpoint",
+          "type": "mission_attempt_checkpoint",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'rodada'"
+        },
+        "usage_segments": {
+          "name": "usage_segments",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens_in": {
+          "name": "tokens_in",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens_out": {
+          "name": "tokens_out",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens_cache": {
+          "name": "tokens_cache",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "turns": {
+          "name": "turns",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estimated": {
+          "name": "estimated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "result": {
+          "name": "result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result_note": {
+          "name": "result_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "mission_attempt_report_attempt_idx": {
+          "name": "mission_attempt_report_attempt_idx",
+          "columns": [
+            {
+              "expression": "mission_attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mission_attempt_report_mission_attempt_id_mission_attempt_id_fk": {
+          "name": "mission_attempt_report_mission_attempt_id_mission_attempt_id_fk",
+          "tableFrom": "mission_attempt_report",
+          "tableTo": "mission_attempt",
+          "columnsFrom": [
+            "mission_attempt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mission_attempt_report_attempt_sequence_uq": {
+          "name": "mission_attempt_report_attempt_sequence_uq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "mission_attempt_id",
+            "sequence"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "mission_attempt_report_sequence_ck": {
+          "name": "mission_attempt_report_sequence_ck",
+          "value": "\"mission_attempt_report\".\"sequence\" > 0"
+        },
+        "mission_attempt_report_final_result_ck": {
+          "name": "mission_attempt_report_final_result_ck",
+          "value": "\"mission_attempt_report\".\"checkpoint\" = 'final' OR (\"mission_attempt_report\".\"result\" IS NULL AND \"mission_attempt_report\".\"result_note\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.model_price": {
+      "name": "model_price",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_per_mtok": {
+          "name": "input_per_mtok",
+          "type": "numeric(12, 6)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_per_mtok": {
+          "name": "output_per_mtok",
+          "type": "numeric(12, 6)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cache_per_mtok": {
+          "name": "cache_per_mtok",
+          "type": "numeric(12, 6)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seeded_at": {
+          "name": "seeded_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "model_price_workspace_idx": {
+          "name": "model_price_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "model_price_workspace_id_workspace_id_fk": {
+          "name": "model_price_workspace_id_workspace_id_fk",
+          "tableFrom": "model_price",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "model_price_workspace_model": {
+          "name": "model_price_workspace_model",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workspace_id",
+            "model"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pairing_code": {
+      "name": "pairing_code",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_hash": {
+          "name": "code_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_id": {
+          "name": "token_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pairing_code_workspace_id_workspace_id_fk": {
+          "name": "pairing_code_workspace_id_workspace_id_fk",
+          "tableFrom": "pairing_code",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pairing_code_created_by_user_id_user_id_fk": {
+          "name": "pairing_code_created_by_user_id_user_id_fk",
+          "tableFrom": "pairing_code",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "pairing_code_token_id_mcp_token_id_fk": {
+          "name": "pairing_code_token_id_mcp_token_id_fk",
+          "tableFrom": "pairing_code",
+          "tableTo": "mcp_token",
+          "columnsFrom": [
+            "token_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pairing_failure": {
+      "name": "pairing_failure",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "window_started_at": {
+          "name": "window_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project": {
+      "name": "project",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_url": {
+          "name": "repo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context": {
+          "name": "context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_version": {
+          "name": "current_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_source": {
+          "name": "context_source",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latest_prerelease": {
+          "name": "latest_prerelease",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_updated_at": {
+          "name": "context_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_prefix": {
+          "name": "id_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "next_number": {
+          "name": "next_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "project_workspace_id_workspace_id_fk": {
+          "name": "project_workspace_id_workspace_id_fk",
+          "tableFrom": "project",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_workspace_prefix": {
+          "name": "project_workspace_prefix",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workspace_id",
+            "id_prefix"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_context_audit": {
+      "name": "project_context_audit",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_ref": {
+          "name": "source_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prerelease": {
+          "name": "prerelease",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_context_audit_project_idx": {
+          "name": "project_context_audit_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_context_audit_project_id_project_id_fk": {
+          "name": "project_context_audit_project_id_project_id_fk",
+          "tableFrom": "project_context_audit",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_context_audit_source_ref": {
+          "name": "project_context_audit_source_ref",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "source",
+            "source_ref"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task": {
+      "name": "task",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mission_id": {
+          "name": "mission_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supersedes_id": {
+          "name": "supersedes_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "superseded_by_id": {
+          "name": "superseded_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "short_id": {
+          "name": "short_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_short_ids": {
+          "name": "previous_short_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "o_que": {
+          "name": "o_que",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "por_que": {
+          "name": "por_que",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "como_confirmo": {
+          "name": "como_confirmo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "tipo": {
+          "name": "tipo",
+          "type": "task_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'feature'"
+        },
+        "status": {
+          "name": "status",
+          "type": "task_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'aberto'"
+        },
+        "revisado": {
+          "name": "revisado",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "task_priority",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'media'"
+        },
+        "devolve_para_kind": {
+          "name": "devolve_para_kind",
+          "type": "reviewer_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'workspace_queue'"
+        },
+        "devolve_para_user_id": {
+          "name": "devolve_para_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "devolve_para_agent_ref": {
+          "name": "devolve_para_agent_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "harness": {
+          "name": "harness",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_url": {
+          "name": "pr_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_hash": {
+          "name": "commit_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_unverified": {
+          "name": "delivery_unverified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "delivery_verification": {
+          "name": "delivery_verification",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_warning": {
+          "name": "delivery_warning",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_in": {
+          "name": "resolved_in",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin": {
+          "name": "origin",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "execution_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'solo'"
+        },
+        "telemetry_incomplete": {
+          "name": "telemetry_incomplete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "validation_ticks": {
+          "name": "validation_ticks",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "is_example": {
+          "name": "is_example",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_by_executor": {
+          "name": "claimed_by_executor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_by_token_id": {
+          "name": "claimed_by_token_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "task_project_idx": {
+          "name": "task_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_status_idx": {
+          "name": "task_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_parent_idx": {
+          "name": "task_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_supersedes_idx": {
+          "name": "task_supersedes_idx",
+          "columns": [
+            {
+              "expression": "supersedes_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_superseded_by_idx": {
+          "name": "task_superseded_by_idx",
+          "columns": [
+            {
+              "expression": "superseded_by_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "task_project_id_project_id_fk": {
+          "name": "task_project_id_project_id_fk",
+          "tableFrom": "task",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "task_mission_id_mission_id_fk": {
+          "name": "task_mission_id_mission_id_fk",
+          "tableFrom": "task",
+          "tableTo": "mission",
+          "columnsFrom": [
+            "mission_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "task_parent_id_task_id_fk": {
+          "name": "task_parent_id_task_id_fk",
+          "tableFrom": "task",
+          "tableTo": "task",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "task_supersedes_id_task_id_fk": {
+          "name": "task_supersedes_id_task_id_fk",
+          "tableFrom": "task",
+          "tableTo": "task",
+          "columnsFrom": [
+            "supersedes_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "task_superseded_by_id_task_id_fk": {
+          "name": "task_superseded_by_id_task_id_fk",
+          "tableFrom": "task",
+          "tableTo": "task",
+          "columnsFrom": [
+            "superseded_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "task_devolve_para_user_id_user_id_fk": {
+          "name": "task_devolve_para_user_id_user_id_fk",
+          "tableFrom": "task",
+          "tableTo": "user",
+          "columnsFrom": [
+            "devolve_para_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "task_claimed_by_token_id_mcp_token_id_fk": {
+          "name": "task_claimed_by_token_id_mcp_token_id_fk",
+          "tableFrom": "task",
+          "tableTo": "mcp_token",
+          "columnsFrom": [
+            "claimed_by_token_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "task_created_by_user_id_user_id_fk": {
+          "name": "task_created_by_user_id_user_id_fk",
+          "tableFrom": "task",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "task_short_id_unique": {
+          "name": "task_short_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "short_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_comment": {
+      "name": "task_comment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_user_id": {
+          "name": "author_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_agent_ref": {
+          "name": "author_agent_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'comment'"
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "task_comment_task_id_task_id_fk": {
+          "name": "task_comment_task_id_task_id_fk",
+          "tableFrom": "task_comment",
+          "tableTo": "task",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "task_comment_author_user_id_user_id_fk": {
+          "name": "task_comment_author_user_id_user_id_fk",
+          "tableFrom": "task_comment",
+          "tableTo": "user",
+          "columnsFrom": [
+            "author_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.usage_recipe": {
+      "name": "usage_recipe",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cli": {
+          "name": "cli",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "yields": {
+          "name": "yields",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "command": {
+          "name": "command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "usage_recipe_workspace_idx": {
+          "name": "usage_recipe_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "usage_recipe_workspace_id_workspace_id_fk": {
+          "name": "usage_recipe_workspace_id_workspace_id_fk",
+          "tableFrom": "usage_recipe",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "usage_recipe_workspace_cli": {
+          "name": "usage_recipe_workspace_cli",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workspace_id",
+            "cli"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "session_version": {
+          "name": "session_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "board_project_id": {
+          "name": "board_project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "board_mission_id": {
+          "name": "board_mission_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "board_task_types": {
+          "name": "board_task_types",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "board_priorities": {
+          "name": "board_priorities",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "board_resolved_in": {
+          "name": "board_resolved_in",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace": {
+      "name": "workspace",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'en'"
+        },
+        "update_mode": {
+          "name": "update_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'off'"
+        },
+        "update_log": {
+          "name": "update_log",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_token": {
+          "name": "github_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pricing_enabled": {
+          "name": "pricing_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "claim_timeout_minutes": {
+          "name": "claim_timeout_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 60
+        },
+        "executors": {
+          "name": "executors",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[{\"id\":\"overclock\",\"label\":\"Overclock\",\"enabled\":false,\"models\":[]},{\"id\":\"claude-code\",\"label\":\"Claude Code\",\"enabled\":false,\"models\":[]},{\"id\":\"codex\",\"label\":\"Codex\",\"enabled\":false,\"models\":[]},{\"id\":\"gemini-cli\",\"label\":\"Gemini CLI\",\"enabled\":false,\"models\":[]},{\"id\":\"cursor\",\"label\":\"Cursor\",\"enabled\":false,\"models\":[]},{\"id\":\"aider\",\"label\":\"Aider\",\"enabled\":false,\"models\":[]},{\"id\":\"generic-mcp\",\"label\":\"Other (generic MCP)\",\"enabled\":false,\"models\":[]}]'::jsonb"
+        },
+        "seen_executors": {
+          "name": "seen_executors",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "cardapio": {
+          "name": "cardapio",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"bug\":{\"model\":null,\"modelTier\":\"mid\",\"effort\":\"medium\"},\"feature\":{\"model\":null,\"modelTier\":\"mid\",\"effort\":\"medium\"},\"rfc\":{\"model\":null,\"modelTier\":\"top\",\"effort\":\"high\"}}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.execution_mode": {
+      "name": "execution_mode",
+      "schema": "public",
+      "values": [
+        "solo",
+        "team"
+      ]
+    },
+    "public.mission_attempt_checkpoint": {
+      "name": "mission_attempt_checkpoint",
+      "schema": "public",
+      "values": [
+        "rodada",
+        "final"
+      ]
+    },
+    "public.mission_attempt_status": {
+      "name": "mission_attempt_status",
+      "schema": "public",
+      "values": [
+        "aberto",
+        "sucesso",
+        "abandonado"
+      ]
+    },
+    "public.mission_status": {
+      "name": "mission_status",
+      "schema": "public",
+      "values": [
+        "ativa",
+        "pausada",
+        "concluida"
+      ]
+    },
+    "public.reviewer_kind": {
+      "name": "reviewer_kind",
+      "schema": "public",
+      "values": [
+        "human",
+        "agent",
+        "workspace_queue"
+      ]
+    },
+    "public.task_priority": {
+      "name": "task_priority",
+      "schema": "public",
+      "values": [
+        "urgente",
+        "alta",
+        "media",
+        "baixa"
+      ]
+    },
+    "public.task_status": {
+      "name": "task_status",
+      "schema": "public",
+      "values": [
+        "aberto",
+        "em_execucao",
+        "feito",
+        "validado",
+        "descartado"
+      ]
+    },
+    "public.task_type": {
+      "name": "task_type",
+      "schema": "public",
+      "values": [
+        "feature",
+        "bug",
+        "rfc"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -246,6 +246,13 @@
       "when": 1787149318841,
       "tag": "0034_project_context_sources",
       "breakpoints": true
+    },
+    {
+      "idx": 35,
+      "version": "7",
+      "when": 1787149319841,
+      "tag": "0035_pairing_failure",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -250,7 +250,7 @@
     {
       "idx": 35,
       "version": "7",
-      "when": 1787149319841,
+      "when": 1787234604449,
       "tag": "0035_pairing_failure",
       "breakpoints": true
     }

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -21,6 +21,7 @@ export { executionAttempt } from "./execution-attempt";
 export { handoff } from "./handoff";
 export { mcpToken } from "./mcp-token";
 export { pairingCode } from "./pairing-code";
+export { pairingFailure } from "./pairing-failure";
 export { cardapioEntry } from "./cardapio-entry";
 export { modelPrice } from "./model-price";
 export { usageRecipe } from "./usage-recipe";

--- a/packages/db/src/schema/pairing-failure.ts
+++ b/packages/db/src/schema/pairing-failure.ts
@@ -1,15 +1,17 @@
 import { integer, pgTable, text, timestamp } from "drizzle-orm/pg-core";
 
 /**
- * Failed pairing exchanges, counted for the whole instance.
+ * Attempts spent against the public pairing endpoint, counted per scope.
  *
  * A wrong guess matches no row, because the lookup is by hash, so there is
  * no code to attribute the attempt to and the counter has to live outside
- * the codes. One row is enough: only one code is live per workspace, and
- * the question being asked is whether somebody is guessing at all.
+ * the codes. What it can be attributed to is where it came from, which is
+ * why the key is a scope string and not a fixed one: a single instance-wide
+ * counter would let ten anonymous requests freeze the pairing of every
+ * workspace at once.
  */
 export const pairingFailure = pgTable("pairing_failure", {
-  /** Fixed key. This table holds exactly one row. */
+  /** The scope the attempts are charged to, e.g. `origin:203.0.113.7`. */
   id: text("id").primaryKey(),
   count: integer("count").notNull().default(0),
   windowStartedAt: timestamp("window_started_at", { withTimezone: true })

--- a/packages/db/src/schema/pairing-failure.ts
+++ b/packages/db/src/schema/pairing-failure.ts
@@ -1,0 +1,18 @@
+import { integer, pgTable, text, timestamp } from "drizzle-orm/pg-core";
+
+/**
+ * Failed pairing exchanges, counted for the whole instance.
+ *
+ * A wrong guess matches no row, because the lookup is by hash, so there is
+ * no code to attribute the attempt to and the counter has to live outside
+ * the codes. One row is enough: only one code is live per workspace, and
+ * the question being asked is whether somebody is guessing at all.
+ */
+export const pairingFailure = pgTable("pairing_failure", {
+  /** Fixed key. This table holds exactly one row. */
+  id: text("id").primaryKey(),
+  count: integer("count").notNull().default(0),
+  windowStartedAt: timestamp("window_started_at", { withTimezone: true })
+    .notNull()
+    .defaultNow(),
+});


### PR DESCRIPTION
Closes the brute force on `POST /api/pair` reported privately as **GHSA-hccf-43jq-44w5** by @EduardoxDev.

This **extends #19**, it does not replace it. The first commit here is @EduardoxDev's, cherry-picked with authorship intact: the diagnosis, the `pairing_failure` table, the migration and the atomic upsert are all his and all still here. The second commit fixes the two things that kept the hole open.

## What #19 got right

The delay was never a defence. It is awaited per request, so nothing serialises: concurrent guesses wait in parallel and the ceiling is the caller's connection count, not the delay. Six digits, ten minutes, and a real bearer token on the other side. Counting the attempts instead of slowing them is the right move, and the single-statement upsert is the right way to count them.

## What was still open

**1. The budget was counted after the exchange, not before it.** `recordFailure` runs once `exchangePairingCode` has already hashed the guess, matched it and consumed the row. So a burst of a thousand guesses has all thousand evaluated — the accounting only decides what happens *afterwards*. If the thousandth guess is the code, the attacker has the token already, and burning the codes after that burns nothing that matters.

**2. The key was `"global"`, one row for the whole instance.** Draining it deleted every unconsumed pairing code on the box. Ten anonymous requests, no auth, and a workspace that had never heard of the guesser loses the code it was in the middle of using. The remedy was a denial of service any stranger could trigger.

## What this adds

**The budget becomes a gate.** `spendAttempt` charges the attempt and returns the new count from the same statement that wrote it — still one upsert, since concurrency was the whole weakness — and the exchange refuses on the spot once the count is past the budget. Past it the code is never hashed and never compared. The thousandth guess cannot win even when it happens to be right.

**The budget is scoped to who spent it.** The key is the origin the deployment can honestly name: the last hop of `x-forwarded-for`, and only where the deploy declares a proxy in front (`OVERCLICK_TRUSTED_PROXY=1`, set in the hosted compose, off in the quickstart that publishes 3000 directly). On a directly exposed instance that header is written by the caller, so trusting it would hand a guesser a fresh budget per request — worse than no scope at all. Undeclared, everyone shares one bucket.

**Nothing is deleted anymore.** A burst against one code cannot reach another. What reopens a bucket a guesser drained is the human: `createPairingCode` clears the budget, which is a signed-in action no guesser can reach. That bounds the exposure at a budget's worth of evaluated guesses per origin against a brand new number out of a million.

The flat delay stays, and now earns its keep: paying it on every refusal is what keeps "wrong code" and "no budget left to look" indistinguishable.

## Tests

- **Bursts of 50, 200 and 1000 concurrent guesses** with the real code buried at the *end* — the exact position where a budget counted after the exchange still lets it through. No guess wins, the row is neither consumed nor deleted, no token is minted.
- **A human who mistypes once** still pairs on the second try.
- **A burst charged to one origin** leaves a second workspace's code alive, and that workspace pairs while the burst is still counted against the guesser.
- **The shared-bucket case** (no proxy declared) is reopened by the human generating a code.

Verified by mutation, not just by passing:

| mutation | result |
|---|---|
| gate moved back after the exchange (#19's ordering) | all 4 burst tests fail — the buried code wins |
| key back to a single `"global"` bucket | the cross-workspace test fails |

`pnpm test` 717 passed (53 + 15 + 5 files), `pnpm typecheck` clean.

## Migration

Unchanged: `pnpm db:generate` emits `0035_pairing_failure.sql` byte for byte identical to the hand-written one in #19. It is generated now rather than hand-written because `packages/db/drizzle/meta/0034_snapshot.json` is no longer empty on main, so 0035 gets its snapshot and the meta chain is whole again. 0035 is still free — main ends at 0034. The whole folder applies through its journal (36 migrations, `pairing_failure` created), and the suite replays it on every test world.

---

Thanks @EduardoxDev — the report and the patch are what made this findable and fixable. #19 is closed in favour of this one, which carries your commit.