### PR TITLE
[OCL-106] kimi: validate the plugin against the real CLI, not the docs

### DIFF
--- a/.kimi-plugin/plugin.json
+++ b/.kimi-plugin/plugin.json
@@ -1,0 +1,58 @@
+{
+  "name": "overclick",
+  "version": "0.2.1",
+  "description": "Run the complete OverClick card workflow from Kimi Code.",
+  "homepage": "https://github.com/ustoppble/overclick",
+  "license": "MIT",
+  "keywords": ["overclick", "task-board", "mcp"],
+  "author": {
+    "name": "OverClick"
+  },
+  "skills": ["./plugin/skills/overclick"],
+  "commands": "./plugin/commands",
+  "hooks": [
+    {
+      "event": "SessionStart",
+      "matcher": "*",
+      "command": "./plugin/hooks/session-start.sh",
+      "timeout": 15
+    },
+    {
+      "event": "PostToolUse",
+      "matcher": "task_claim|mcp__.*__task_claim|task_deliver|mcp__.*__task_deliver|task_release|mcp__.*__task_release",
+      "command": "./plugin/hooks/claim-guard.sh",
+      "timeout": 15
+    },
+    {
+      "event": "PostToolUse",
+      "matcher": "task_deliver|mcp__.*__task_deliver",
+      "command": "./plugin/hooks/post-deliver.sh",
+      "timeout": 30
+    },
+    {
+      "event": "Stop",
+      "matcher": "*",
+      "command": "./plugin/hooks/stop-guard.sh",
+      "timeout": 15
+    },
+    {
+      "event": "PreToolUse",
+      "matcher": "task_create|mcp__.*__task_create",
+      "command": "./plugin/hooks/pre-create.sh",
+      "timeout": 15
+    },
+    {
+      "event": "PreToolUse",
+      "matcher": "Edit|Write|Bash",
+      "command": "./plugin/hooks/claim-guard.sh",
+      "timeout": 15
+    }
+  ],
+  "interface": {
+    "displayName": "OverClick",
+    "shortDescription": "Claim, execute, and deliver OverClick cards",
+    "longDescription": "The OverClick board workflow as a plugin: the canonical OVERCLICK.md rules, the board MCP server, claim/deliver guards, and the /overclick slash commands. Point it at your own OverClick instance.",
+    "developerName": "OverClick",
+    "websiteURL": "https://github.com/ustoppble/overclick"
+  }
+}

--- a/docs/design/plugin.md
+++ b/docs/design/plugin.md
@@ -11,8 +11,8 @@ Provider manifests adapt that same package to each native loader.
 
 | Capability | Claude Code | Grok CLI | Kimi Code | Codex |
 | --- | --- | --- | --- | --- |
-| Manifest | `.claude-plugin/plugin.json` | `plugin.json` | `kimi.plugin.json` | `.codex-plugin/plugin.json` |
-| Repository marketplace | `.claude-plugin/marketplace.json` | `.grok-plugin/marketplace.json` | Native custom install | Installer-created local marketplace |
+| Manifest | `.claude-plugin/plugin.json` | `plugin.json` | `kimi.plugin.json` (package root) or `.kimi-plugin/plugin.json` (repository root) | `.codex-plugin/plugin.json` |
+| Repository marketplace | `.claude-plugin/marketplace.json` | `.grok-plugin/marketplace.json` | Official registry (`curated` tier) plus native custom install | Installer-created local marketplace |
 | Skill | `skills/overclick/SKILL.md` | Same | Same | Same |
 | Commands | Auto-discovered `commands/` | Auto-discovered `commands/` | `commands` manifest field | Skill-driven; not declared in the manifest |
 | MCP | `.mcp.json` plus native user config | `.mcp.json` plus native user config | `mcpServers` plus private user config | `mcpServers` manifest field plus `[mcp_servers]` user config |
@@ -90,6 +90,85 @@ unrecognized CLI also needs it.
 The package keeps generic instance and token inputs. It contains no internal routing
 menu, organization names, deployment authority, or private endpoint. Live harness
 selection always comes from `harness_recommend` on the connected board.
+
+## Kimi Code, validated hands-on (OCL-106)
+
+OCL-49 recorded the Kimi row from documentation only, because the binary was not on
+the subagent's machine. It is now validated against Kimi Code 0.37.2 running locally.
+What the CLI actually does, read from its own manifest parser and confirmed by
+installing the package:
+
+- The manifest is `kimi.plugin.json` at the plugin root, or `.kimi-plugin/plugin.json`.
+  A root `kimi.plugin.json` shadows the directory form. `name` must match
+  `^[a-z0-9][a-z0-9_-]{0,63}$`.
+- `skills`, `agents` and `commands` are `./`-relative and must resolve inside the
+  plugin. `hooks` entries are `{event, matcher?, command, timeout?}` and are validated
+  strictly: an unknown key rejects the whole hook. Plugin hooks run with the plugin
+  root as working directory and `KIMI_PLUGIN_ROOT` exported, so `./hooks/x.sh` is correct.
+- `mcpServers` uses `transport`, not `type`. A `type` key is silently dropped and the
+  transport re-inferred from `url`, so the previous manifest worked by accident; it now
+  declares `transport` explicitly.
+- `url` is validated as a real URL. A `${OVERCLICK_URL}` placeholder is **not** expanded
+  by Kimi: the entry fails validation and the server is dropped with the plugin still
+  reporting `state: ok` and `hasErrors: false`. That silent drop is why install.sh
+  substitutes the instance URL into the installed copy before registering it.
+- `tools`, `apps`, `inject`, `configFile`, `config_file` and `bootstrap` are parsed but
+  unsupported, and are reported as informational diagnostics.
+- Plugin MCP tools are namespaced `mcp__plugin-<pluginId>_<server>__<tool>`, which the
+  existing `mcp__.*__task_claim` hook matchers still cover.
+
+### Installing without a TUI
+
+Kimi Code has no `kimi plugin` subcommand. `/plugins install` is a host slash command,
+and `--prompt` hands slash commands to the model instead of the host — `--prompt` also
+refuses to combine with `--auto` or `--yolo` at all. The previous
+`kimi --auto --prompt "/plugins install ..."` call could therefore never succeed. The
+installer now writes Kimi's own registry the way its manager does: copy the package to
+`<KIMI_CODE_HOME>/plugins/managed/overclick` and register it in
+`<KIMI_CODE_HOME>/plugins/installed.json`, preserving any other installed plugin.
+
+For a user installing by hand, the working command is typed at the Kimi prompt:
+
+```text
+/plugins install <absolute path to the package>
+```
+
+Non-official sources require an interactive trust confirmation, which is the other
+reason the headless path cannot use it.
+
+### Official registry and submission
+
+The registry is real: `https://code.kimi.com/kimi-code/plugins/marketplace.json`,
+overridable with `KIMI_CODE_PLUGIN_MARKETPLACE_URL`, browsable in the CLI with
+`/plugins marketplace`. Entries carry a `tier` of `official` (Moonshot-hosted zips) or
+`curated` (third-party sources). The catalog is served from the public
+`MoonshotAI/kimi-code` repository at `plugins/marketplace.json`, so submission is a pull
+request against that file; there is no separate application form. Third parties are
+already listed this way (`superpowers`, `vercel-plugin`, `modern-web-guidance`,
+`cloudbase`).
+
+A curated entry points at a GitHub repository, and Kimi resolves the plugin root by
+looking for a manifest in the extracted archive root or in a single child directory —
+it does not search deeper. `plugin/kimi.plugin.json` alone is therefore not reachable
+from a repository install, which is why the repository root also carries
+`.kimi-plugin/plugin.json` pointing into `./plugin/`. That root manifest deliberately
+omits `mcpServers`: a registry install cannot know the user's instance URL, and a
+placeholder would be dropped silently. Registry users get the skill, commands and hooks,
+then run install.sh (or add the server to `~/.kimi-code/mcp.json`) to connect their board.
+
+The entry to submit, once the owner decides to publish:
+
+```json
+{
+  "id": "overclick",
+  "tier": "curated",
+  "displayName": "OverClick",
+  "description": "Claim, execute, and deliver OverClick cards from Kimi Code.",
+  "homepage": "https://github.com/ustoppble/overclick",
+  "keywords": ["overclick", "task-board", "mcp", "workflow"],
+  "source": "https://github.com/ustoppble/overclick"
+}
+```
 
 ## Verification contract
 

--- a/install.sh
+++ b/install.sh
@@ -187,9 +187,9 @@ else:
     data = {}
 
 mode = os.environ["OC_JSON_MODE"]
-if mode == "mcp":
+if mode in ("mcp", "mcp-kimi"):
     data.setdefault("mcpServers", {})["overclick"] = {
-        "type": "http",
+        ("transport" if mode == "mcp-kimi" else "type"): "http",
         "url": os.environ["OC_MCP_URL"],
         "headers": {"Authorization": "Bearer " + os.environ["OC_MCP_TOKEN"]},
     }
@@ -229,10 +229,10 @@ const path = require("node:path");
 const file = process.env.OC_JSON_FILE;
 let data = {};
 if (fs.existsSync(file)) data = JSON.parse(fs.readFileSync(file, "utf8"));
-if (process.env.OC_JSON_MODE === "mcp") {
+if (process.env.OC_JSON_MODE === "mcp" || process.env.OC_JSON_MODE === "mcp-kimi") {
   data.mcpServers ??= {};
   data.mcpServers.overclick = {
-    type: "http",
+    [process.env.OC_JSON_MODE === "mcp-kimi" ? "transport" : "type"]: "http",
     url: process.env.OC_MCP_URL,
     headers: { Authorization: "Bearer " + process.env.OC_MCP_TOKEN },
   };
@@ -267,7 +267,7 @@ JS
 # work without requiring shell profile edits. The repository package remains a
 # generic environment-variable template.
 merge_json_config mcp "$plugin_target/.mcp.json"
-merge_json_config mcp "$plugin_target/kimi.plugin.json"
+merge_json_config mcp-kimi "$plugin_target/kimi.plugin.json"
 chmod 600 "$plugin_target/.mcp.json" "$plugin_target/kimi.plugin.json"
 
 native_marketplace="$overclick_root/native-marketplace"
@@ -414,12 +414,66 @@ if has_cli grok; then
     --header "Authorization: Bearer $token" overclick "$mcp_url"
 fi
 
+# Kimi Code has no non-interactive plugin subcommand: `/plugins install` is a TUI
+# slash command, and `--prompt` hands slash commands to the model instead of the
+# host (and refuses to combine with --auto/--yolo at all). So we write Kimi's own
+# plugin registry directly, the same way its manager does: copy the payload to
+# plugins/managed/<id> and register it in plugins/installed.json, preserving any
+# other installed plugin.
+kimi_register_plugin() {
+  local kimi_home=${KIMI_CODE_HOME:-$install_home/.kimi-code}
+  local managed="$kimi_home/plugins/managed/overclick"
+
+  mkdir -p "$kimi_home/plugins/managed" || return 1
+  rm -rf "$managed" || return 1
+  cp -R "$plugin_target" "$managed" || return 1
+
+  OC_KIMI_INSTALLED="$kimi_home/plugins/installed.json" OC_KIMI_ROOT="$managed" \
+    OC_PLUGIN_TARGET="$plugin_target" python3 <<'KIMIPY'
+import json, os, pathlib, tempfile
+from datetime import datetime, timezone
+
+path = pathlib.Path(os.environ["OC_KIMI_INSTALLED"])
+data = {"version": 1, "plugins": []}
+if path.exists():
+    try:
+        loaded = json.loads(path.read_text())
+    except Exception as exc:
+        raise SystemExit(f"Refusing to replace invalid Kimi plugin registry: {exc}")
+    if isinstance(loaded, dict) and isinstance(loaded.get("plugins"), list):
+        data = loaded
+
+now = datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+previous = next((p for p in data["plugins"] if p.get("id") == "overclick"), {})
+plugins = [p for p in data["plugins"] if p.get("id") != "overclick"]
+plugins.append({
+    "id": "overclick",
+    "root": os.environ["OC_KIMI_ROOT"],
+    "source": "local-path",
+    "enabled": previous.get("enabled", True),
+    "installedAt": previous.get("installedAt", now),
+    "updatedAt": now,
+    "originalSource": os.environ["OC_PLUGIN_TARGET"],
+})
+data["plugins"] = plugins
+
+path.parent.mkdir(parents=True, exist_ok=True)
+fd, temp_name = tempfile.mkstemp(prefix=".overclick-", dir=path.parent)
+with os.fdopen(fd, "w") as handle:
+    json.dump(data, handle, indent=2)
+    handle.write("\n")
+os.replace(temp_name, path)
+os.chmod(path, 0o600)
+KIMIPY
+}
+
 if has_cli kimi; then
-  kimi_plugin_path=${plugin_target//\\/\\\\}
-  kimi_plugin_path=${kimi_plugin_path//\"/\\\"}
-  quiet_try "Kimi plugin" kimi --auto --prompt "/plugins install \"$kimi_plugin_path\""
-  merge_json_config mcp "$install_home/.kimi-code/mcp.json"
-  quiet_try "Kimi MCP" kimi --auto --prompt "/plugins mcp enable overclick overclick"
+  merge_json_config mcp-kimi "$install_home/.kimi-code/mcp.json"
+  if command -v python3 >/dev/null 2>&1 && kimi_register_plugin; then
+    printf '%s\n' "Kimi plugin configured."
+  else
+    printf '%s\n' "Kimi plugin needs manual confirmation: run /plugins install $plugin_target inside Kimi Code." >&2
+  fi
 fi
 
 if [[ "${OVERCLICK_AGENTS_FALLBACK:-0}" = "1" ]] || \

--- a/plugin/kimi.plugin.json
+++ b/plugin/kimi.plugin.json
@@ -2,15 +2,21 @@
   "name": "overclick",
   "version": "0.1.12",
   "description": "Run the complete OverClick card workflow from Kimi Code.",
-  "keywords": ["overclick", "task-board", "mcp"],
+  "keywords": [
+    "overclick",
+    "task-board",
+    "mcp"
+  ],
   "author": {
     "name": "OverClick"
   },
   "license": "MIT",
-  "skills": ["./skills/overclick"],
+  "skills": [
+    "./skills/overclick"
+  ],
   "mcpServers": {
     "overclick": {
-      "type": "http",
+      "transport": "http",
       "url": "${OVERCLICK_URL}",
       "headers": {
         "Authorization": "Bearer ${OVERCLICK_TOKEN}"

--- a/scripts/test-plugin-package.sh
+++ b/scripts/test-plugin-package.sh
@@ -10,6 +10,18 @@ jq -e '.skills and .mcpServers and (has("hooks") | not) and (has("commands") | n
   "$REPO_ROOT/plugin/.codex-plugin/plugin.json" >/dev/null
 jq -e '.skills and .mcpServers and (.hooks | length == 6) and .commands' \
   "$REPO_ROOT/plugin/kimi.plugin.json" >/dev/null
+# Kimi discriminates MCP transports on "transport"; a "type" key is dropped and the
+# transport re-inferred from the url, so declaring it is working by accident.
+jq -e '.mcpServers.overclick.transport == "http" and (.mcpServers.overclick | has("type") | not)' \
+  "$REPO_ROOT/plugin/kimi.plugin.json" >/dev/null
+# Kimi finds a plugin root only in an archive root or a single child directory, so a
+# repository install needs a root manifest pointing into ./plugin/. It carries no
+# mcpServers: a registry install cannot know the instance URL, and Kimi drops an
+# unresolvable url silently.
+jq -e '(.skills | index("./plugin/skills/overclick")) and .commands == "./plugin/commands"
+  and (.hooks | length == 6) and (.hooks | all(.command | startswith("./plugin/hooks/")))
+  and (has("mcpServers") | not)' \
+  "$REPO_ROOT/.kimi-plugin/plugin.json" >/dev/null
 jq -e '.hooks | keys | sort == ["PostToolUse", "PreToolUse", "SessionStart", "Stop"]' \
   "$REPO_ROOT/plugin/hooks/hooks.json" >/dev/null
 jq -e '(.hooks.PostToolUse | length == 2) and (.hooks.PreToolUse | length == 2)' \
@@ -74,6 +86,17 @@ test "$(grep -c 'claim-guard.sh' "$TEST_ROOT/home/.codex/hooks.json" || true)" -
 test "$(grep -c '^enforce_claim=0$' "$TEST_ROOT/home/.config/overclick/config")" -eq 1
 test "$(grep -c '^token=' "$TEST_ROOT/home/.config/overclick/config")" -eq 1
 test "$(stat -f '%Lp' "$TEST_ROOT/home/.config/overclick/config" 2>/dev/null || stat -c '%a' "$TEST_ROOT/home/.config/overclick/config")" -eq 600
+
+# Kimi has no non-interactive plugin subcommand, so install.sh writes its registry
+# directly. Running twice must leave exactly one entry, and the installed copy must
+# carry a resolved url: Kimi validates it and silently drops the server otherwise.
+test "$(jq -r '[.plugins[] | select(.id == "overclick")] | length' \
+  "$TEST_ROOT/home/.kimi-code/plugins/installed.json")" -eq 1
+jq -e '.mcpServers.overclick.transport == "http"
+  and (.mcpServers.overclick.url | startswith("$") | not)' \
+  "$TEST_ROOT/home/.kimi-code/plugins/managed/overclick/kimi.plugin.json" >/dev/null
+test -x "$TEST_ROOT/home/.kimi-code/plugins/managed/overclick/hooks/claim-guard.sh"
+
 sed -i.bak 's/enforce_claim=0/enforce_claim=1/' "$TEST_ROOT/home/.config/overclick/config"
 run_installer
 test "$(grep -c '^enforce_claim=1$' "$TEST_ROOT/home/.config/overclick/config")" -eq 1


### PR DESCRIPTION
OCL-49 filled in the Kimi column from documentation, because the binary was not on that machine. Kimi Code 0.37.2 is on this one, so the column finally got checked. Three things it claimed were wrong.

**The MCP server was silently dropped.** Kimi discriminates transports on `transport`, not `type`. Our `type` key was thrown away by the parser, which then re-inferred `http` from the `url` — so it worked, by accident. The real problem sat one line below: Kimi validates that url and does **not** expand `${OVERCLICK_URL}`. The entry failed validation, the server was dropped, and the plugin still reported `state: ok` with `hasErrors: false`. A board plugin with no board, reporting success.

**The installer's Kimi path could never have worked.** There is no `kimi plugin` subcommand. `/plugins install` is a host slash command, and `--prompt` hands slash commands to the model instead of the host — `--prompt` also refuses to combine with `--auto` outright (`error: Cannot combine --prompt with --auto`). So `kimi --auto --prompt "/plugins install ..."` failed on argument parsing every time, in every version, and `quiet_try` turned that into a one-line warning. install.sh now writes Kimi's registry the way Kimi's own manager does: copy to `plugins/managed/overclick`, register in `plugins/installed.json`, leave other plugins alone.

**A repository install could not find the plugin.** Kimi resolves the plugin root from the archive root or one single child directory, never deeper, so `plugin/kimi.plugin.json` was unreachable from GitHub — the exact path a marketplace entry uses. The new root `.kimi-plugin/plugin.json` points into `./plugin/` and deliberately omits `mcpServers`: a registry install cannot know the user's instance URL, and a placeholder would be dropped in silence.

## Verified against the running CLI

- `install.sh` output loads with skill, 6 hooks, 5 commands and the MCP server **enabled**.
- A live `kimi` session resolves the skill and the board tools (namespaced `mcp__plugin-overclick_overclick__task_*`, which the existing `mcp__.*__task_claim` matchers still cover).
- Installing straight from this branch on GitHub now succeeds (`manifestKind: kimi-plugin-dir`); the same call against `main` fails with *No manifest at kimi.plugin.json or .kimi-plugin/plugin.json*.
- The new assertions in `scripts/test-plugin-package.sh` were confirmed to fail when `transport` or the root manifest regresses.

Testing used an isolated `KIMI_CODE_HOME`; the owner's Kimi install was not modified.

## Registry

The official registry is real — `https://code.kimi.com/kimi-code/plugins/marketplace.json`, browsable with `/plugins marketplace`, tiers `official` and `curated`. Its catalog is the public `MoonshotAI/kimi-code` repo at `plugins/marketplace.json`, so submission is a PR against that file. The entry to submit is in `docs/design/plugin.md`; publishing is the owner's call and is not part of this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)