### PR TITLE
[OCL-105] plugin: stop shipping a stale version to the Grok catalog

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "overclick",
       "description": "Claim, execute, and deliver OverClick cards.",
-      "version": "0.1.12",
+      "version": "0.2.1",
       "source": {
         "type": "local",
         "path": "./plugin"

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "overclick",
-  "version": "0.1.12",
+  "version": "0.2.1",
   "description": "Run the complete OverClick card workflow from Claude Code.",
   "author": {
     "name": "OverClick"

--- a/plugin/.codex-plugin/plugin.json
+++ b/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "overclick",
-  "version": "0.1.12",
+  "version": "0.2.1",
   "description": "Run the complete OverClick card workflow from Codex.",
   "author": {
     "name": "OverClick"

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -1,0 +1,84 @@
+# overclick
+
+Claim, execute, and deliver [OverClick](https://github.com/ustoppble/overclick) cards from
+your CLI. OverClick is an MIT-licensed, self-hosted task board for hybrid human + AI-agent
+teams: humans write the contract and validate, agents claim the card, do the work, and
+report back with evidence and per-model telemetry.
+
+This plugin carries the *discipline* of that board — the workflow rules, the slash
+commands, the guards — so an agent that installs it already knows how to behave on a card.
+
+## Install
+
+### Grok
+
+```bash
+grok plugin marketplace add ustoppble/overclick
+grok plugin install overclick
+```
+
+Or install straight from the repo, without registering the marketplace — the plugin lives
+in the `plugin/` subdirectory:
+
+```bash
+grok plugin install 'ustoppble/overclick#plugin'
+```
+
+Then point it at your own board:
+
+```bash
+grok mcp add --transport http --scope user \
+  --header "Authorization: Bearer <your-token>" \
+  overclick https://<your-instance>/mcp
+```
+
+Verify with `grok plugin details overclick` and `grok inspect` — the latter lists the
+`overclick` skill, the five slash commands, the hooks, and the MCP server.
+
+### Every CLI at once
+
+The board's instance serves an installer that detects which CLIs you have and drives each
+one's *native* plugin manager (Claude Code, Codex, Grok, Kimi). See the repository
+[README](https://github.com/ustoppble/overclick).
+
+## What it ships
+
+| Component | What it does |
+|---|---|
+| `skills/overclick` | The workflow: how to read a card contract, claim it, deliver it with measured usage |
+| `commands/` | `/board`, `/card`, `/claim`, `/deliver`, `/release` |
+| `hooks/hooks.json` | Board snapshot at session start; claim-marker bookkeeping; a delivery commit check; opt-in guards |
+| `.mcp.json` | The `overclick` MCP server, read from `${OVERCLICK_URL}` / `${OVERCLICK_TOKEN}` |
+| `OVERCLICK.md` | The canonical rules the skill and commands both defer to |
+
+## Network endpoints and credentials
+
+The plugin talks to **exactly one endpoint: your own OverClick instance**, whose URL you
+supply. There is no vendor endpoint, no analytics, no telemetry, and no phone-home — the
+plugin ships no hostname of ours at all.
+
+- **Credential:** a bearer token for your instance. The installer writes it to
+  `${XDG_CONFIG_HOME:-~/.config}/overclick/config` with mode `600`, or you pass it to your
+  CLI's own MCP config. It is never committed, never printed, and never leaves your machine
+  except as the `Authorization` header on requests to your instance.
+- **Hook traffic:** `session-start.sh` reads your current cards, and the enforcement guards
+  ask the board whether you hold a claim. Both hit the same instance URL.
+
+## Hooks and least privilege
+
+Two hooks are on by default and are read-only with respect to your repo: the session-start
+board snapshot, and the `PostToolUse` bookkeeping that records or clears the local claim
+marker after `task_claim` / `task_deliver` / `task_release`.
+
+The **enforcement** guards are opt-in and ship disabled (`enforce_claim=0`,
+`enforce_stop=0`, `enforce_harness=0` in the config file). `claim-guard.sh` is the one
+matched on `Edit|Write|Bash`: with `enforce_claim=0` it exits silently without inspecting
+anything, and only when you deliberately turn it on does it block a write that has no
+claimed card behind it. Turning it on is a choice you make about your own workflow.
+
+No hook downloads or executes remote content. They are plain POSIX shell, readable in
+`hooks/`, and they use `jq`, `python3`, or `node` — whichever your machine already has.
+
+## License
+
+[MIT](https://github.com/ustoppble/overclick/blob/main/LICENSE).

--- a/plugin/kimi.plugin.json
+++ b/plugin/kimi.plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "overclick",
-  "version": "0.1.12",
+  "version": "0.2.1",
   "description": "Run the complete OverClick card workflow from Kimi Code.",
   "keywords": ["overclick", "task-board", "mcp"],
   "author": {

--- a/scripts/test-plugin-package.sh
+++ b/scripts/test-plugin-package.sh
@@ -6,6 +6,22 @@ TEST_ROOT=$(mktemp -d)
 trap 'rm -rf -- "$TEST_ROOT"' EXIT
 FIXTURE_URL=$(printf '%s%s%s' 'https' '://' 'fixture')
 
+# Every plugin manifest ships the same version as package.json (OCL-105). The
+# release guard in verify-release-version.sh only covers the package.json set,
+# so the plugin manifests drifted to 0.1.12 while package.json was already at
+# 0.2.1 — and .grok-plugin/marketplace.json advertised that stale version to
+# every Grok user browsing the catalog.
+PKG_VERSION=$(jq -r '.version' "$REPO_ROOT/package.json")
+for manifest in plugin/plugin.json plugin/.claude-plugin/plugin.json \
+  plugin/.codex-plugin/plugin.json plugin/kimi.plugin.json; do
+  jq -e --arg v "$PKG_VERSION" '.version == $v' "$REPO_ROOT/$manifest" >/dev/null ||
+    { echo "$manifest is not at $PKG_VERSION" >&2; exit 1; }
+done
+for catalog in .grok-plugin/marketplace.json .claude-plugin/marketplace.json; do
+  jq -e --arg v "$PKG_VERSION" 'all(.plugins[]; .version == $v)' "$REPO_ROOT/$catalog" >/dev/null ||
+    { echo "$catalog is not at $PKG_VERSION" >&2; exit 1; }
+done
+
 jq -e '.skills and .mcpServers and (has("hooks") | not) and (has("commands") | not)' \
   "$REPO_ROOT/plugin/.codex-plugin/plugin.json" >/dev/null
 jq -e '.skills and .mcpServers and (.hooks | length == 6) and .commands' \


### PR DESCRIPTION
The Grok marketplace entry advertised `0.1.12` while the plugin it points at was already `0.2.1`. `verify-release-version.sh` only guards the `package.json` set, so the four plugin manifests drifted away from it unnoticed.

This is not cosmetic. Running xAI's own `generate-plugin-index.py` against `main` produces `"version": "0.1.12"` for OverClick — that stale number is what a Grok user would read in the official catalog before installing. Against this branch it produces `0.2.1`.

- Sync `plugin/.claude-plugin`, `plugin/.codex-plugin`, `plugin/kimi.plugin.json` and `.grok-plugin/marketplace.json` to `package.json`.
- Add the parity check to `scripts/test-plugin-package.sh`, where the drift would have been caught. Verified it fails on a reintroduced drift and passes once restored.
- Add `plugin/README.md`: the xAI marketplace review asks a submission to declare its network endpoints, its credentials, and why its hooks need the scope they ask for, and we had nowhere to say that the only endpoint is the user's own instance and that the `Edit|Write|Bash` guard ships disabled.

Verified hands-on with Grok 1.0.5: `grok plugin validate ./plugin` passes, and installing the branch commit materializes v0.2.1 with the skill, five commands, hooks and MCP server all loaded per `grok inspect`.

Card: OCL-105.

🤖 Generated with [Claude Code](https://claude.com/claude-code)