### PR TITLE
[OCL-90] --oc-ok deixa de ser decoração no modal e em Configurações

### DIFF
--- a/apps/web/src/styles/nebula.css
+++ b/apps/web/src/styles/nebula.css
@@ -1562,10 +1562,10 @@ body:has(.nb) { display: block; padding: 0; background: var(--nebula-void); }
 
 /* ---------- validation panel (Done · review) ---------- */
 .nb .d-verify { display: flex; align-items: baseline; gap: 10px; flex-wrap: wrap;
-  background: rgb(var(--oc-ok-rgb) / .06); border: 1px solid rgb(var(--oc-ok-rgb) / .22); border-radius: var(--oc-radius-box);
+  background: var(--nebula-panel-solid); border: 1px solid var(--nebula-glass-border); border-radius: var(--oc-radius-box);
   padding: 9px 13px; margin-bottom: 10px; }
 .nb .d-verify-lbl { font-family: var(--nebula-font-label); font-size: 9.5px; letter-spacing: .08em;
-  text-transform: uppercase; color: var(--oc-ok); white-space: nowrap; }
+  text-transform: uppercase; color: var(--nebula-text-tertiary); white-space: nowrap; }
 .nb .d-verify-value { font-size: 12px; color: var(--nebula-text-primary); word-break: break-all; }
 .nb a.d-verify-value { text-decoration: underline; text-underline-offset: 2px; }
 .nb .d-checklist { display: flex; flex-direction: column; gap: 6px; }
@@ -1783,15 +1783,16 @@ body:has(.nb) { display: block; padding: 0; background: var(--nebula-void); }
 .nb .seen-sugg .sec-cap { margin-top: 0; }
 .nb .seen-row { display: flex; gap: 8px; flex-wrap: wrap; }
 .nb .seen-chip { display: inline-flex; align-items: center; gap: 8px;
-  background: rgb(var(--oc-ok-rgb) / .06); border: 1px solid rgb(var(--oc-ok-rgb) / .25); border-radius: var(--oc-radius-pill);
+  background: var(--nebula-panel-solid); border: 1px solid var(--nebula-glass-border); border-radius: var(--oc-radius-pill);
   padding: 6px 8px 6px 14px; font-size: 12px; color: var(--nebula-text-primary); }
 .nb .seen-chip b { font-weight: var(--nebula-weight-medium); }
 .nb .seen-chip small { font-family: var(--nebula-font-label); font-size: 10px; color: var(--nebula-text-tertiary); }
-/* A chip button stays dense, but not so dense a mouse has to aim: 30px is
+/* A chip button stays dense, but not so dense a mouse has to aim: 32px is
    the floor here, and on a phone the chip itself becomes a full row so the
    button clears 44px without the chip growing into a card. */
-.nb .seen-add { background: var(--oc-btn-light-bg); border: none; border-radius: var(--oc-radius-pill); color: var(--oc-btn-light-text);
-  font-size: 11.5px; font-weight: 500; padding: 4px 12px; min-height: 30px; cursor: pointer; white-space: nowrap; }
+.nb .seen-add { background: transparent; border: 1px solid var(--nebula-glass-border); border-radius: var(--oc-radius-pill); color: var(--nebula-text-secondary);
+  font-size: 12px; font-weight: 500; padding: 4px 12px; min-height: 32px; cursor: pointer; white-space: nowrap; }
+.nb .seen-add:hover:not(:disabled) { color: var(--nebula-text-primary); border-color: var(--oc-border-hover); }
 .nb .seen-add:disabled { opacity: .4; cursor: not-allowed; }
 .nb .seen-add:focus-visible { outline: none; box-shadow: var(--nebula-focus-ring-offset); }
 


### PR DESCRIPTION
## Summary
- `.d-verify` (bloco "Validação · Como confirmo" do modal) e `.seen-chip` ("vistos em conexões reais" em Configurações) usavam `rgba(--oc-ok-rgb)` como decoração em conteúdo que **não** é status — instrução e sugestão, respectivamente. Doutrina `docs/design/ux-v2.md` §2: `--oc-ok`/`--oc-danger` só em status dot, status/error text e ação destrutiva. Ambos os blocos agora usam superfície/borda neutra (`--oc-surface-3`/`--oc-border`, via os aliases já existentes `--nebula-panel-solid`/`--nebula-glass-border`) e rótulo em `--oc-text-3`.
- De quebra, `.seen-add` ("adicionar") caiu de tratamento de ação primária (fundo branco cheio) para a anatomia do Control (borda 1px, fundo transparente) do §3, e teve `font-size` 11.5px→12px e `min-height` 30px→32px ajustados para caírem na rampa/spacing scale de §2.
- Escopo estrito: só cor/superfície desses três elementos e o tamanho de `.seen-add` — nada de redesenho do modal, de Configurações, de tema ou do logo.

**Desvio de harness registrado:** o cardápio da OCL-90 pedia `kimi · k3 · max`; por decisão do dono, execução foi com Claude (conta 2) via `claude-code`.

## Test plan
- [x] `pnpm --filter @agent-board/web test -- --run src/styles` → `styles/tokens.test.ts` (25) e `styles/layers.test.ts` (9) passam — guards de estilo verdes.
- [ ] Verificação visual manual (abrir modal → bloco Validação · Como confirmo; `/settings` → chips "vistos em conexões reais" e botões "adicionar") — não executada nesta sessão (sem browser); pedir revisão visual antes do merge.
- Nota: `pnpm --filter @agent-board/web test` completo tem 25 suites falhando por `@agent-board/mcp-core` sem build (`dist/` ausente) neste worktree recém-criado — pré-existente, não relacionado a esta mudança (CSS-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)