### PR TITLE
[OCL-114] plugin: stop shipping a dead board.invalid MCP

### DIFF
--- a/docs/design/plugin.md
+++ b/docs/design/plugin.md
@@ -15,13 +15,62 @@ Provider manifests adapt that same package to each native loader.
 | Repository marketplace | `.claude-plugin/marketplace.json` | `.grok-plugin/marketplace.json` | Official registry (`curated` tier) plus native custom install | Installer-created local marketplace | No public registry; installs from a directory or a GitHub subpath |
 | Skill | `skills/overclick/SKILL.md` | Same | Same | Same | Same |
 | Commands | Auto-discovered `commands/` | Auto-discovered `commands/` | `commands` manifest field | Skill-driven; not declared in the manifest | Auto-discovered `commands/`, converted to namespaced skills |
-| MCP | `.mcp.json` plus native user config | `.mcp.json` plus native user config | `mcpServers` plus private user config | `mcpServers` manifest field plus `[mcp_servers]` user config | `mcp_config.json` in the plugin (`serverUrl` + `headers`) |
+| MCP | `claude mcp add`, user scope | `grok mcp add`, user scope | `~/.kimi-code/mcp.json` | `[mcp_servers.overclick]` in `config.toml` | `mcp_config.json` in the plugin (`serverUrl` + `headers`) - its only channel |
 | Hooks | `hooks/hooks.json` | `hooks/hooks.json` | `hooks` manifest field | Global lifecycle hooks, but no client-side claim guard; deliberately absent from the plugin manifest | `hooks.json` at the plugin root, dispatched through `hooks/antigravity.sh` |
 | Memory | `@` import in `~/.claude/CLAUDE.md` | Bundled skill only | Bundled skill only | Bundled skill only | `rules/AGENTS.md` inside the plugin, loaded whenever the plugin is enabled |
 
 The Codex manifest contains only the skill and MCP contributions. Its installer
 uses the native marketplace manager, then writes the required user MCP block and
 merges global hooks without replacing unrelated rules.
+
+### One MCP registration per CLI, and none in the package (OCL-114)
+
+The package declares **no** MCP server. `plugin/.mcp.json`, `plugin/mcp_config.json`
+and `plugin/.codex-plugin/mcp.json` ship an empty `mcpServers`, and
+`plugin/kimi.plugin.json` has no `mcpServers` key at all - the same reasoning that
+already kept it out of the repository-root `.kimi-plugin/plugin.json`, applied
+everywhere.
+
+Two failures came out of the old arrangement, and both were seen on a real machine:
+
+- A `${OVERCLICK_URL}` placeholder is not expanded by any of these CLIs from the
+  package itself. Kimi drops the server silently. Claude keeps it and reports
+  `${OVERCLICK_URL} (HTTP) - Failed to connect`. Anyone installing straight from a
+  marketplace - the documented path for users who only want the plugin - therefore
+  got a server that could never connect, and every agent reading it concluded the
+  board was down.
+- Where install.sh *did* resolve the URL, it wrote the server into the package copy
+  **and** into the CLI's own configuration, so each CLI ended up holding two servers
+  named `overclick`. A stale package copy could then shadow a working connection.
+
+So: install.sh writes the resolved server where each CLI keeps its own servers, and
+never into the package. Antigravity is the exception, because its plugin manifest is
+the only channel it reads; that copy stays mode-600. A registry or marketplace install
+without install.sh gets the skill, commands and hooks and no server - absent, never
+dead.
+
+The installer also refuses an instance URL whose host is in a reserved namespace
+(RFC 2606/6761: `.invalid`, `.test`, `.example`), because such a URL is a test
+fixture rather than a board and baking it produces exactly the dead server above.
+
+And it will not take the name over: if a CLI already holds an `overclick` server
+pointing at a different instance, that registration is left alone with an
+instruction, while one pointing at this instance is refreshed as before.
+
+### `--header` is variadic (OCL-114)
+
+`claude mcp add` and `grok mcp add` declare `-H, --header <header...>`. A variadic
+option consumes every following argument that is not itself an option, so
+
+```
+claude mcp add --transport http --scope user --header "Authorization: Bearer …" overclick <url>
+```
+
+hands `overclick` and `<url>` to `--header` and dies on `missing required argument
+'name'`. `quiet_try` renders that as "needs manual confirmation in its native plugin
+manager", which reads like advice rather than a failure, so the Claude registration
+had been failing silently while the package's own `.mcp.json` carried the connection.
+The name and the URL go before `--header`.
 
 ## Hook policy
 
@@ -70,6 +119,16 @@ mode-600 permission on the materialized `mcp_config.json`. The repository packag
 stays a generic template. The stable package copy and a mode-600 config live in
 the user's configuration area. Provider MCP config is updated idempotently; Codex gets
 an explicit `[mcp_servers.overclick]` block and merged global hooks.
+
+`OVERCLICK_INSTALL_HOME` redirects the *managers*, not only the files (OCL-114).
+The native plugin managers resolve their user scope from `HOME` - and Claude Code
+from `CLAUDE_CONFIG_DIR` when that is exported, which a session managing more than
+one account does - so a sandboxed or test run used to register a marketplace in the
+operator's real configuration, pointing at a temporary directory and carrying
+whatever instance that run was given. The installer now overrides `HOME`,
+`XDG_CONFIG_HOME`, `CLAUDE_CONFIG_DIR`, `CODEX_HOME`, `KIMI_CODE_HOME` and
+`GEMINI_HOME` whenever `OVERCLICK_INSTALL_HOME` is set. They are overrides rather
+than defaults for the reason above: an ambient value would otherwise win.
 
 `GET /install.sh?code=NNNNNN` serves the same script with the instance URL and a
 one-time pairing code answered ahead of the prompts, which is what makes the

--- a/install.sh
+++ b/install.sh
@@ -16,6 +16,25 @@ overclick_root="$config_root/overclick"
 plugin_target="$overclick_root/plugin"
 private_config="$overclick_root/config"
 
+# OCL-114: OVERCLICK_INSTALL_HOME only ever redirected the files this script
+# writes itself. The native managers below (`claude plugin marketplace add`,
+# `claude mcp add`, `codex plugin add`, ...) resolve their own user scope from
+# HOME, so a sandboxed or test run still wrote into the operator's real
+# configuration - which is how a marketplace pointing at a temporary directory,
+# carrying a fixture instance URL, ended up registered on a working machine.
+# Redirect the managers to the same home the files go to - as an override, not a
+# default: a CLI that already exports its own config directory (a Claude Code
+# session managing more than one account does) would otherwise win and put the
+# sandboxed run right back into the real configuration.
+if [[ -n "${OVERCLICK_INSTALL_HOME:-}" ]]; then
+  export HOME="$install_home"
+  export XDG_CONFIG_HOME="$config_root"
+  export CLAUDE_CONFIG_DIR="$install_home/.claude"
+  export CODEX_HOME="$install_home/.codex"
+  export KIMI_CODE_HOME="$install_home/.kimi-code"
+  export GEMINI_HOME="$install_home/.gemini"
+fi
+
 read_private_setting() {
   local key=$1 line
   [[ -f "$private_config" ]] || return 1
@@ -47,6 +66,22 @@ if [[ "${instance_url#*://}" == *@* ]]; then
   printf '%s\n' "Instance URL must not contain embedded credentials." >&2
   exit 1
 fi
+
+# OCL-114: a run pointed at a test fixture baked that fixture into every agent
+# config it touched, and each of those agents then reported the board as down.
+# The reserved namespaces of RFC 2606/6761 can never resolve, so a URL in one is
+# never a board: refuse it here rather than register a server that cannot connect.
+instance_host=${instance_url#*://}
+instance_host=${instance_host%%/*}
+instance_host=${instance_host%%\?*}
+instance_host=${instance_host%%:*}
+instance_host=$(printf '%s' "$instance_host" | tr '[:upper:]' '[:lower:]')
+case "$instance_host" in
+  invalid|test|example|localdomain|*.invalid|*.test|*.example|*.localdomain|example.com|example.net|example.org)
+    printf '%s\n' "That instance URL is in a reserved namespace that can never resolve (RFC 2606/6761), so it is a test fixture rather than a board. Use the URL of your own OverClick instance." >&2
+    exit 1
+    ;;
+esac
 
 instance_url=${instance_url%/}
 if [[ "$instance_url" == */mcp ]]; then
@@ -269,9 +304,11 @@ else:
     data = {}
 
 mode = os.environ["OC_JSON_MODE"]
-if mode in ("mcp", "mcp-kimi"):
+if mode == "mcp-kimi":
+    # Kimi discriminates the transport on `transport`; a `type` key is dropped
+    # and the transport re-inferred from the url.
     data.setdefault("mcpServers", {})["overclick"] = {
-        ("transport" if mode == "mcp-kimi" else "type"): "http",
+        "transport": "http",
         "url": os.environ["OC_MCP_URL"],
         "headers": {"Authorization": "Bearer " + os.environ["OC_MCP_TOKEN"]},
     }
@@ -319,10 +356,10 @@ const path = require("node:path");
 const file = process.env.OC_JSON_FILE;
 let data = {};
 if (fs.existsSync(file)) data = JSON.parse(fs.readFileSync(file, "utf8"));
-if (process.env.OC_JSON_MODE === "mcp" || process.env.OC_JSON_MODE === "mcp-kimi") {
+if (process.env.OC_JSON_MODE === "mcp-kimi") {
   data.mcpServers ??= {};
   data.mcpServers.overclick = {
-    [process.env.OC_JSON_MODE === "mcp-kimi" ? "transport" : "type"]: "http",
+    transport: "http",
     url: process.env.OC_MCP_URL,
     headers: { Authorization: "Bearer " + process.env.OC_MCP_TOKEN },
   };
@@ -360,12 +397,14 @@ JS
   return 1
 }
 
-# Native managers install this private copy, so plugin-level MCP declarations
-# work without requiring shell profile edits. The repository package remains a
-# generic environment-variable template.
-merge_json_config mcp "$plugin_target/.mcp.json"
-merge_json_config mcp-kimi "$plugin_target/kimi.plugin.json"
-chmod 600 "$plugin_target/.mcp.json" "$plugin_target/kimi.plugin.json"
+# OCL-114: the package used to declare its own `overclick` MCP server on top of
+# the one registered in each CLI's own configuration below. Every install
+# therefore produced two servers of the same name per CLI - and, because the
+# repository template carries an unexpanded ${OVERCLICK_URL}, the plugin-level
+# one is dead for anyone who installs straight from a marketplace instead of
+# through this script. Each CLI now gets exactly one registration, written where
+# that CLI keeps its own servers, and the package ships none. Antigravity is the
+# exception below: its plugin manifest is the only channel it reads.
 
 native_marketplace="$overclick_root/native-marketplace"
 mkdir -p "$native_marketplace/.claude-plugin" "$native_marketplace/.grok-plugin" "$native_marketplace/plugin"
@@ -391,6 +430,19 @@ fi
 
 has_cli() {
   [[ "$detected_clis" == *",$1,"* ]]
+}
+
+# A server already named `overclick` in a CLI is somebody's board. Answering
+# "yes" here only for one that points somewhere else keeps a re-run against the
+# same instance a plain credential refresh, while a run pointed at a different
+# instance stops instead of silently taking the name over (OCL-114). The listing
+# carries an Authorization header, so it is matched and discarded, never printed.
+foreign_mcp_registration() {
+  local existing
+  existing=$("$@" 2>/dev/null) || return 1
+  [[ -n "$existing" ]] || return 1
+  printf '%s' "$existing" | grep -Fq "$mcp_url" && return 1
+  return 0
 }
 
 quiet_try() {
@@ -480,9 +532,18 @@ if has_cli claude; then
   else
     printf '%s\n' "Claude plugin needs manual confirmation in its native plugin manager." >&2
   fi
-  claude mcp remove overclick --scope user >/dev/null 2>&1 || true
-  quiet_try "Claude MCP" claude mcp add --transport http --scope user \
-    --header "Authorization: Bearer $token" overclick "$mcp_url"
+  if foreign_mcp_registration claude mcp get overclick; then
+    printf '%s\n' "Claude already has an MCP server named overclick pointing at a different instance; it was left untouched. Remove it with 'claude mcp remove overclick' and re-run this installer to move to this board." >&2
+  else
+    claude mcp remove overclick --scope user >/dev/null 2>&1 || true
+    # `--header` is variadic (`-H, --header <header...>`), so it eats every
+    # argument that follows it - including the name and the URL, which is why
+    # this call used to die on "missing required argument 'name'" while
+    # quiet_try reported it as something to confirm by hand. The positionals
+    # have to come first (OCL-114).
+    quiet_try "Claude MCP" claude mcp add --transport http --scope user \
+      overclick "$mcp_url" --header "Authorization: Bearer $token"
+  fi
   claude_block=$(printf '%s\n' '<!-- overclick:start -->' "@$plugin_target/OVERCLICK.md" '<!-- overclick:end -->')
   replace_marked_block "$install_home/.claude/CLAUDE.md" "$claude_block"
 
@@ -552,9 +613,14 @@ if has_cli grok; then
   else
     printf '%s\n' "Grok plugin needs manual confirmation in its native plugin manager." >&2
   fi
-  grok mcp remove --scope user overclick >/dev/null 2>&1 || true
-  quiet_try "Grok MCP" grok mcp add --transport http --scope user \
-    --header "Authorization: Bearer $token" overclick "$mcp_url"
+  if foreign_mcp_registration grok mcp get overclick; then
+    printf '%s\n' "Grok already has an MCP server named overclick pointing at a different instance; it was left untouched. Remove it with 'grok mcp remove overclick' and re-run this installer to move to this board." >&2
+  else
+    grok mcp remove --scope user >/dev/null 2>&1 || true
+    # Same variadic `--header` as Claude: name and URL before it.
+    quiet_try "Grok MCP" grok mcp add --transport http --scope user \
+      overclick "$mcp_url" --header "Authorization: Bearer $token"
+  fi
 fi
 
 # Kimi Code has no non-interactive plugin subcommand: `/plugins install` is a TUI

--- a/plugin/.codex-plugin/mcp.json
+++ b/plugin/.codex-plugin/mcp.json
@@ -1,9 +1,3 @@
 {
-  "mcpServers": {
-    "overclick": {
-      "type": "http",
-      "url": "${OVERCLICK_URL}",
-      "bearer_token_env_var": "OVERCLICK_TOKEN"
-    }
-  }
+  "mcpServers": {}
 }

--- a/plugin/.mcp.json
+++ b/plugin/.mcp.json
@@ -1,11 +1,3 @@
 {
-  "mcpServers": {
-    "overclick": {
-      "type": "http",
-      "url": "${OVERCLICK_URL}",
-      "headers": {
-        "Authorization": "Bearer ${OVERCLICK_TOKEN}"
-      }
-    }
-  }
+  "mcpServers": {}
 }

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -48,7 +48,7 @@ one's *native* plugin manager (Claude Code, Codex, Grok, Kimi). See the reposito
 | `skills/overclick` | The workflow: how to read a card contract, claim it, deliver it with measured usage |
 | `commands/` | `/board`, `/card`, `/claim`, `/deliver`, `/release` |
 | `hooks/hooks.json` | Board snapshot at session start; claim-marker bookkeeping; a delivery commit check; opt-in guards |
-| `.mcp.json` | The `overclick` MCP server, read from `${OVERCLICK_URL}` / `${OVERCLICK_TOKEN}` |
+| `.mcp.json` | Empty on purpose: the package declares no MCP server. The installer writes the `overclick` server into each CLI's own configuration, with your instance URL resolved, so a marketplace install can never leave you a server that cannot connect |
 | `OVERCLICK.md` | The canonical rules the skill and commands both defer to |
 
 ## Network endpoints and credentials

--- a/plugin/kimi.plugin.json
+++ b/plugin/kimi.plugin.json
@@ -14,15 +14,6 @@
   "skills": [
     "./skills/overclick"
   ],
-  "mcpServers": {
-    "overclick": {
-      "transport": "http",
-      "url": "${OVERCLICK_URL}",
-      "headers": {
-        "Authorization": "Bearer ${OVERCLICK_TOKEN}"
-      }
-    }
-  },
   "hooks": [
     {
       "event": "SessionStart",

--- a/plugin/mcp_config.json
+++ b/plugin/mcp_config.json
@@ -1,11 +1,3 @@
 {
-  "mcpServers": {
-    "overclick": {
-      "serverUrl": "${OVERCLICK_URL}",
-      "headers": {
-        "Authorization": "Bearer ${OVERCLICK_TOKEN}"
-      },
-      "disabled": false
-    }
-  }
+  "mcpServers": {}
 }

--- a/scripts/test-plugin-package.sh
+++ b/scripts/test-plugin-package.sh
@@ -28,12 +28,24 @@ done
 
 jq -e '.skills and .mcpServers and (has("hooks") | not) and (has("commands") | not)' \
   "$REPO_ROOT/plugin/.codex-plugin/plugin.json" >/dev/null
-jq -e '.skills and .mcpServers and (.hooks | length == 6) and .commands' \
+jq -e '.skills and (.hooks | length == 6) and .commands' \
   "$REPO_ROOT/plugin/kimi.plugin.json" >/dev/null
-# Kimi discriminates MCP transports on "transport"; a "type" key is dropped and the
-# transport re-inferred from the url, so declaring it is working by accident.
-jq -e '.mcpServers.overclick.transport == "http" and (.mcpServers.overclick | has("type") | not)' \
-  "$REPO_ROOT/plugin/kimi.plugin.json" >/dev/null
+
+# OCL-114. The package ships NO MCP server. A `${OVERCLICK_URL}` placeholder is
+# never expanded by the CLIs, so every marketplace install used to hand the user
+# an `overclick` server that could not connect - and, on a machine where a run
+# had baked a fixture instance into these files, one that pointed at a host that
+# does not exist. install.sh writes the resolved server into each CLI's own
+# configuration instead, so the only thing the package can contribute is nothing.
+for template in plugin/.mcp.json plugin/mcp_config.json plugin/.codex-plugin/mcp.json; do
+  jq -e '.mcpServers | length == 0' "$REPO_ROOT/$template" >/dev/null ||
+    { echo "$template must ship no MCP server" >&2; exit 1; }
+done
+jq -e 'has("mcpServers") | not' "$REPO_ROOT/plugin/kimi.plugin.json" >/dev/null
+if grep -rq 'OVERCLICK_URL' "$REPO_ROOT/plugin"; then
+  echo "the package still carries an unexpandable OVERCLICK_URL placeholder" >&2
+  exit 1
+fi
 # Kimi finds a plugin root only in an archive root or a single child directory, so a
 # repository install needs a root manifest pointing into ./plugin/. It carries no
 # mcpServers: a registry install cannot know the instance URL, and Kimi drops an
@@ -71,6 +83,43 @@ touch "$TEST_ROOT/codex-cache/OVERCLICK.md"
 cat >"$TEST_ROOT/bin/agent-stub" <<'SH'
 #!/bin/sh
 printf '%s:%s:%s\n' "$(basename -- "$0")" "${1:-}" "${2:-}" >>"$OC_TEST_NATIVE_LOG"
+# The native managers resolve their own user scope from HOME, so what HOME was
+# when they ran is the whole question a sandboxed install has to answer.
+printf 'home:%s\n' "${HOME:-}" >>"$OC_TEST_NATIVE_LOG"
+# `claude mcp add` and `grok mcp add` declare `-H, --header <header...>`, a
+# VARIADIC option: it consumes every following argument that is not itself an
+# option. Put the name and the URL after it and they become header values, and
+# the command dies on "missing required argument 'name'" - which quiet_try
+# reports as a step to confirm by hand, so the failure reads like a warning
+# (OCL-114). Parse the way commander does, so the ordering stays under test.
+if [ "${1:-}" = "mcp" ] && [ "${2:-}" = "add" ]; then
+  shift 2
+  positionals=0
+  collecting=0
+  url=""
+  for argument in "$@"; do
+    case "$argument" in
+      --header|-H) collecting=1; continue ;;
+      --transport|--scope|-s) collecting=0; skip_value=1; continue ;;
+      -*) collecting=0; continue ;;
+    esac
+    if [ "${skip_value:-0}" = "1" ]; then skip_value=0; continue; fi
+    if [ "$collecting" = "1" ]; then continue; fi
+    positionals=$((positionals + 1))
+    case "$argument" in http://*|https://*) url=$argument ;; esac
+  done
+  if [ "$positionals" -lt 2 ]; then
+    echo "error: missing required argument 'name'" >&2
+    exit 1
+  fi
+  printf 'mcp-url:%s\n' "$url" >>"$OC_TEST_NATIVE_LOG"
+  exit 0
+fi
+# A board somebody already configured under this name. The real CLIs print the
+# server they hold; an absent one is empty output here and a non-zero exit there.
+if [ "${1:-}" = "mcp" ] && [ "${2:-}" = "get" ]; then
+  [ -n "${OC_TEST_EXISTING_MCP:-}" ] && printf 'overclick: %s (HTTP)\n' "$OC_TEST_EXISTING_MCP"
+fi
 if [ "${1:-}" = "plugin" ] && [ "${2:-}" = "list" ]; then
   case "$(basename -- "$0")" in
     claude)
@@ -160,9 +209,14 @@ test "$(file_mode "$TEST_ROOT/home/.config/overclick/config")" -eq 600
 # carry a resolved url: Kimi validates it and silently drops the server otherwise.
 test "$(jq -r '[.plugins[] | select(.id == "overclick")] | length' \
   "$TEST_ROOT/home/.kimi-code/plugins/installed.json")" -eq 1
-jq -e '.mcpServers.overclick.transport == "http"
-  and (.mcpServers.overclick.url | startswith("$") | not)' \
+jq -e 'has("mcpServers") | not' \
   "$TEST_ROOT/home/.kimi-code/plugins/managed/overclick/kimi.plugin.json" >/dev/null
+# Kimi discriminates MCP transports on "transport"; a "type" key is dropped and the
+# transport re-inferred from the url, so declaring it is working by accident.
+jq -e --arg url "$FIXTURE_URL/mcp" '.mcpServers.overclick.transport == "http"
+  and .mcpServers.overclick.url == $url
+  and (.mcpServers.overclick | has("type") | not)' \
+  "$TEST_ROOT/home/.kimi-code/mcp.json" >/dev/null
 test -x "$TEST_ROOT/home/.kimi-code/plugins/managed/overclick/hooks/claim-guard.sh"
 
 # Antigravity gets the package through its own manager, so what has to hold is
@@ -184,8 +238,41 @@ jq -e '.overclick | (.PreToolUse | length == 2) and (.PostToolUse | length == 1)
   and .PreInvocation and .Stop' "$agy_plugin/hooks.json" >/dev/null
 # The repository package stays a generic template: only the installed copy is
 # allowed to carry an instance.
-jq -e '.mcpServers.overclick.serverUrl == "${OVERCLICK_URL}"' \
-  "$REPO_ROOT/plugin/mcp_config.json" >/dev/null
+jq -e '.mcpServers | length == 0' "$REPO_ROOT/plugin/mcp_config.json" >/dev/null
+
+# OCL-114: every copy the installer leaves behind, other than the Antigravity
+# one above and each CLI's own config, must be free of a server entry - so no
+# CLI can end up with two `overclick` servers, and no dead one can survive in a
+# marketplace directory after the instance it was baked from is gone.
+for copy in \
+  "$TEST_ROOT/home/.config/overclick/plugin" \
+  "$TEST_ROOT/home/.config/overclick/native-marketplace/plugin" \
+  "$TEST_ROOT/home/.config/overclick/codex-marketplace/plugins/overclick"; do
+  jq -e '.mcpServers | length == 0' "$copy/.mcp.json" >/dev/null ||
+    { echo "$copy/.mcp.json declares a duplicate MCP server" >&2; exit 1; }
+  jq -e 'has("mcpServers") | not' "$copy/kimi.plugin.json" >/dev/null ||
+    { echo "$copy/kimi.plugin.json declares a duplicate MCP server" >&2; exit 1; }
+  if grep -Rq 'fixture' "$copy/.mcp.json" "$copy/kimi.plugin.json"; then
+    echo "$copy still carries baked credentials" >&2
+    exit 1
+  fi
+done
+
+# The one registration Claude gets has to be the resolved instance, and it has
+# to be written through Claude's own manager rather than into the package.
+grep -Fq "mcp-url:$FIXTURE_URL/mcp" "$TEST_ROOT/native.log"
+# quiet_try turns a failed registration into a line that reads like advice, so
+# the absence of that line is the only thing that says the server was really
+# registered.
+if grep -Fq 'Claude MCP needs manual confirmation' "$TEST_ROOT/install.err"; then
+  echo "the Claude MCP registration failed" >&2
+  exit 1
+fi
+grep -Fq 'Claude MCP configured.' "$TEST_ROOT/install.out"
+# A sandboxed install must not reach the operator's real configuration: the
+# native managers resolve their user scope from HOME, so HOME has to follow
+# OVERCLICK_INSTALL_HOME (OCL-114).
+grep -Fq "home:$TEST_ROOT/home" "$TEST_ROOT/native.log"
 
 # A PreToolUse hook that answers with an empty object is read by Antigravity as
 # a denial, so the adapter has to speak on every path — including the one where
@@ -485,5 +572,57 @@ git -C "$TEST_ROOT/git/work" remote add origin "$TEST_ROOT/git/remote.git"
 git -C "$TEST_ROOT/git/work" push -u origin HEAD >/dev/null 2>&1
 commit=$(git -C "$TEST_ROOT/git/work" rev-parse HEAD)
 (cd "$TEST_ROOT/git/work" && printf '{"tool_input":{"evidence":[{"text":"commit %s"}]}}' "$commit" | "$REPO_ROOT/plugin/hooks/post-deliver.sh")
+
+# OCL-114, the shape of the original failure: a run pointed at a reserved,
+# unresolvable namespace baked that host into the agent configs and every agent
+# that read them concluded the board was down. It has to be refused up front.
+if PATH="$TEST_ROOT/bin:$PATH" \
+  OC_TEST_NATIVE_LOG="$TEST_ROOT/reserved-native.log" \
+  OC_TEST_CLAUDE_CACHE="$TEST_ROOT/claude-cache" \
+  OC_TEST_CODEX_CACHE="$TEST_ROOT/codex-cache" \
+  OVERCLICK_INSTALL_HOME="$TEST_ROOT/home-reserved" \
+  OVERCLICK_PROJECT_DIR="$TEST_ROOT/project" \
+  OVERCLICK_INSTANCE_URL="$(printf '%s%s%s' 'https' '://' 'board.invalid')" \
+  OVERCLICK_TOKEN="fixture" \
+  OVERCLICK_CLIS="claude" \
+    "$REPO_ROOT/install.sh" >"$TEST_ROOT/reserved.out" 2>"$TEST_ROOT/reserved.err"; then
+  echo "installer accepted an instance URL in a reserved namespace" >&2
+  exit 1
+fi
+grep -Fq 'reserved namespace' "$TEST_ROOT/reserved.err"
+test ! -e "$TEST_ROOT/home-reserved/.config/overclick/config"
+test ! -e "$TEST_ROOT/reserved-native.log"
+
+# A server already named `overclick` and pointing somewhere else is somebody's
+# working board. Installing must not take the name over: no remove, no add.
+PATH="$TEST_ROOT/bin:$PATH" \
+OC_TEST_NATIVE_LOG="$TEST_ROOT/collision-native.log" \
+OC_TEST_CLAUDE_CACHE="$TEST_ROOT/claude-cache" \
+OC_TEST_CODEX_CACHE="$TEST_ROOT/codex-cache" \
+OC_TEST_EXISTING_MCP="$(printf '%s%s%s' 'https' '://' 'other-board.internal/mcp')" \
+OVERCLICK_INSTALL_HOME="$TEST_ROOT/home-collision" \
+OVERCLICK_PROJECT_DIR="$TEST_ROOT/project" \
+OVERCLICK_INSTANCE_URL="$FIXTURE_URL" \
+OVERCLICK_TOKEN="fixture" \
+OVERCLICK_CLIS="claude" \
+  "$REPO_ROOT/install.sh" >"$TEST_ROOT/collision.out" 2>"$TEST_ROOT/collision.err"
+grep -Fq 'left untouched' "$TEST_ROOT/collision.err"
+test "$(grep -c '^claude:mcp:remove$' "$TEST_ROOT/collision-native.log" || true)" -eq 0
+test "$(grep -c '^mcp-url:' "$TEST_ROOT/collision-native.log" || true)" -eq 0
+
+# The same server pointing at THIS instance is just a credential refresh, so a
+# re-run must still rewrite it rather than skip it.
+PATH="$TEST_ROOT/bin:$PATH" \
+OC_TEST_NATIVE_LOG="$TEST_ROOT/refresh-native.log" \
+OC_TEST_CLAUDE_CACHE="$TEST_ROOT/claude-cache" \
+OC_TEST_CODEX_CACHE="$TEST_ROOT/codex-cache" \
+OC_TEST_EXISTING_MCP="$FIXTURE_URL/mcp" \
+OVERCLICK_INSTALL_HOME="$TEST_ROOT/home-refresh" \
+OVERCLICK_PROJECT_DIR="$TEST_ROOT/project" \
+OVERCLICK_INSTANCE_URL="$FIXTURE_URL" \
+OVERCLICK_TOKEN="fixture" \
+OVERCLICK_CLIS="claude" \
+  "$REPO_ROOT/install.sh" >"$TEST_ROOT/refresh.out" 2>"$TEST_ROOT/refresh.err"
+grep -Fq "mcp-url:$FIXTURE_URL/mcp" "$TEST_ROOT/refresh-native.log"
 
 echo "plugin package checks passed"


### PR DESCRIPTION
The plugin package no longer declares any MCP server. install.sh writes the resolved overclick server into each CLI config, so a sandbox install cannot leak into real config (the true board.invalid cause). Also fixes claude mcp add failing silently on a variadic --header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)