### PR TITLE
[OCL-111] CI: run critical integration tests against real Postgres (repro the /api/pair 500)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,26 @@ concurrency:
 jobs:
   test:
     runs-on: ubuntu-latest
+
+    # Backs the real-postgres regression suite (pairing.real-postgres.integration.test.ts),
+    # which exists because the PGlite-only suite shipped OCL-109: PGlite tolerates a
+    # `Date` bound into `sql`, postgres-js — what production runs — does not. Every
+    # other integration test still boots its own in-memory PGlite and ignores this.
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
     steps:
       - uses: actions/checkout@v5
 
@@ -49,8 +69,13 @@ jobs:
       # so a type error reaches main unless tsc is asked separately.
       - run: pnpm -r --if-present typecheck
 
-      # No database service: the integration tests boot an in-memory PGlite.
+      # Most integration tests boot an in-memory PGlite and need no service.
+      # pairing.real-postgres.integration.test.ts is the exception: it talks
+      # to the postgres service above through the same postgres-js driver
+      # production uses, which is what OCL-109 needed and PGlite cannot give it.
       - run: pnpm test
+        env:
+          DATABASE_URL: postgres://postgres:postgres@localhost:5432/postgres
 
       # The plugin package is not a pnpm workspace, so `pnpm test` never reached
       # it and this suite only ever ran by hand. That is how the manifest version

--- a/apps/web/src/mcp/pairing.real-postgres.integration.test.ts
+++ b/apps/web/src/mcp/pairing.real-postgres.integration.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { createPairingCode, exchangePairingCode } from "../lib/pairing";
+import { createRealPostgresWorld } from "./test-db-postgres";
+
+/**
+ * The regression pairing.integration.test.ts could not catch on its own
+ * (OCL-109): that suite runs on PGlite, which accepts a `Date` bound into
+ * `sql`. Production runs postgres-js, which refuses it, so every real
+ * pairing answered 500 while the PGlite suite stayed green. This file runs
+ * the same exchange against the driver production actually uses, which is
+ * the only thing that can catch this class of bug again.
+ *
+ * Skipped without DATABASE_URL (no real Postgres to talk to) — the CI job
+ * sets it against the postgres service; nothing local changes.
+ */
+describe.skipIf(!process.env.DATABASE_URL)(
+  "one-time token pairing against real postgres-js (OCL-109 regression)",
+  () => {
+    it("exchanges a 6-digit code for a working bearer token without a driver error", async () => {
+      const world = await createRealPostgresWorld();
+      try {
+        const created = await createPairingCode(world.db, {
+          workspaceId: world.workspaceId,
+          label: "paired via code",
+        });
+
+        // Before the OCL-109 fix this threw inside postgres-js — the driver
+        // rejected the Date bound into spendAttemptStatement's sql — and the
+        // route answered 500 instead of ever reaching this result.
+        const exchanged = await exchangePairingCode(world.db, created.code);
+        expect(exchanged.ok).toBe(true);
+        if (!exchanged.ok) return;
+        expect(exchanged.label).toBe("paired via code");
+      } finally {
+        await world.close();
+      }
+    }, 60_000);
+
+    it("spends the failure budget on real postgres-js without a driver error", async () => {
+      const world = await createRealPostgresWorld();
+      try {
+        const created = await createPairingCode(world.db, {
+          workspaceId: world.workspaceId,
+          label: "paired via code",
+        });
+
+        // A wrong guess also runs spendAttemptStatement — the exact path
+        // that crashed the driver pre-fix — so this must not throw either.
+        const wrong = await exchangePairingCode(world.db, "000000");
+        expect(wrong.ok).toBe(false);
+
+        const right = await exchangePairingCode(world.db, created.code);
+        expect(right.ok).toBe(true);
+      } finally {
+        await world.close();
+      }
+    }, 60_000);
+  },
+);

--- a/apps/web/src/mcp/test-db-postgres.ts
+++ b/apps/web/src/mcp/test-db-postgres.ts
@@ -1,0 +1,91 @@
+import { randomUUID } from "node:crypto";
+import { readdirSync, readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { createDb, workspace } from "@agent-board/db";
+import type { McpDatabase } from "./types";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const MIGRATIONS_DIR = resolve(here, "../../../../packages/db/drizzle");
+
+export type RealPostgresWorld = {
+  db: McpDatabase;
+  workspaceId: string;
+};
+
+/**
+ * The one thing PGlite cannot stand in for: whether postgres-js — what
+ * production actually runs — accepts a query. OCL-109 shipped because the
+ * whole integration suite ran on PGlite, which tolerates a `Date` bound
+ * into `sql`; postgres-js refuses it and every real pairing answered 500
+ * while this suite stayed green (see pairing.ts and pairing.integration.test.ts).
+ *
+ * Migrations hardcode the "public" schema (drizzle-kit always emits it), so
+ * a search_path swap cannot isolate one test's tables from another's the
+ * way PGlite's one-process-per-world does. A fresh database per world is
+ * what actually isolates them here.
+ */
+function adminUrl(): string {
+  const url = process.env.DATABASE_URL;
+  if (!url) {
+    throw new Error(
+      "DATABASE_URL is required to run against real Postgres. Point it at a " +
+        "throwaway server (see .github/workflows/ci.yml) — never at a database " +
+        "with data worth keeping, since worlds are created and dropped freely.",
+    );
+  }
+  return url;
+}
+
+function withDatabaseName(base: string, name: string): string {
+  const url = new URL(base);
+  url.pathname = `/${name}`;
+  return url.toString();
+}
+
+export async function createRealPostgresWorld(): Promise<
+  RealPostgresWorld & { close: () => Promise<void> }
+> {
+  const base = adminUrl();
+  const dbName = `test_${randomUUID().replace(/-/g, "")}`;
+
+  const admin = createDb(base);
+  try {
+    await admin.sql.unsafe(`CREATE DATABASE "${dbName}"`);
+  } finally {
+    await admin.sql.end();
+  }
+
+  const { db: fullDb, sql } = createDb(withDatabaseName(base, dbName));
+
+  const files = readdirSync(MIGRATIONS_DIR)
+    .filter((name) => name.endsWith(".sql"))
+    .sort();
+  for (const file of files) {
+    const content = readFileSync(resolve(MIGRATIONS_DIR, file), "utf8");
+    for (const statement of content.split("--> statement-breakpoint")) {
+      const trimmed = statement.trim();
+      if (trimmed) await sql.unsafe(trimmed);
+    }
+  }
+
+  const db = fullDb as unknown as McpDatabase;
+
+  const [ws] = await fullDb
+    .insert(workspace)
+    .values({ name: "OverClick Real Postgres Test" })
+    .returning({ id: workspace.id });
+  if (!ws) throw new Error("failed to insert workspace");
+
+  const close = async () => {
+    await sql.end();
+    const cleanup = createDb(base);
+    try {
+      await cleanup.sql.unsafe(`DROP DATABASE IF EXISTS "${dbName}" WITH (FORCE)`);
+    } finally {
+      await cleanup.sql.end();
+    }
+  };
+
+  return { db, workspaceId: ws.id, close };
+}


### PR DESCRIPTION
Closes the coverage gap where OCL-101 passed 717 PGlite tests and broke /api/pair with a 500 on real Postgres. Adds a postgres service to GitHub Actions and an integration suite that reproduces OCL-109 against real postgres-js.

🤖 Generated with [Claude Code](https://claude.com/claude-code)