### PR TITLE
[OCL-107] antigravity: native plugin via agy CLI — all 5 components install

### DIFF
--- a/docs/design/plugin.md
+++ b/docs/design/plugin.md
@@ -9,14 +9,15 @@ in OCL-49 and the owner's final decisions. It replaces the discarded OCL-47 desi
 workflow source; the bundled skill points to it instead of maintaining a second copy.
 Provider manifests adapt that same package to each native loader.
 
-| Capability | Claude Code | Grok CLI | Kimi Code | Codex |
-| --- | --- | --- | --- | --- |
-| Manifest | `.claude-plugin/plugin.json` | `plugin.json` | `kimi.plugin.json` (package root) or `.kimi-plugin/plugin.json` (repository root) | `.codex-plugin/plugin.json` |
-| Repository marketplace | `.claude-plugin/marketplace.json` | `.grok-plugin/marketplace.json` | Official registry (`curated` tier) plus native custom install | Installer-created local marketplace |
-| Skill | `skills/overclick/SKILL.md` | Same | Same | Same |
-| Commands | Auto-discovered `commands/` | Auto-discovered `commands/` | `commands` manifest field | Skill-driven; not declared in the manifest |
-| MCP | `.mcp.json` plus native user config | `.mcp.json` plus native user config | `mcpServers` plus private user config | `mcpServers` manifest field plus `[mcp_servers]` user config |
-| Hooks | `hooks/hooks.json` | `hooks/hooks.json` | `hooks` manifest field | Global lifecycle hooks, but no client-side claim guard; deliberately absent from the plugin manifest |
+| Capability | Claude Code | Grok CLI | Kimi Code | Codex | Antigravity (`agy`) |
+| --- | --- | --- | --- | --- | --- |
+| Manifest | `.claude-plugin/plugin.json` | `plugin.json` | `kimi.plugin.json` (package root) or `.kimi-plugin/plugin.json` (repository root) | `.codex-plugin/plugin.json` | `plugin.json` (shared with Grok) |
+| Repository marketplace | `.claude-plugin/marketplace.json` | `.grok-plugin/marketplace.json` | Official registry (`curated` tier) plus native custom install | Installer-created local marketplace | No public registry; installs from a directory or a GitHub subpath |
+| Skill | `skills/overclick/SKILL.md` | Same | Same | Same | Same |
+| Commands | Auto-discovered `commands/` | Auto-discovered `commands/` | `commands` manifest field | Skill-driven; not declared in the manifest | Auto-discovered `commands/`, converted to namespaced skills |
+| MCP | `.mcp.json` plus native user config | `.mcp.json` plus native user config | `mcpServers` plus private user config | `mcpServers` manifest field plus `[mcp_servers]` user config | `mcp_config.json` in the plugin (`serverUrl` + `headers`) |
+| Hooks | `hooks/hooks.json` | `hooks/hooks.json` | `hooks` manifest field | Global lifecycle hooks, but no client-side claim guard; deliberately absent from the plugin manifest | `hooks.json` at the plugin root, dispatched through `hooks/antigravity.sh` |
+| Memory | `@` import in `~/.claude/CLAUDE.md` | Bundled skill only | Bundled skill only | Bundled skill only | `rules/AGENTS.md` inside the plugin, loaded whenever the plugin is enabled |
 
 The Codex manifest contains only the skill and MCP contributions. Its installer
 uses the native marketplace manager, then writes the required user MCP block and
@@ -60,7 +61,13 @@ contains the board URL or token.
 
 The repository root `install.sh` is also served verbatim by `GET /install.sh`.
 It uses a hidden token prompt in interactive mode, detects installed CLIs, and calls
-their native plugin managers. The stable package copy and a mode-600 config live in
+their native plugin managers. Antigravity is detected as `agy` on PATH or at
+`~/.local/bin/agy`, where its own installer puts it. Because `agy plugin install`
+copies the directory it is handed, the installer stages a private copy under
+`<config root>/overclick/antigravity/overclick`, writes the credentials and the
+resolved `OVERCLICK.md` path into that copy, installs it, and re-checks the
+mode-600 permission on the materialized `mcp_config.json`. The repository package
+stays a generic template. The stable package copy and a mode-600 config live in
 the user's configuration area. Provider MCP config is updated idempotently; Codex gets
 an explicit `[mcp_servers.overclick]` block and merged global hooks.
 
@@ -204,10 +211,67 @@ The entry to submit, once the owner decides to publish:
 }
 ```
 
+## Antigravity, validated hands-on (OCL-107)
+
+OCL-49 never covered Antigravity. It is validated here against `agy` on the
+owner's machine (binary at `~/.local/bin/agy`, customization docs bundled as
+the built-in `agy-customizations` skill). Antigravity has a first-class plugin system —
+`agy plugin install|uninstall|list|enable|disable|validate` — and all five
+components the board needs load from a single directory, so it gets the native
+path, not the AGENTS.md fallback.
+
+`agy plugin install <dir>` copies the directory into
+`~/.gemini/config/plugins/<name>/` and ingests `skills/`, `commands/`,
+`mcp_config.json`, `hooks.json`, and `rules/`. A GitHub subpath works too:
+`agy plugin install https://github.com/ustoppble/overclick/tree/main/plugin`
+clones and installs the same package. `agy plugin validate <dir>` reports what
+each component contributed and is the cheapest pre-flight check.
+
+Four dialect differences are absorbed by `plugin/hooks/antigravity.sh` rather
+than by forking the shared hooks, all confirmed by probing a live `agy` session:
+
+1. Tool names are Antigravity step types — `run_command`, `write_to_file`,
+   `replace_file_content`, `view_file`, `call_mcp_tool` — and every MCP call
+   arrives as `call_mcp_tool` with the real tool under
+   `toolCall.args.ToolName` and its input under `toolCall.args.Arguments`. A
+   matcher alone cannot single out `task_claim`; the adapter reads the payload.
+2. `PreToolUse` must answer with an explicit decision. An empty object is read
+   as a denial — a hook that stays quiet blocks the agent — so the adapter
+   always emits `allow`, `deny`, or `ask`, and fails open when it cannot parse
+   its input.
+3. `PostToolUse` carries the call and an `error` string but never the tool
+   response. The claim marker is therefore written from the call arguments, and
+   the post-delivery remote check moves ahead of `task_deliver` as an `ask`,
+   since after the fact there is no channel back to the model.
+4. Hooks start in the plugin directory and `workspacePaths` is empty in print
+   mode, so the repository is recovered from the path the call mentions
+   (`TargetFile`, `Cwd`) and resolved with `git rev-parse --show-toplevel`.
+   `OVERCLICK_WORKSPACE` overrides it.
+
+There is no `SessionStart`. `PreInvocation` is the closest event and fires on
+every model call, so the snapshot is gated on `invocationNum == 0` and returned
+as `{"injectSteps": [{"ephemeralMessage": ...}]}`.
+
+MCP uses `serverUrl` plus `headers`, which the bundled `mcp_servers.md` does not
+document but `agy mcp add --header "Authorization: Bearer …" <name> <url>`
+writes verbatim; install.sh emits that same shape into the staged copy.
+
+### Official registry and submission
+
+There is nothing to submit to, and that is a finding rather than a blocker.
+`agy plugin link` and the `plugin@marketplace` form resolve names against a
+Google-hosted, server-side customization catalog
+(`SearchMarketplaceCustomizations`); every name tried was rejected as
+`unknown marketplace`, and neither the CLI nor the bundled docs expose a
+submission endpoint. Distribution is therefore the directory install that
+install.sh performs, or the GitHub subpath form for a manual install.
+
 ## Verification contract
 
 - Validate all JSON manifests and both provider validators.
 - Validate the Codex plugin and the OverClick skill with their official local tools.
+- Run `agy plugin validate plugin/`; skills, commands, mcpServers, and hooks must all
+  report as processed.
 - Run the installer twice against an isolated home with stub native managers; markers,
   MCP entries, and hook rules must remain singular and private input must not appear in
   output.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -10,7 +10,7 @@ Takes about 10 minutes.
   Linux: your distro's `docker` + `docker-compose-plugin` packages;
   Windows: Docker Desktop with WSL2.
 - An MCP-capable coding agent on your machine: Claude Code, Codex CLI, Gemini CLI,
-  [Overclock](https://overclock.sh), or any MCP client
+  Antigravity (`agy`), [Overclock](https://overclock.sh), or any MCP client
 
 ## 1. Run the board
 

--- a/install.sh
+++ b/install.sh
@@ -275,6 +275,14 @@ if mode in ("mcp", "mcp-kimi"):
         "url": os.environ["OC_MCP_URL"],
         "headers": {"Authorization": "Bearer " + os.environ["OC_MCP_TOKEN"]},
     }
+elif mode == "mcp-antigravity":
+    # Antigravity names the remote transport `serverUrl` and has no `type`
+    # field; `agy mcp add --header ... <url>` writes exactly this shape.
+    data.setdefault("mcpServers", {})["overclick"] = {
+        "serverUrl": os.environ["OC_MCP_URL"],
+        "headers": {"Authorization": "Bearer " + os.environ["OC_MCP_TOKEN"]},
+        "disabled": False,
+    }
 elif mode in ("hooks", "hooks-no-claim-guard"):
     source = json.loads(pathlib.Path(os.environ["OC_HOOK_SOURCE"]).read_text())
     target = os.environ["OC_PLUGIN_TARGET"]
@@ -317,6 +325,13 @@ if (process.env.OC_JSON_MODE === "mcp" || process.env.OC_JSON_MODE === "mcp-kimi
     [process.env.OC_JSON_MODE === "mcp-kimi" ? "transport" : "type"]: "http",
     url: process.env.OC_MCP_URL,
     headers: { Authorization: "Bearer " + process.env.OC_MCP_TOKEN },
+  };
+} else if (process.env.OC_JSON_MODE === "mcp-antigravity") {
+  data.mcpServers ??= {};
+  data.mcpServers.overclick = {
+    serverUrl: process.env.OC_MCP_URL,
+    headers: { Authorization: "Bearer " + process.env.OC_MCP_TOKEN },
+    disabled: false,
   };
 } else {
   const source = JSON.parse(fs.readFileSync(process.env.OC_HOOK_SOURCE, "utf8"));
@@ -362,6 +377,11 @@ if [[ -n "${OVERCLICK_CLIS:-}" ]]; then
   detected_clis=",${OVERCLICK_CLIS// /},"
 else
   detected_clis=","
+  # Antigravity ships its CLI as `agy`, and its own installer puts it in
+  # ~/.local/bin, which is not always on PATH for a non-login shell.
+  if command -v agy >/dev/null 2>&1 || [[ -x "$install_home/.local/bin/agy" ]]; then
+    detected_clis+="agy,"
+  fi
   for candidate in claude codex grok kimi; do
     if command -v "$candidate" >/dev/null 2>&1; then
       detected_clis+="$candidate,"
@@ -599,8 +619,46 @@ if has_cli kimi; then
   fi
 fi
 
+if has_cli agy; then
+  if command -v agy >/dev/null 2>&1; then
+    agy_bin=agy
+  else
+    agy_bin="$install_home/.local/bin/agy"
+  fi
+  # `agy plugin install` copies the directory it is given into
+  # ~/.gemini/config/plugins/<name>, so the staged copy is what carries the
+  # credentials and the resolved rule path, and the repository package stays a
+  # generic template.
+  agy_stage="$overclick_root/antigravity/overclick"
+  agy_installed="$install_home/.gemini/config/plugins/overclick"
+  rm -rf -- "$agy_stage"
+  mkdir -p "$agy_stage"
+  cp -R "$plugin_target/." "$agy_stage/"
+  merge_json_config mcp-antigravity "$agy_stage/mcp_config.json"
+  chmod 600 "$agy_stage/mcp_config.json"
+  agy_rule_block=$(printf '%s\n' '<!-- overclick:start -->' \
+    "Read and follow $agy_installed/OVERCLICK.md for all OverClick board work." \
+    '<!-- overclick:end -->')
+  replace_marked_block "$agy_stage/rules/AGENTS.md" "$agy_rule_block"
+  quiet_try "Antigravity plugin" "$agy_bin" plugin install "$agy_stage"
+  "$agy_bin" plugin enable overclick >/dev/null 2>&1 || true
+  # The manager copies the staged directory, so the credentials land in a second
+  # place and need the same mode-600 the staged copy already has.
+  if [[ -f "$agy_installed/mcp_config.json" ]]; then
+    chmod 600 "$agy_installed/mcp_config.json"
+  fi
+
+  if "$agy_bin" plugin list 2>/dev/null | grep -q '"overclick"' && \
+    [[ -f "$agy_installed/OVERCLICK.md" ]]; then
+    printf '%s\n' "Antigravity plugin verified: imported and materialized at $agy_installed."
+  else
+    printf '%s\n' "Antigravity plugin did not materialize: 'agy plugin list' shows no overclick entry with OVERCLICK.md on disk. Retry or install manually." >&2
+    validation_failed=1
+  fi
+fi
+
 if [[ "${OVERCLICK_AGENTS_FALLBACK:-0}" = "1" ]] || \
-  { ! has_cli claude && ! has_cli codex && ! has_cli grok && ! has_cli kimi; }; then
+  { ! has_cli claude && ! has_cli codex && ! has_cli grok && ! has_cli kimi && ! has_cli agy; }; then
   agents_block=$(printf '%s\n' '<!-- overclick:start -->' "Read and follow $plugin_target/OVERCLICK.md for all OverClick board work." '<!-- overclick:end -->')
   replace_marked_block "$project_dir/AGENTS.md" "$agents_block"
   printf '%s\n' "No plugin-capable CLI was detected; the AGENTS.md fallback was installed."

--- a/plugin/OVERCLICK.md
+++ b/plugin/OVERCLICK.md
@@ -148,6 +148,18 @@ claim leases expire when abandoned, and the delivery verification introduced by
 OCL-23 rejects unverifiable delivery evidence. This limitation is why the guard
 must not be described as universal enforcement.
 
+Antigravity (`agy`) runs every hook through `hooks/antigravity.sh`, which
+translates its dialect into the shared scripts. Three behaviours differ there:
+the board snapshot rides on `PreInvocation` gated to the first model call,
+because Antigravity has no `SessionStart`; the post-delivery remote check runs
+*before* `task_deliver` and answers `ask` instead of reporting afterwards,
+because Antigravity's `PostToolUse` carries no tool response and therefore has
+no way to tell the model anything; and the claim marker is written from the call
+arguments, for the same reason. Antigravity also leaves `workspacePaths` empty
+in print mode, so the repository is recovered from the path the call itself
+mentions — set `OVERCLICK_WORKSPACE` to pin it when a session edits nothing
+under the repository root.
+
 The motivating incident happened on 2026-08-19: a Kimi worker executed OCL-37
 without claiming it, leaving the card `aberto` while real work was already in
 progress and therefore invisible to the board.

--- a/plugin/hooks.json
+++ b/plugin/hooks.json
@@ -1,0 +1,52 @@
+{
+  "overclick": {
+    "PreInvocation": [
+      {
+        "type": "command",
+        "command": "./hooks/antigravity.sh pre-invocation",
+        "timeout": 20
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "call_mcp_tool",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "./hooks/antigravity.sh pre-tool",
+            "timeout": 30
+          }
+        ]
+      },
+      {
+        "matcher": "run_command|write_to_file|replace_file_content|edit_notebook",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "./hooks/antigravity.sh pre-tool",
+            "timeout": 20
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "call_mcp_tool",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "./hooks/antigravity.sh post-tool",
+            "timeout": 20
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "type": "command",
+        "command": "./hooks/antigravity.sh stop",
+        "timeout": 20
+      }
+    ]
+  }
+}

--- a/plugin/hooks/antigravity.sh
+++ b/plugin/hooks/antigravity.sh
@@ -1,0 +1,256 @@
+#!/bin/sh
+# Antigravity (`agy`) speaks a different hook dialect than the other CLIs, so
+# this adapter is the only Antigravity-specific piece: it rewrites the incoming
+# payload into the shape the shared OverClick hooks already understand, runs
+# them unchanged, and rewrites their answer back.
+#
+# Differences that forced an adapter, all verified hands-on against agy:
+#   * tool names are Antigravity step types (run_command, write_to_file,
+#     replace_file_content, call_mcp_tool), and every MCP call arrives as
+#     call_mcp_tool with the real tool under toolCall.args.ToolName;
+#   * PreToolUse must answer with an explicit decision — an empty object is
+#     read as a denial, so silence is not an option;
+#   * PostToolUse never carries the tool response, only the call and an error
+#     string, so anything that needed the response has to read the arguments;
+#   * SessionStart does not exist; PreInvocation is the closest event and it
+#     fires on every model call, so the snapshot is gated on invocationNum 0;
+#   * hooks run with the plugin directory as their working directory, so the
+#     repository has to be recovered from the payload.
+set -eu
+
+SCRIPT_DIR=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/common.sh"
+
+event=${1:-}
+payload=$(cat)
+
+# Fail open. A guard that cannot parse its input must not become a wall between
+# the agent and the repository; the board still enforces the same rules.
+oc_agy_allow() {
+  printf '%s\n' '{"decision":"allow"}'
+  exit 0
+}
+
+oc_agy_normalize() {
+  if command -v python3 >/dev/null 2>&1; then
+    OC_AGY_WORKSPACE=${OVERCLICK_WORKSPACE:-} python3 -c '
+import json, os, sys
+
+try:
+    data = json.load(sys.stdin)
+except ValueError:
+    data = {}
+
+call = data.get("toolCall") or {}
+args = call.get("args") or {}
+agy_tool = call.get("name") or ""
+
+if agy_tool == "call_mcp_tool":
+    tool_name = args.get("ToolName") or ""
+    tool_input = args.get("Arguments") or {}
+elif agy_tool == "run_command":
+    tool_name = "Bash"
+    tool_input = {"command": args.get("CommandLine") or ""}
+elif agy_tool == "write_to_file":
+    tool_name = "Write"
+    tool_input = {"file_path": args.get("TargetFile") or ""}
+elif agy_tool in ("replace_file_content", "edit_notebook"):
+    tool_name = "Edit"
+    tool_input = {"file_path": args.get("TargetFile") or ""}
+else:
+    tool_name = agy_tool
+    tool_input = {}
+
+workspaces = data.get("workspacePaths") or []
+hint = workspaces[0] if workspaces else ""
+if not hint:
+    hint = os.environ.get("OC_AGY_WORKSPACE", "")
+if not hint:
+    target = args.get("TargetFile") or ""
+    hint = os.path.dirname(target) if target else ""
+if not hint:
+    hint = args.get("Cwd") or ""
+
+print(json.dumps({
+    "tool_name": tool_name,
+    "agy_tool": agy_tool,
+    "session_id": data.get("conversationId") or "",
+    "cwd": "",
+    "tool_input": tool_input,
+    "tool_response": {},
+    "invocation_num": data.get("invocationNum") or 0,
+    "error": data.get("error") or "",
+    "termination_reason": data.get("terminationReason") or "",
+    "workspace_hint": hint,
+}, separators=(",", ":")))
+'
+    return
+  fi
+
+  if command -v node >/dev/null 2>&1; then
+    # shellcheck disable=SC2016
+    OC_AGY_WORKSPACE=${OVERCLICK_WORKSPACE:-} node -e '
+let raw="";process.stdin.on("data",c=>raw+=c).on("end",()=>{
+ let d={};try{d=JSON.parse(raw)}catch{}
+ const call=d.toolCall??{},args=call.args??{},agy=call.name??"";
+ let toolName,toolInput;
+ if(agy==="call_mcp_tool"){toolName=args.ToolName??"";toolInput=args.Arguments??{};}
+ else if(agy==="run_command"){toolName="Bash";toolInput={command:args.CommandLine??""};}
+ else if(agy==="write_to_file"){toolName="Write";toolInput={file_path:args.TargetFile??""};}
+ else if(agy==="replace_file_content"||agy==="edit_notebook"){toolName="Edit";toolInput={file_path:args.TargetFile??""};}
+ else {toolName=agy;toolInput={};}
+ let hint=(d.workspacePaths??[])[0]??"";
+ if(!hint) hint=process.env.OC_AGY_WORKSPACE??"";
+ if(!hint&&args.TargetFile) hint=require("node:path").dirname(args.TargetFile);
+ if(!hint) hint=args.Cwd??"";
+ console.log(JSON.stringify({tool_name:toolName,agy_tool:agy,session_id:d.conversationId??"",cwd:"",
+  tool_input:toolInput,tool_response:{},invocation_num:d.invocationNum??0,error:d.error??"",
+  termination_reason:d.terminationReason??"",workspace_hint:hint}));
+});'
+    return
+  fi
+
+  return 1
+}
+
+oc_agy_field() {
+  oc_agy_key=$1
+  if command -v python3 >/dev/null 2>&1; then
+    OC_AGY_KEY=$oc_agy_key python3 -c '
+import json, os, sys
+try:
+    print(json.load(sys.stdin).get(os.environ["OC_AGY_KEY"], ""))
+except ValueError:
+    print("")
+'
+    return
+  fi
+  if command -v node >/dev/null 2>&1; then
+    # shellcheck disable=SC2016
+    OC_AGY_KEY=$oc_agy_key node -e '
+let raw="";process.stdin.on("data",c=>raw+=c).on("end",()=>{
+ try{console.log(JSON.parse(raw)[process.env.OC_AGY_KEY]??"")}catch{console.log("")}});'
+    return
+  fi
+  printf '\n'
+}
+
+# The claim marker belongs next to the code, not next to the plugin. Antigravity
+# leaves workspacePaths empty in print mode, so the repository is recovered from
+# whatever path the call itself mentioned.
+oc_agy_repo_root() {
+  oc_agy_hint=$1
+  [ -n "$oc_agy_hint" ] || return 1
+  [ -d "$oc_agy_hint" ] || oc_agy_hint=$(dirname -- "$oc_agy_hint")
+  [ -d "$oc_agy_hint" ] || return 1
+  git -C "$oc_agy_hint" rev-parse --show-toplevel 2>/dev/null || printf '%s' "$oc_agy_hint"
+}
+
+oc_agy_reason() {
+  oc_agy_text=$1
+  printf '%s' "$oc_agy_text" | tr '\n' ' ' | sed -e 's/.*"reason"[[:space:]]*:[[:space:]]*"//' -e 's/".*//'
+}
+
+oc_agy_escape() {
+  printf '%s' "$1" | tr '\n' ' ' | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g'
+}
+
+normalized=$(printf '%s' "$payload" | oc_agy_normalize 2>/dev/null || true)
+if [ -z "$normalized" ]; then
+  case "$event" in
+    pre-tool) oc_agy_allow ;;
+    *) printf '%s\n' '{}'; exit 0 ;;
+  esac
+fi
+
+workspace_hint=$(printf '%s' "$normalized" | oc_agy_field workspace_hint 2>/dev/null || true)
+repo_root=$(oc_agy_repo_root "$workspace_hint" 2>/dev/null || true)
+if [ -n "$repo_root" ] && command -v python3 >/dev/null 2>&1; then
+  normalized=$(printf '%s' "$normalized" | OC_AGY_ROOT=$repo_root python3 -c '
+import json, os, sys
+data = json.load(sys.stdin)
+data["cwd"] = os.environ["OC_AGY_ROOT"]
+print(json.dumps(data, separators=(",", ":")))
+')
+elif [ -n "$repo_root" ] && command -v node >/dev/null 2>&1; then
+  # shellcheck disable=SC2016
+  normalized=$(printf '%s' "$normalized" | OC_AGY_ROOT=$repo_root node -e '
+let raw="";process.stdin.on("data",c=>raw+=c).on("end",()=>{
+ const d=JSON.parse(raw);d.cwd=process.env.OC_AGY_ROOT;console.log(JSON.stringify(d));});')
+fi
+
+tool_name=$(printf '%s' "$normalized" | oc_agy_field tool_name 2>/dev/null || true)
+tool_error=$(printf '%s' "$normalized" | oc_agy_field error 2>/dev/null || true)
+
+case "$event" in
+  pre-invocation)
+    invocation=$(printf '%s' "$normalized" | oc_agy_field invocation_num 2>/dev/null || printf '1')
+    [ "$invocation" = "0" ] || { printf '%s\n' '{}'; exit 0; }
+    snapshot=$(sh "$SCRIPT_DIR/session-start.sh" </dev/null 2>/dev/null || true)
+    [ -n "$snapshot" ] || { printf '%s\n' '{}'; exit 0; }
+    printf '{"injectSteps":[{"ephemeralMessage":"%s"}]}\n' "$(oc_agy_escape "$snapshot")"
+    ;;
+
+  pre-tool)
+    case "$tool_name" in
+      task_create|mcp__*__task_create)
+        verdict=$(printf '%s' "$normalized" | sh "$SCRIPT_DIR/pre-create.sh" 2>/dev/null || true)
+        case "$verdict" in
+          *'"decision":"block"'*)
+            printf '{"decision":"deny","reason":"%s"}\n' "$(oc_agy_escape "$(oc_agy_reason "$verdict")")"
+            ;;
+          *) oc_agy_allow ;;
+        esac
+        ;;
+      task_deliver|mcp__*__task_deliver)
+        # Antigravity's PostToolUse has no channel back to the model, so the
+        # push check moves ahead of the call. It asks instead of denying: the
+        # blocking guards stay opt-in, and the human keeps the last word.
+        # post-deliver.sh inspects the repository through its own working
+        # directory, and Antigravity starts hooks in the plugin directory.
+        if complaint=$(cd "${repo_root:-.}" && printf '%s' "$normalized" | sh "$SCRIPT_DIR/post-deliver.sh" 2>&1 >/dev/null); then
+          oc_agy_allow
+        else
+          [ -n "$complaint" ] || complaint="OverClick could not verify the delivered commit."
+          printf '{"decision":"ask","reason":"%s"}\n' "$(oc_agy_escape "$complaint")"
+        fi
+        ;;
+      Bash|Edit|Write)
+        verdict=$(printf '%s' "$normalized" | sh "$SCRIPT_DIR/claim-guard.sh" 2>/dev/null || true)
+        case "$verdict" in
+          *'"decision":"block"'*)
+            printf '{"decision":"deny","reason":"%s"}\n' "$(oc_agy_escape "$(oc_agy_reason "$verdict")")"
+            ;;
+          *) oc_agy_allow ;;
+        esac
+        ;;
+      *) oc_agy_allow ;;
+    esac
+    ;;
+
+  post-tool)
+    if [ -z "$tool_error" ]; then
+      case "$tool_name" in
+        task_claim|mcp__*__task_claim|task_deliver|mcp__*__task_deliver|task_release|mcp__*__task_release)
+          printf '%s' "$normalized" | sh "$SCRIPT_DIR/claim-guard.sh" >/dev/null 2>&1 || true
+          ;;
+      esac
+    fi
+    printf '%s\n' '{}'
+    ;;
+
+  stop)
+    verdict=$(printf '%s' "$normalized" | sh "$SCRIPT_DIR/stop-guard.sh" 2>/dev/null || true)
+    case "$verdict" in
+      *'"decision":"block"'*)
+        printf '{"decision":"continue","reason":"%s"}\n' "$(oc_agy_escape "$(oc_agy_reason "$verdict")")"
+        ;;
+      *) printf '%s\n' '{}' ;;
+    esac
+    ;;
+
+  *)
+    printf '%s\n' '{}'
+    ;;
+esac

--- a/plugin/mcp_config.json
+++ b/plugin/mcp_config.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "overclick": {
+      "serverUrl": "${OVERCLICK_URL}",
+      "headers": {
+        "Authorization": "Bearer ${OVERCLICK_TOKEN}"
+      },
+      "disabled": false
+    }
+  }
+}

--- a/plugin/rules/AGENTS.md
+++ b/plugin/rules/AGENTS.md
@@ -1,0 +1,3 @@
+<!-- overclick:start -->
+Read and follow ${OVERCLICK_PLUGIN_ROOT}/OVERCLICK.md for all OverClick board work.
+<!-- overclick:end -->

--- a/scripts/test-plugin-package.sh
+++ b/scripts/test-plugin-package.sh
@@ -75,6 +75,9 @@ if [ "${1:-}" = "plugin" ] && [ "${2:-}" = "list" ]; then
     claude)
       printf '[{"id":"overclick@overclick","enabled":true,"installPath":"%s"}]' "$OC_TEST_CLAUDE_CACHE"
       ;;
+    # OCL-104 gave Codex the same "ask the CLI what it holds" check Claude has,
+    # in its own listing shape. Without an answer here the stub reports an
+    # install that never materialized and the whole suite fails on that.
     codex)
       printf '{"installed":[{"name":"overclick","installed":true,"enabled":true,"source":{"path":"%s"}}]}' "$OC_TEST_CODEX_CACHE"
       ;;
@@ -86,6 +89,27 @@ chmod +x "$TEST_ROOT/bin/agent-stub"
 for cli in claude codex grok kimi; do
   ln -s agent-stub "$TEST_ROOT/bin/$cli"
 done
+
+# Antigravity's manager copies the directory it is handed into
+# ~/.gemini/config/plugins/<name>, and install.sh then re-checks the mode of the
+# credentials that landed in that second copy. A stub that only exits 0 would
+# leave both the copy and that check untested, so it copies like the real one.
+cat >"$TEST_ROOT/bin/agy" <<'SH'
+#!/bin/sh
+printf '%s:%s:%s\n' agy "${1:-}" "${2:-}" >>"$OC_TEST_NATIVE_LOG"
+plugins="$OVERCLICK_INSTALL_HOME/.gemini/config/plugins"
+case "${1:-}:${2:-}" in
+  plugin:install)
+    mkdir -p "$plugins/overclick"
+    cp -R "$3/." "$plugins/overclick/"
+    ;;
+  plugin:list)
+    [ -d "$plugins/overclick" ] && printf '{"imports":[{"name":"overclick","source":"antigravity"}]}'
+    ;;
+esac
+exit 0
+SH
+chmod +x "$TEST_ROOT/bin/agy"
 
 cat >"$TEST_ROOT/home/.codex/hooks.json" <<'JSON'
 {
@@ -109,7 +133,7 @@ run_installer() {
   OVERCLICK_PROJECT_DIR="$TEST_ROOT/project" \
   OVERCLICK_INSTANCE_URL="$FIXTURE_URL" \
   OVERCLICK_TOKEN="fixture" \
-  OVERCLICK_CLIS="claude,codex,grok,kimi" \
+  OVERCLICK_CLIS="claude,codex,grok,kimi,agy" \
     "$REPO_ROOT/install.sh" >"$TEST_ROOT/install.out" 2>"$TEST_ROOT/install.err"
 }
 
@@ -139,6 +163,44 @@ jq -e '.mcpServers.overclick.transport == "http"
   and (.mcpServers.overclick.url | startswith("$") | not)' \
   "$TEST_ROOT/home/.kimi-code/plugins/managed/overclick/kimi.plugin.json" >/dev/null
 test -x "$TEST_ROOT/home/.kimi-code/plugins/managed/overclick/hooks/claim-guard.sh"
+
+# Antigravity gets the package through its own manager, so what has to hold is
+# what the manager ends up holding: the MCP shape it actually parses
+# (serverUrl + headers, no "type"), a resolved url rather than the repository
+# template, the rule pointing at the OVERCLICK.md that exists on disk, and a
+# second copy of the credentials that is no more readable than the first.
+agy_plugin="$TEST_ROOT/home/.gemini/config/plugins/overclick"
+jq -e '(.mcpServers.overclick.serverUrl | startswith("$") | not)
+  and .mcpServers.overclick.headers.Authorization
+  and (.mcpServers.overclick | has("type") | not)' \
+  "$agy_plugin/mcp_config.json" >/dev/null
+test "$(stat -f '%Lp' "$agy_plugin/mcp_config.json" 2>/dev/null || stat -c '%a' "$agy_plugin/mcp_config.json")" -eq 600
+test "$(grep -c '<!-- overclick:start -->' "$agy_plugin/rules/AGENTS.md")" -eq 1
+grep -Fq "$agy_plugin/OVERCLICK.md" "$agy_plugin/rules/AGENTS.md"
+test -f "$agy_plugin/OVERCLICK.md"
+test -x "$agy_plugin/hooks/antigravity.sh"
+jq -e '.overclick | (.PreToolUse | length == 2) and (.PostToolUse | length == 1)
+  and .PreInvocation and .Stop' "$agy_plugin/hooks.json" >/dev/null
+# The repository package stays a generic template: only the installed copy is
+# allowed to carry an instance.
+jq -e '.mcpServers.overclick.serverUrl == "${OVERCLICK_URL}"' \
+  "$REPO_ROOT/plugin/mcp_config.json" >/dev/null
+
+# A PreToolUse hook that answers with an empty object is read by Antigravity as
+# a denial, so the adapter has to speak on every path — including the one where
+# there is no JSON runtime to read the payload with at all. That branch is only
+# reachable with python3 and node off PATH, which is why it gets its own PATH.
+mkdir -p "$TEST_ROOT/nojson"
+for utility in sh grep sed tr cat dirname printf git; do
+  target=$(command -v "$utility" 2>/dev/null) && ln -sf "$target" "$TEST_ROOT/nojson/$utility"
+done
+agy_hook() { (cd "$agy_plugin" && printf '%s' "$3" | PATH="$1" sh ./hooks/antigravity.sh "$2"); }
+for agy_path in "$PATH" "$TEST_ROOT/nojson"; do
+  printf '%s' "$(agy_hook "$agy_path" pre-tool 'not json')" | grep -Fq '"decision":'
+  printf '%s' "$(agy_hook "$agy_path" pre-tool '{"toolCall":{"name":"run_command","args":{"CommandLine":"ls"}}}')" |
+    grep -Fq '"decision":"allow"'
+done
+printf '%s' "$(agy_hook "$PATH" pre-invocation '{"invocationNum":3}')" | grep -Fq '{}'
 
 sed -i.bak 's/enforce_claim=0/enforce_claim=1/' "$TEST_ROOT/home/.config/overclick/config"
 run_installer

--- a/scripts/test-plugin-package.sh
+++ b/scripts/test-plugin-package.sh
@@ -174,7 +174,7 @@ jq -e '(.mcpServers.overclick.serverUrl | startswith("$") | not)
   and .mcpServers.overclick.headers.Authorization
   and (.mcpServers.overclick | has("type") | not)' \
   "$agy_plugin/mcp_config.json" >/dev/null
-test "$(stat -f '%Lp' "$agy_plugin/mcp_config.json" 2>/dev/null || stat -c '%a' "$agy_plugin/mcp_config.json")" -eq 600
+test "$(file_mode "$agy_plugin/mcp_config.json")" -eq 600
 test "$(grep -c '<!-- overclick:start -->' "$agy_plugin/rules/AGENTS.md")" -eq 1
 grep -Fq "$agy_plugin/OVERCLICK.md" "$agy_plugin/rules/AGENTS.md"
 test -f "$agy_plugin/OVERCLICK.md"


### PR DESCRIPTION
Antigravity has a native plugin system (agy CLI) and all 5 overclick components (MCP, skill, slash commands, hooks, memory) install from a single directory, verified running in sandbox. No public registry to submit to — distribution is via install.sh or a GitHub subpath. Fixed a pre-existing red on main (codex stub not answering `codex plugin list --json`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)