### PR TITLE
[OCL-104] codex: make the native marketplace path actually install

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,12 @@
+{
+  "name": "overclick",
+  "interface": { "displayName": "OverClick" },
+  "plugins": [
+    {
+      "name": "overclick",
+      "source": { "source": "local", "path": "./plugin" },
+      "policy": { "installation": "AVAILABLE", "authentication": "ON_INSTALL" },
+      "category": "Productivity"
+    }
+  ]
+}

--- a/install.sh
+++ b/install.sh
@@ -339,6 +339,29 @@ process.stdin.on("end", () => {
   return 1
 }
 
+# Same reasoning as verify_claude_plugin: `codex plugin add` prints a success
+# line even when the marketplace layout is wrong, so ask Codex what it holds.
+verify_codex_plugin() {
+  local listing
+  listing=$(codex plugin list --json 2>/dev/null) || return 1
+  if command -v python3 >/dev/null 2>&1; then
+    printf '%s' "$listing" | python3 -c '
+import json, sys
+try:
+    data = json.load(sys.stdin)
+except Exception:
+    sys.exit(1)
+for entry in data.get("installed", []):
+    if entry.get("name") == "overclick" and entry.get("installed") and entry.get("enabled"):
+        print((entry.get("source") or {}).get("path", ""))
+        sys.exit(0)
+sys.exit(1)
+'
+    return $?
+  fi
+  return 1
+}
+
 validation_failed=0
 
 if has_cli claude; then
@@ -371,8 +394,13 @@ fi
 
 if has_cli codex; then
   codex_marketplace="$overclick_root/codex-marketplace"
-  codex_plugin="$codex_marketplace/.agents/plugins/overclick"
-  mkdir -p "$codex_plugin"
+  # Codex resolves each plugin `source.path` against the MARKETPLACE ROOT, not
+  # against the directory holding marketplace.json. The manifest below says
+  # "./plugins/overclick", so the payload has to live at <root>/plugins/overclick;
+  # copying it next to the manifest makes `codex plugin add` fail with
+  # "plugin source path is not a directory".
+  codex_plugin="$codex_marketplace/plugins/overclick"
+  mkdir -p "$codex_plugin" "$codex_marketplace/.agents/plugins"
   cp -R "$plugin_target/." "$codex_plugin/"
   cat >"$codex_marketplace/.agents/plugins/marketplace.json" <<'JSON'
 {
@@ -388,9 +416,21 @@ if has_cli codex; then
   ]
 }
 JSON
+  # `codex` refuses to load its configuration when CODEX_HOME does not exist,
+  # so every plugin call below would fail on a machine where codex is installed
+  # but has never been run.
+  mkdir -p "$install_home/.codex"
   quiet_try "Codex marketplace" codex plugin marketplace add "$codex_marketplace"
   quiet_try "Codex plugin" codex plugin add overclick@overclick
   write_codex_mcp
+
+  codex_install_path=$(verify_codex_plugin) || codex_install_path=""
+  if [[ -n "$codex_install_path" && -f "$codex_install_path/OVERCLICK.md" ]]; then
+    printf '%s\n' "Codex plugin verified: enabled and materialized at $codex_install_path."
+  else
+    printf '%s\n' "Codex plugin did not materialize: 'codex plugin list --json' shows no enabled overclick entry with OVERCLICK.md on disk. Do not trust the earlier \"configured\" messages; retry or install manually." >&2
+    validation_failed=1
+  fi
   # Codex has no supported client-side claim guard. Keep the existing lifecycle
   # integrations, while claim enforcement remains on the board for this CLI.
   merge_json_config hooks-no-claim-guard "$install_home/.codex/hooks.json" "$plugin_target/hooks/hooks.json"

--- a/plugin/.codex-plugin/mcp.json
+++ b/plugin/.codex-plugin/mcp.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "overclick": {
+      "type": "http",
+      "url": "${OVERCLICK_URL}",
+      "bearer_token_env_var": "OVERCLICK_TOKEN"
+    }
+  }
+}

--- a/plugin/.codex-plugin/plugin.json
+++ b/plugin/.codex-plugin/plugin.json
@@ -12,8 +12,11 @@
     "longDescription": "Connect Codex to an OverClick board and keep every work item in the claim-to-deliver loop.",
     "developerName": "OverClick",
     "category": "Productivity",
-    "capabilities": ["MCP", "Skills"],
+    "capabilities": [
+      "MCP",
+      "Skills"
+    ],
     "defaultPrompt": "Show my OverClick board and help me execute the next card."
   },
-  "mcpServers": "./.mcp.json"
+  "mcpServers": "./.codex-plugin/mcp.json"
 }


### PR DESCRIPTION
The install.sh copied the Codex plugin payload to the wrong location, breaking 100% of Codex installs. Fixed and proven in a clean profile. Adds the Codex two-step marketplace path (marketplace add + plugin add), a .agents/plugins/marketplace.json, and the .codex-plugin mcp.json/plugin.json corrections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)