### PR TITLE
[OCL-103] the ghost install was our version pin, not Claude's github source

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "overclick",
-      "description": "Claim, execute, and deliver OverClick cards.",
+      "description": "Claim, execute, and deliver cards on your own self-hosted OverClick board. Ships the workflow skill, the /overclick:* commands, and hooks: a session-start board snapshot and a delivery commit check run by default, while the Edit|Write|Bash claim guard and the stop/harness guards ship disabled. The only network endpoint is the OverClick instance you configure - no third-party calls, no telemetry.",
       "version": "0.2.1",
       "source": "./plugin"
     }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,3 +51,10 @@ jobs:
 
       # No database service: the integration tests boot an in-memory PGlite.
       - run: pnpm test
+
+      # The plugin package is not a pnpm workspace, so `pnpm test` never reached
+      # it and this suite only ever ran by hand. That is how the manifest version
+      # drift behind the OCL-76 ghost install got to main, and it left the suite
+      # itself red here for a while without anyone finding out. Runs against stub
+      # CLIs, no network.
+      - run: scripts/test-plugin-package.sh

--- a/README.md
+++ b/README.md
@@ -54,6 +54,29 @@ claude mcp add --transport http overclick http://<your-host>/mcp \
 
 Then, in your terminal: *"grab the next task from the board."* Watch the example card move.
 
+### Install the plugin (Claude Code)
+
+The MCP server above is enough to claim and deliver cards. The plugin adds the rest of
+the workflow — the canonical `OVERCLICK.md`, the `/overclick:*` commands, and the
+lifecycle hooks — from this repository's own marketplace:
+
+```bash
+claude plugin marketplace add ustoppble/overclick
+claude plugin install overclick@overclick
+```
+
+Verify it materialized rather than trusting the success message — `claude plugin list`
+must report the version and `claude plugin details overclick` must list the components:
+
+```bash
+claude plugin list          # overclick@overclick, enabled
+claude plugin details overclick
+```
+
+`claude plugin update overclick@overclick` picks up later releases. For the other CLIs, or
+to have the installer write the MCP server and your token into each CLI's native config in
+one pass, use `install.sh` instead — see [docs/design/plugin.md](docs/design/plugin.md).
+
 ## What makes it different
 
 - **Cards are contracts.** *What / Why / How to confirm*, written before the work, so

--- a/docs/design/plugin.md
+++ b/docs/design/plugin.md
@@ -85,10 +85,29 @@ it clones the plugin package with plain `git` into a persistent
 clone`. Re-running install.sh fetches and hard-resets that checkout to
 `origin/HEAD` — **updating the plugin is re-running install.sh**, nothing else.
 This checkout, not a `source github` marketplace entry, is what Claude's
-native marketplace add points at: a `source github` entry can register and
-report success without ever materializing a cache (confirmed 2026-08-19 on
-the owner's machine), while a local directory marketplace served from this
-checkout works. install.sh never uses `source github` for this reason.
+native marketplace add points at — but the reason is token injection, not a
+broken `source github`. install.sh merges the user's instance URL and token
+into the plugin copy's `.mcp.json` before handing it to the native manager,
+and only a local directory can carry that private copy; the repository package
+ships a generic environment-variable template.
+
+OCL-103 corrected the reason originally recorded here. `source github` was
+blamed for "registering without ever materializing a cache" (OCL-76,
+2026-08-19). That premise is wrong: on a clean profile,
+`claude plugin marketplace add ustoppble/overclick` followed by
+`claude plugin install overclick@overclick` clones the repository, materializes
+`plugins/cache/overclick/overclick/<version>`, and reports the full component
+inventory — verified on CLI 2.1.235 (the exact build in use when the ghost was
+reported) and on 2.1.237. The real cause was manifest version drift: Claude
+resolves an installed plugin's version from `plugin.json`, not from the
+marketplace entry, and keys the cache directory by it. With the marketplace
+entry advertising 0.2.1 over a `plugin.json` still pinned to 0.1.12, users
+installed 0.1.12 into a directory a previous 0.1.12 install already occupied,
+and every `claude plugin update` answered "already at the latest version
+(0.1.12)" without ever refreshing the content. OCL-105 pinned every manifest to
+`package.json`'s version in `scripts/test-plugin-package.sh`, and OCL-103 put
+that suite in CI, where it had never run.
+
 Because "successfully installed" only means the CLI accepted the command,
 install.sh also asks `claude plugin list --json` for the enabled overclick
 entry's `installPath` and checks that `OVERCLICK.md` actually exists there;

--- a/docs/rfcs/OCL-103-native-marketplace.md
+++ b/docs/rfcs/OCL-103-native-marketplace.md
@@ -1,0 +1,272 @@
+# OCL-103 — Claude Code's native marketplace: the ghost install, and how submission actually works
+
+Status: level 1 fixed on this branch; level 2 is a prepared submission awaiting the
+owner. Every claim below was produced hands-on; the command or file that produced it
+is named inline.
+
+## Level 1 — the ghost install
+
+### What was believed
+
+OCL-76 (2026-08-19) recorded that `claude plugin marketplace add ustoppble/overclick`
+"aceita, marca enabledPlugins, mas NUNCA materializa o clone/cache", concluded that
+Claude's `source: github` was broken, and built install.sh around a local directory
+marketplace to route around it.
+
+### That premise is wrong
+
+On a clean profile (`CLAUDE_CONFIG_DIR` pointed at an empty directory), the github
+path works end to end:
+
+```
+claude plugin marketplace add ustoppble/overclick
+  → Cloning repository … Clone complete, validating marketplace…
+  → ✔ Successfully added marketplace: overclick
+claude plugin install overclick@overclick
+  → ✔ Successfully installed plugin: overclick@overclick (scope: user)
+claude plugin details overclick
+  → Skills (6) board, card, claim, deliver, overclick, release
+  → Hooks (4) SessionStart, PostToolUse, Stop, PreToolUse
+  → MCP servers (1) overclick
+```
+
+The cache really is on disk at `plugins/cache/overclick/overclick/<version>` with
+`OVERCLICK.md`, `skills/`, `commands/` and `hooks/` in it.
+
+This was verified on **CLI 2.1.235 — the exact build in use when the ghost was
+reported** (`~/.local/share/claude/versions/2.1.235`, installed 2026-08-18, still the
+current binary when OCL-76 was filed at 2026-08-19 14:34 BRT) — and again on 2.1.237.
+So there is no upstream bug to file and no issue to open: `source: github` was never
+the problem.
+
+### The real cause: manifest version drift
+
+Claude resolves an installed plugin's version from `plugin.json`, **not** from the
+marketplace entry, and keys the cache directory by that version. `claude plugin
+validate` says so directly:
+
+> `plugins[0].version`: Entry declares version "0.2.1" but
+> `plugin/.claude-plugin/plugin.json` says "0.1.12". At install time, plugin.json wins
+> (calculatePluginVersion precedence) — the entry version is silently ignored.
+
+Commit `8b3ac70` (2026-08-19 14:29, ~5 minutes before the ghost was reported) bumped
+the marketplace entry to 0.2.1 and left `plugin/.claude-plugin/plugin.json` at 0.1.12.
+Every consequence follows from that:
+
+1. The install resolves to **0.1.12**, not the 0.2.1 the entry advertises.
+2. It lands in `cache/overclick/overclick/0.1.12` — the directory an earlier 0.1.12
+   install already occupied. `claude plugin list` reports `Version: 0.1.12`, which is
+   exactly OCL-76's "list mostra versão velha de cache anterior".
+3. Worse, the version never changes, so the plugin can never update itself again.
+
+Point 3 reproduced in isolation with a synthetic marketplace (entry 0.2.1 over a
+`plugin.json` pinned at 0.1.12), publishing new content without touching the version:
+
+```
+claude plugin update reprox@reprox
+  → ✔ reprox is already at the latest version (0.1.12).
+cat …/cache/reprox/reprox/0.1.12/skills/demo/SKILL.md
+  → OLD-V1          # the new content never arrived
+```
+
+That is the ghost: not an install that fetches nothing, but an install pinned to a
+stale version that no later update can dislodge.
+
+A second, unrelated artifact was found in `~/.claude/plugins/installed_plugins.json`:
+`overclick@overclick` records `installPath` at
+`~/.claude/plugins/cache/overclick/overclick/0.1.12`, and that directory does not
+exist. It is a leftover from the 2026-08-19 debugging session, not the live state —
+the profile this repository is worked from resolves a real, populated `installPath`.
+Harmless, but it is another way "installed" can be reported over nothing.
+
+### Where the fix landed
+
+The version drift itself was corrected in parallel by two sibling cards that reached
+`main` first, from the other end of the same problem:
+
+- **OCL-105** (#24) found `.grok-plugin/marketplace.json` advertising the stale 0.2.1
+  to the Grok catalog and bumped every plugin manifest, adding a guard in
+  `scripts/test-plugin-package.sh` that pins them all to `package.json`'s version. That
+  guard is stronger than the one drafted here — it anchors to the release version rather
+  than to internal agreement — so this branch dropped its own and kept OCL-105's.
+- **OCL-104** (#28) fixed the Codex path and added a `codex plugin list --json`
+  materialization check to install.sh.
+
+Same root cause, three cards, one fix. What this branch adds on top:
+
+- **CI now runs `scripts/test-plugin-package.sh`.** It never did: the plugin package is
+  not a pnpm workspace, so `pnpm test` never reached it and the suite only ever ran by
+  hand. That is how the drift reached `main` in the first place — and why OCL-105's new
+  guard would otherwise have sat there unexecuted.
+- **The suite was red on `main`.** OCL-104's Codex materialization check has no
+  counterpart in the test harness: `agent-stub` only ever answered
+  `claude plugin list --json`, so Codex verification read empty output, install.sh
+  exited 1, and the whole suite failed. The stub now answers per CLI, in each one's own
+  shape — a flat array with `installPath` for Claude, `{installed: [...]}` with
+  `source.path` for Codex.
+- README documents the native two-command install with its verification step, since it
+  is now the honest recommendation.
+- `docs/design/plugin.md` and the install.sh comments no longer assert that
+  `source: github` is broken. install.sh keeps its local directory marketplace, but for
+  the reason that actually justifies it: it injects the user's instance URL and token
+  into the package's `.mcp.json`, and only a private local copy can carry that.
+- The Claude manifest and marketplace entry disclose the hooks and the network scope
+  (see the self-review below). Grok, Codex and Kimi keep the descriptions their own
+  cards chose; OCL-105 covers the same ground for the xAI review in `plugin/README.md`.
+
+Verified on a clean profile: `Version: 0.2.1`, `installPath` exists, `OVERCLICK.md`
+present, 6 skills / 4 hooks / 1 MCP server in the inventory.
+
+## Level 2 — submitting to a public marketplace
+
+### The card's plan does not exist
+
+The card asks for a fork + PR to `anthropics/claude-plugins-official`. Two independent
+sources say that cannot work.
+
+The official documentation
+([code.claude.com/docs/en/plugins](https://code.claude.com/docs/en/plugins)) is explicit:
+
+> The official marketplace, `claude-plugins-official`, is curated separately. Anthropic
+> decides which plugins to include at its discretion. **There is no application
+> process, and the submission form does not add plugins to the official marketplace.**
+
+And the repository auto-closes outside PRs. PR #5417 ("Add QECTOR QEC Toolkit"), closed
+2026-08-18, got a bot reply:
+
+> Thanks for your interest! This repo only accepts contributions from Anthropic team
+> members. If you'd like to submit a plugin to the marketplace, please submit your
+> plugin here.
+
+Consistent with the PR history: every new-plugin PR that merged was authored by
+`bryan-anthropic`; community "Add plugin" PRs are closed unmerged. Opening one would
+be closed by a bot within a day.
+
+### What does exist: `claude-plugins-community`
+
+Third-party submissions land in `anthropics/claude-plugins-community` after review —
+users add it with `/plugin marketplace add anthropics/claude-plugins-community` and
+install from it as `@claude-community`. It currently carries 2281 plugins; `overclick`
+is not among them.
+
+Submission is a form, not a PR:
+
+- Console (individual authors): <https://platform.claude.com/plugins/submit>
+- claude.ai (requires a Team/Enterprise org with directory-management access):
+  <https://claude.ai/admin-settings/directory/submissions/plugins/new>
+
+`clau.de/plugin-directory-submission` 302-redirects to the docs section above.
+
+The catalog is a **read-only mirror** — its `marketplace.json` is generated by the
+review pipeline, so there is no entry file for us to author or PR. Approved plugins are
+pinned to a commit SHA and CI bumps the pin as new commits are pushed. The catalog
+syncs nightly, so approval and appearance are not simultaneous.
+
+### The gate we were failing until today
+
+> Run `claude plugin validate ./your-plugin` locally before you submit. The review
+> pipeline runs the same check on every submission, along with automated safety
+> screening. […] add `--strict` to treat warnings as errors.
+
+Before this branch, that check **failed**:
+
+```
+claude plugin validate . --strict
+  → ⚠ plugins[0].version: Entry declares version "0.2.1" but … says "0.1.12"
+  → ✘ Validation failed (--strict treats warnings as errors)
+```
+
+After the fix, both the marketplace and the plugin pass `--strict`. The level 1 bug and
+the level 2 blocker were the same defect.
+
+### The entry the pipeline would generate
+
+`overclick` lives in `plugin/`, not at the repo root. That is supported: 406 of the
+2281 community entries use a `git-subdir` source. The expected shape, with the SHA
+filled in by their CI:
+
+```json
+{
+  "name": "overclick",
+  "description": "<the plugin.json description>",
+  "category": "productivity",
+  "source": {
+    "source": "git-subdir",
+    "url": "ustoppble/overclick",
+    "path": "plugin",
+    "ref": "main",
+    "sha": "<pinned by the review pipeline>"
+  },
+  "homepage": "https://github.com/ustoppble/overclick"
+}
+```
+
+`category` is optional (only 156 of 2281 entries set one); `productivity` is the
+closest of the categories in use.
+
+### Self-review against their published policy
+
+The reviewer's rubric is public at `.github/policy/prompt.md` in the official repo.
+Our hooks, in the format it asks for:
+
+| Hook | Gated? | Network |
+| --- | --- | --- |
+| `SessionStart:hooks/session-start.sh` | ungated (`startup\|resume\|clear\|compact`) | yes — the user's own configured instance |
+| `PostToolUse:hooks/claim-guard.sh` | gated to `task_claim/deliver/release` | no |
+| `PostToolUse:hooks/post-deliver.sh` | gated to `task_deliver` | no (git fetch against the project's own remote) |
+| `PreToolUse:hooks/pre-create.sh` | gated to `task_create` | yes when enabled; **default off** |
+| `PreToolUse:hooks/claim-guard.sh` | **ungated** (`Edit\|Write\|Bash`) | yes when enabled; **default off** |
+| `Stop:hooks/stop-guard.sh` | **ungated** (`*`) | yes when enabled; **default off** |
+
+Where we stand well: `has_undisclosed_telemetry` is false — every outbound call goes to
+the MCP host the user configures, there is no analytics, no usage ping, no third-party
+endpoint. No credential is read from one service and sent to another.
+
+**The one honest risk** is `has_broad_scope_hooks`. The rubric sets it true if "any
+UserPromptSubmit/PreToolUse/PostToolUse hook runs without a project-relevance gate,"
+and `passes=false` follows automatically. Our claim guard binds `PreToolUse` on
+`Edit|Write|Bash` with no gate. It returns immediately unless the user sets
+`enforce_claim=1`, but a reviewer reading `hooks/hooks.json` sees an ungated binding on
+every edit in every project — and the rubric is applied to the registration, not to the
+runtime early-exit.
+
+Two options for the owner, neither taken here because both change the guard's design:
+
+1. Gate the registration on project relevance — only bind when the project actually
+   uses OverClick (for example, a `.overclick/` directory present).
+2. Ship the claim guard unregistered and have install.sh add the binding only when the
+   user opts in, so the shipped `hooks.json` carries no ungated `PreToolUse`.
+
+Option 2 preserves the guard exactly and is the smaller change; option 1 is more
+self-contained. This is a design decision, so it is left for the owner.
+
+Already addressed here: `description_matches_behavior`. The old description ("Run the
+complete OverClick card workflow from Claude Code") would surprise a user who then
+found a hook inspecting every `Edit`/`Write`/`Bash`. All six manifests now disclose the
+hooks, the opt-in guards, and the network scope up front.
+
+### Owner steps — the Claude submission is a form, not code
+
+Nothing below is an engineering task; all of it is the owner's to do, and none of it can
+be done from a branch.
+
+1. **Decide the `has_broad_scope_hooks` question above.** As shipped, the submission
+   fails the automated review on that one point. Land whichever mitigation you prefer
+   before submitting if you want it to pass first time.
+2. **Merge this branch.** The review pipeline pins a SHA from `main` and runs
+   `claude plugin validate` against it, so `main` is what gets judged.
+3. **Submit the form** at <https://platform.claude.com/plugins/submit> (Console, for
+   individual authors) — repo `ustoppble/overclick`, path `plugin`, source `git-subdir`.
+   The claude.ai form at
+   <https://claude.ai/admin-settings/directory/submissions/plugins/new> is the same
+   thing but needs a Team/Enterprise org with directory-management access.
+4. **Then wait.** Approved plugins are pinned to a commit SHA in
+   `anthropics/claude-plugins-community` and the catalog syncs nightly, so approval and
+   appearance are not the same moment. Check by searching the plugin name in that
+   repo's `marketplace.json`.
+
+The target is **`claude-plugins-community`, reached by form** — not
+`claude-plugins-official`, which takes no submissions at all, and not a pull request,
+which its bot auto-closes. There is therefore no submission PR link to hand over: this
+document is the submission package. Publication is outward-facing and stays the owner's
+call.

--- a/install.sh
+++ b/install.sh
@@ -148,12 +148,14 @@ if [[ -f "$script_dir/plugin/OVERCLICK.md" ]]; then
 elif [[ -n "${OVERCLICK_PLUGIN_DIR:-}" && -f "$OVERCLICK_PLUGIN_DIR/OVERCLICK.md" ]]; then
   source_root=$(CDPATH='' cd -- "$OVERCLICK_PLUGIN_DIR/.." && pwd)
 else
-  # A `source github` marketplace entry can register without ever fetching the
-  # package (Claude CLI accepts it, marks it enabled, never materializes a
-  # cache). A plain git checkout served as a local directory marketplace is
-  # what actually works, so this installer keeps that checkout itself and
-  # re-running install.sh doubles as the update path (git pull, not a fresh
-  # ephemeral clone every run).
+  # This installer serves a local directory marketplace instead of a
+  # `source github` entry because it injects the user's instance URL and token
+  # into the package's .mcp.json, and only a private local copy can carry
+  # that. (OCL-103: `source github` itself works; the ghost install blamed on
+  # it in OCL-76 was manifest version drift. Users who only want the plugin can
+  # `claude plugin marketplace add ustoppble/overclick` directly.) The checkout
+  # is kept rather than re-cloned so re-running install.sh doubles as the
+  # update path: git fetch + reset, not a fresh ephemeral clone every run.
   if ! command -v git >/dev/null 2>&1; then
     printf '%s\n' "git is required to fetch the OverClick plugin package." >&2
     exit 1
@@ -381,9 +383,10 @@ quiet_try() {
   fi
 }
 
-# "Successfully installed" only means the CLI accepted the command; the
-# github-source bug this fixes accepted it and never materialized anything.
-# Ask the CLI what it actually has on disk instead of trusting exit codes.
+# "Successfully installed" only means the CLI accepted the command. The OCL-76
+# ghost install exited 0 while the plugin the user ended up with was a stale
+# cache directory from an earlier version. Ask the CLI what it actually has on
+# disk instead of trusting exit codes.
 verify_claude_plugin() {
   local listing
   listing=$(claude plugin list --json 2>/dev/null) || return 1

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "overclick",
   "version": "0.2.1",
-  "description": "Run the complete OverClick card workflow from Claude Code.",
+  "description": "Claim, execute, and deliver cards on your own self-hosted OverClick board. Ships the workflow skill, the /overclick:* commands, and hooks: a session-start board snapshot and a delivery commit check run by default, while the Edit|Write|Bash claim guard and the stop/harness guards ship disabled. The only network endpoint is the OverClick instance you configure - no third-party calls, no telemetry.",
   "author": {
     "name": "OverClick"
   },

--- a/scripts/test-plugin-package.sh
+++ b/scripts/test-plugin-package.sh
@@ -44,15 +44,41 @@ jq -e '(.hooks.PostToolUse | length == 2) and (.hooks.PreToolUse | length == 2)'
   "$REPO_ROOT/plugin/hooks/hooks.json" >/dev/null
 test -x "$REPO_ROOT/plugin/hooks/claim-guard.sh"
 test "$(find "$REPO_ROOT/plugin/commands" -name '*.md' | wc -l | tr -d ' ')" -eq 5
-test "$(find "$REPO_ROOT/plugin" "$REPO_ROOT/skills" -name SKILL.md | wc -l | tr -d ' ')" -eq 1
+# A root skills/ need not exist; 2>/dev/null keeps its absence from printing a
+# find error that reads like a failed check in CI. A stray root SKILL.md still
+# pushes the count past 1 and fails here.
+test "$(find "$REPO_ROOT/plugin" "$REPO_ROOT/skills" -name SKILL.md 2>/dev/null | wc -l | tr -d ' ')" -eq 1
 
-mkdir -p "$TEST_ROOT/bin" "$TEST_ROOT/home/.codex" "$TEST_ROOT/project" "$TEST_ROOT/claude-cache"
+# `stat -f` means "file mode" on BSD/macOS but "filesystem status" on GNU
+# coreutils — where it SUCCEEDS and prints a multi-line filesystem block, so a
+# `stat -f ... || stat -c ...` fallback never reaches the GNU form and `test`
+# aborts with "Illegal number" (exit 2). Probe the GNU flag first: it is the one
+# that fails cleanly on the other platform.
+file_mode() {
+  stat -c '%a' "$1" 2>/dev/null || stat -f '%Lp' "$1"
+}
+
+mkdir -p "$TEST_ROOT/bin" "$TEST_ROOT/home/.codex" "$TEST_ROOT/project" "$TEST_ROOT/claude-cache" "$TEST_ROOT/codex-cache"
 touch "$TEST_ROOT/claude-cache/OVERCLICK.md"
+touch "$TEST_ROOT/codex-cache/OVERCLICK.md"
+# OCL-104 gave install.sh a `codex plugin list --json` materialization check to
+# match the Claude one, but this stub only ever answered for claude, so codex
+# verification saw empty output, install.sh exited 1, and this whole suite
+# failed. Each CLI that install.sh verifies needs an answer here — its own
+# shape: claude returns a flat array with installPath, codex an {installed: []}
+# whose entries carry source.path.
 cat >"$TEST_ROOT/bin/agent-stub" <<'SH'
 #!/bin/sh
 printf '%s:%s:%s\n' "$(basename -- "$0")" "${1:-}" "${2:-}" >>"$OC_TEST_NATIVE_LOG"
-if [ "$(basename -- "$0")" = "claude" ] && [ "${1:-}" = "plugin" ] && [ "${2:-}" = "list" ]; then
-  printf '[{"id":"overclick@overclick","enabled":true,"installPath":"%s"}]' "$OC_TEST_CLAUDE_CACHE"
+if [ "${1:-}" = "plugin" ] && [ "${2:-}" = "list" ]; then
+  case "$(basename -- "$0")" in
+    claude)
+      printf '[{"id":"overclick@overclick","enabled":true,"installPath":"%s"}]' "$OC_TEST_CLAUDE_CACHE"
+      ;;
+    codex)
+      printf '{"installed":[{"name":"overclick","installed":true,"enabled":true,"source":{"path":"%s"}}]}' "$OC_TEST_CODEX_CACHE"
+      ;;
+  esac
 fi
 exit 0
 SH
@@ -78,6 +104,7 @@ run_installer() {
   PATH="$TEST_ROOT/bin:$PATH" \
   OC_TEST_NATIVE_LOG="$TEST_ROOT/native.log" \
   OC_TEST_CLAUDE_CACHE="$TEST_ROOT/claude-cache" \
+  OC_TEST_CODEX_CACHE="$TEST_ROOT/codex-cache" \
   OVERCLICK_INSTALL_HOME="$TEST_ROOT/home" \
   OVERCLICK_PROJECT_DIR="$TEST_ROOT/project" \
   OVERCLICK_INSTANCE_URL="$FIXTURE_URL" \
@@ -101,7 +128,7 @@ test "$(grep -c 'session-start.sh' "$TEST_ROOT/home/.codex/hooks.json")" -eq 1
 test "$(grep -c 'claim-guard.sh' "$TEST_ROOT/home/.codex/hooks.json" || true)" -eq 0
 test "$(grep -c '^enforce_claim=0$' "$TEST_ROOT/home/.config/overclick/config")" -eq 1
 test "$(grep -c '^token=' "$TEST_ROOT/home/.config/overclick/config")" -eq 1
-test "$(stat -f '%Lp' "$TEST_ROOT/home/.config/overclick/config" 2>/dev/null || stat -c '%a' "$TEST_ROOT/home/.config/overclick/config")" -eq 600
+test "$(file_mode "$TEST_ROOT/home/.config/overclick/config")" -eq 600
 
 # Kimi has no non-interactive plugin subcommand, so install.sh writes its registry
 # directly. Running twice must leave exactly one entry, and the installed copy must
@@ -124,6 +151,7 @@ mkdir -p "$TEST_ROOT/claude-cache-empty"
 if PATH="$TEST_ROOT/bin:$PATH" \
   OC_TEST_NATIVE_LOG="$TEST_ROOT/native-unverified.log" \
   OC_TEST_CLAUDE_CACHE="$TEST_ROOT/claude-cache-empty" \
+  OC_TEST_CODEX_CACHE="$TEST_ROOT/codex-cache" \
   OVERCLICK_INSTALL_HOME="$TEST_ROOT/home-unverified" \
   OVERCLICK_PROJECT_DIR="$TEST_ROOT/project" \
   OVERCLICK_INSTANCE_URL="$FIXTURE_URL" \
@@ -135,8 +163,8 @@ if PATH="$TEST_ROOT/bin:$PATH" \
 fi
 grep -Fq 'did not materialize' "$TEST_ROOT/unverified.err"
 
-# The github-source bug this fixes never gives install.sh a local checkout to
-# reuse. Exercise that path directly: a bare install.sh copy, no plugin/ next
+# `curl | bash` never gives install.sh a local checkout to reuse (OCL-103: the
+# github source was never the bug). Exercise that path directly: a bare install.sh copy, no plugin/ next
 # to it, sourcing a local git remote instead of network github.
 mkdir -p "$TEST_ROOT/plugin-remote/plugin/.codex-plugin" \
   "$TEST_ROOT/plugin-remote/.claude-plugin" "$TEST_ROOT/plugin-remote/.grok-plugin"
@@ -159,6 +187,7 @@ run_clone_installer() {
   PATH="$TEST_ROOT/bin:$PATH" \
   OC_TEST_NATIVE_LOG="$TEST_ROOT/clone-native.log" \
   OC_TEST_CLAUDE_CACHE="$TEST_ROOT/clone-cache" \
+  OC_TEST_CODEX_CACHE="$TEST_ROOT/codex-cache" \
   OVERCLICK_INSTALL_HOME="$TEST_ROOT/clone-home" \
   OVERCLICK_PROJECT_DIR="$TEST_ROOT/project" \
   OVERCLICK_INSTANCE_URL="$FIXTURE_URL" \
@@ -341,7 +370,7 @@ test ! -e "$TEST_ROOT/project/.overclick/claim.json"
 claim_input=$(jq -nc --arg cwd "$TEST_ROOT/project" '{cwd:$cwd,session_id:"session-fixture",tool_name:"mcp__overclick__task_claim",tool_input:{task_id:"T-1"},tool_response:{structuredContent:{task:{short_id:"T-1",status:"em_execucao"},attempt:{id:"attempt-fixture",started_at:"2026-08-19T12:00:00.000Z"}}}}')
 printf '%s' "$claim_input" | PATH="$TEST_ROOT/bin:$PATH" OVERCLICK_CONFIG_FILE="$HOOK_CONFIG" "$REPO_ROOT/plugin/hooks/claim-guard.sh"
 test -f "$TEST_ROOT/project/.overclick/claim.json"
-test "$(stat -f '%Lp' "$TEST_ROOT/project/.overclick/claim.json" 2>/dev/null || stat -c '%a' "$TEST_ROOT/project/.overclick/claim.json")" -eq 600
+test "$(file_mode "$TEST_ROOT/project/.overclick/claim.json")" -eq 600
 jq -e '.task_id == "T-1" and .claimed_at == "2026-08-19T12:00:00.000Z" and .session_id == "session-fixture"' "$TEST_ROOT/project/.overclick/claim.json" >/dev/null
 test -z "$(printf '%s' "$write_input" | PATH="$TEST_ROOT/bin:$PATH" OC_TEST_HAS_CLAIM=0 OVERCLICK_CONFIG_FILE="$HOOK_CONFIG" "$REPO_ROOT/plugin/hooks/claim-guard.sh")"
 other_session_input=$(jq -nc --arg cwd "$TEST_ROOT/project" '{cwd:$cwd,session_id:"another-session",tool_name:"Write",tool_input:{file_path:"changed.txt",content:"fixture"}}')


### PR DESCRIPTION
> Rebased onto current `main` (through OCL-102 #25, OCL-104 #28, OCL-105 #24, OCL-106 #29). CI green.

## The ghost, resolved

OCL-76 blamed Claude's `source: github` for accepting a marketplace and never materializing it. On a clean profile it materializes fine — verified on **CLI 2.1.235, the exact build in use when the ghost was reported**, and on 2.1.237. No upstream bug, nothing to file.

The real cause is ours. Claude resolves an installed plugin's version from `plugin.json`, not from the marketplace entry, and keys the cache directory by it. `8b3ac70` bumped the entry to 0.2.1 and left `plugin.json` at 0.1.12, so:

- the install resolved to **0.1.12**, not the advertised 0.2.1;
- it landed on top of an existing `cache/overclick/overclick/0.1.12` — OCL-76's "versão velha de cache anterior";
- and since the version never moves, `claude plugin update` answers *"already at the latest version (0.1.12)"* forever, so new content never arrives.

`claude plugin validate` names this exactly, and a synthetic marketplace reproduces the frozen-content half in isolation.

## What's left after the rebase

**OCL-105 (#24)** and **OCL-104 (#28)** hit `main` first and already fixed the drift itself — OCL-105 with a version guard anchored to `package.json`, which is stronger than the one this branch drafted, so mine is dropped in favour of theirs. Same root cause found from three directions.

What this branch still carries:

- **CI now runs `scripts/test-plugin-package.sh`.** It never did — the plugin package is not a pnpm workspace, so `pnpm test` never reached it and it only ever ran by hand. That is how the drift got to `main`, and why OCL-105's new guard would otherwise sit there unexecuted.
- **That suite is red on `main`, for two independent reasons.** Verified: `main` exits non-zero today.
  1. OCL-104 gave install.sh a `codex plugin list --json` materialization check with no counterpart in the harness — `agent-stub` only answered for `claude`, so codex verification read empty output and install.sh exited 1. The stub now answers per CLI in each one's own shape.
  2. `stat -f` means *file mode* on BSD but *filesystem status* on GNU, where it **succeeds** and prints a multi-line block — so the `stat -f … || stat -c …` fallback never reached the GNU form and `test` aborted with `Illegal number`. **That is the `exit 2` seen on Linux.** A `file_mode` helper probes `-c` first, the flag that fails cleanly on the other platform.
- README documents the native two-command install with its verification step.
- The false premise is gone from `docs/design/plugin.md` and the install.sh comments. install.sh keeps its directory marketplace for the reason that actually justifies it: it injects the user's instance URL and token into the package's `.mcp.json`.
- The **Claude** manifest and marketplace entry disclose the hooks and network scope — the official rubric judges `description_matches_behavior` on that field. Grok, Codex and Kimi keep the descriptions their own cards chose.

## Level 2 — `docs/rfcs/OCL-103-native-marketplace.md`

`claude-plugins-official` takes **no submissions**: the docs say so ("no application process") and its bot auto-closes outside PRs (evidence: PR #5417). The real target is **`claude-plugins-community`** via the Console form, with a `git-subdir` source on `ustoppble/overclick` path `plugin` — an owner step, not code.

The RFC also records the one honest gap against their published review rubric: the claim guard's **ungated `PreToolUse` on `Edit|Write|Bash`**, which trips `has_broad_scope_hooks` and auto-fails review. Two mitigations offered; neither applied, because it changes the guard's design.

> No submission PR link, because a PR is the wrong channel. Publication stays outward-facing and yours.

## Verification

```
scripts/test-plugin-package.sh           → passed   (main: exit 1)
claude plugin validate . --strict        → ✔ passed
claude plugin validate ./plugin --strict → ✔ passed
CI on e4895b9                            → success
clean profile install                    → 0.2.1, installPath exists,
                                           6 skills / 4 hooks / 1 MCP server
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)