### PR TITLE
[OCL-91] Banner de atualização: altura, blur e tamanhos fora da rampa

### DIFF
--- a/apps/web/src/components/update-banner.tsx
+++ b/apps/web/src/components/update-banner.tsx
@@ -35,6 +35,7 @@ export function UpdateBanner({
   const [requested, setRequested] = useState(false);
   const [err, setErr] = useState<string | null>(null);
   const [hidden, setHidden] = useState(false);
+  const [showNotes, setShowNotes] = useState(false);
 
   if (hidden) return null;
 
@@ -59,9 +60,20 @@ export function UpdateBanner({
     <div className="update-banner nebula-glass">
       <div className="ub-head">
         <b>{t.updates.newVersion(version)}</b>
-        <a href={url} target="_blank" rel="noreferrer">
-          {t.updates.releaseNotes}
-        </a>
+        {notes ? (
+          <button
+            type="button"
+            className="ub-notes-toggle"
+            aria-expanded={showNotes}
+            onClick={() => setShowNotes((v) => !v)}
+          >
+            {t.updates.releaseNotes} {showNotes ? "▴" : "▾"}
+          </button>
+        ) : (
+          <a href={url} target="_blank" rel="noreferrer">
+            {t.updates.releaseNotes}
+          </a>
+        )}
         <div className="spacer" />
         <button className="btn-ghost" onClick={() => setHidden(true)}>
           {t.updates.dismiss}
@@ -70,7 +82,7 @@ export function UpdateBanner({
           {t.updates.updateBtn}
         </button>
       </div>
-      {notes ? <pre className="ub-notes">{notes.slice(0, 800)}</pre> : null}
+      {notes && showNotes ? <pre className="ub-notes">{notes.slice(0, 800)}</pre> : null}
       {requested ? <p className="wok">{t.updates.updateRequested}</p> : null}
       {showCmd ? (
         runtime === "source" ? (

--- a/apps/web/src/styles/nebula.css
+++ b/apps/web/src/styles/nebula.css
@@ -2238,13 +2238,35 @@ body:has(.nb) { display: block; padding: 0; background: var(--nebula-void); }
   background: rgb(var(--oc-danger-rgb) / 0.06); border-left: 2px solid rgb(var(--oc-danger-rgb) / 0.45);
   border-radius: var(--oc-radius-control); line-height: 1.5; }
 
-/* ---- update banner + updates tab (AGB-18) ---- */
-.nb .update-banner { margin: 0 0 18px; padding: 14px 18px; border: 1px solid var(--nebula-plan-divider); border-radius: var(--oc-radius-box); }
+/* ---- update banner + updates tab (AGB-18) ----
+   ux-v2 §1/§3: a one-line notice, not a changelog block — the release notes
+   are a disclosure the reader opens, so the collapsed banner never competes
+   with the board for the first fold. */
+.nb .update-banner { margin: 0 0 18px; padding: 10px 18px; border: 1px solid var(--nebula-plan-divider); border-radius: var(--oc-radius-box); }
 .nb .update-banner .ub-head { display: flex; align-items: center; gap: 14px; }
 .nb .update-banner .ub-head a { color: var(--nebula-mist-glow); font-size: 12px; }
-.nb .update-banner .ub-notes { margin: 10px 0 0; padding: 10px 12px; max-height: 140px; overflow: auto; font-family: var(--nebula-font-label); font-size: 11px; color: var(--nebula-text-secondary); white-space: pre-wrap; border: 1px solid var(--nebula-plan-divider); border-radius: var(--oc-radius-control); }
+.nb .update-banner .ub-notes-toggle {
+  background: none; border: none; padding: 0; margin: 0; cursor: pointer;
+  color: var(--nebula-mist-glow); font-family: var(--nebula-font-sans); font-size: 12px;
+}
+.nb .update-banner .ub-notes-toggle:hover { color: var(--nebula-text-primary); }
+.nb .update-banner .ub-notes-toggle:focus-visible { outline: none; box-shadow: var(--nebula-focus-ring-offset); border-radius: var(--oc-radius-control-sm); }
+/* §1: mono is the data voice, not the prose voice — the changelog body reads
+   in the UI face; only the .ub-cmd code lines below stay in mono. */
+.nb .update-banner .ub-notes { margin: 10px 0 0; padding: 10px 12px; max-height: 140px; overflow: auto; font-family: var(--nebula-font-sans); font-size: 12px; color: var(--nebula-text-secondary); white-space: pre-wrap; border: 1px solid var(--nebula-plan-divider); border-radius: var(--oc-radius-control); }
 .nb .update-banner .ub-cmd { display: flex; align-items: center; gap: 10px; margin-top: 10px; font-size: 12px; color: var(--nebula-text-secondary); }
 .nb .update-banner .ub-cmd code { font-family: var(--nebula-font-mono); color: var(--nebula-mist-light); }
+/* §3: the banner's own controls follow the Control anatomy (32px, 13px/500)
+   — scoped to the banner only, the topbar's ghost/new buttons are untouched.
+   §1: blur is for panels that float over content; a button in flow doesn't. */
+.nb .update-banner .btn-ghost,
+.nb .update-banner .btn-new {
+  height: 32px;
+  padding: 0 12px;
+  font-size: 13px;
+  -webkit-backdrop-filter: none;
+  backdrop-filter: none;
+}
 /* row explicitly: the global `label` rule stacks its children in a column. */
 .nb .upd-toggle { display: flex; flex-direction: row; align-items: center; gap: 10px; font-size: 13px; cursor: pointer; margin-top: 16px; }
 .nb .upd-toggle input { flex: 0 0 auto; }


### PR DESCRIPTION
## Summary
- Release notes agora ficam atrás de um disclosure (toggle "notas da release ▾/▴"), então o banner colapsa a uma linha em vez de empurrar a topbar com 247px de changelog.
- Remove `backdrop-filter: blur(12px)` dos botões `.btn-ghost`/`.btn-new` do banner (§1: blur é pra painel que flutua, não pra controle em fluxo).
- Botões do banner passam a 32px de altura / 13px de fonte, seguindo a anatomia do Control (§3) — mudança escopada só ao `.update-banner`, não toca os botões globais de topbar/modal.
- `border-radius: 999px` do nebula mantido (resolve por `--oc-radius-pill`, não é bug — vira 8px automaticamente no tema xai).
- Prosa do changelog (`ub-notes`) migra da face mono pra face de UI; os comandos em `.ub-cmd code` continuam mono.

Escopo: só `UpdateBanner`/`update-banner.tsx` e as regras `.nb .update-banner *` em `nebula.css`. Nenhum token novo — só reuso dos `--oc-*`/aliases `--nebula-*` já existentes.

## Nota de harness
Card pedia `kimi · k3 · max`; execução foi com Claude (conta 2) por decisão do dono — desvio registrado no `task_deliver`.

## Test plan
- [x] `pnpm --filter @agent-board/web test -- src/styles src/components` — 60/60 passando (guards de estilo incluídos)
- [x] `tsc --noEmit` limpo em `update-banner.tsx`
- [ ] Verificação visual em 1440/1100/900/700px e troca nebula⇄xai (não rodei o app; peço checagem visual antes do merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)