### PR TITLE
[OCL-84] Board card: stop the footer leaking past the border, match ux-v2 §3

### DIFF
--- a/apps/web/src/app/home/board.tsx
+++ b/apps/web/src/app/home/board.tsx
@@ -311,11 +311,14 @@ function CardMetaTail({
   card,
   t,
   lead,
+  telemetryLine,
 }: {
   card: BoardCard;
   t: Dict;
   /** True when something already sits to the left on this line. */
   lead: boolean;
+  /** The footer's share of the telemetry line — cost already pulled out of it. */
+  telemetryLine: TelemetrySegment[];
 }) {
   const sep = lead ? <span className="tel-sep">·</span> : null;
   if (card.status === "aberto") {
@@ -335,8 +338,8 @@ function CardMetaTail({
       </span>
     ) : null;
   }
-  if (card.telemetryLine.length > 0) {
-    return <TelemetryLine segments={card.telemetryLine} lead={lead} />;
+  if (telemetryLine.length > 0) {
+    return <TelemetryLine segments={telemetryLine} lead={lead} />;
   }
   // Never a bare "no telemetry" on a delivered card: without any numbers the
   // honest label is that usage went unreported.
@@ -428,6 +431,13 @@ function Card({
   const harness =
     card.harnessChain ?? (exec ? (card.executor ?? t.board.agent) : null);
   const activate = () => (selectable ? onToggleSelect(card.id) : onOpen(card));
+  // The cost lives at the top of the card (ux-v2 §3), on the id's own line,
+  // so the footer never has to compete with it for room. What is left of the
+  // telemetry line still degrades there, by priority, never past the border.
+  const costSegment = card.telemetryLine.find((s) => s.kind === "cost") ?? null;
+  const footTelemetry = costSegment
+    ? card.telemetryLine.filter((s) => s !== costSegment)
+    : card.telemetryLine;
   // Three lines and no more: what the card is, what it says, what it cost.
   // Mission, branch, executor and the effort of the harness all stay one
   // click away in the detail panel.
@@ -436,7 +446,7 @@ function Card({
       id={`board-card-${card.id}`}
       className={`card nebula-glass${exec ? " exec nebula-corners" : ""}${dim ? " dim" : ""}${
         selectable ? " selectable" : ""
-      }${selected ? " picked" : ""}`}
+      }${selected ? " picked" : ""}${card.tipo === "bug" ? " type-bug" : ""}`}
       role="button"
       tabIndex={0}
       aria-pressed={selectable ? selected : undefined}
@@ -444,32 +454,41 @@ function Card({
       onKeyDown={activateOnKey(activate)}
     >
       <div className="id-row">
-        {selectable ? (
-          <input
-            type="checkbox"
-            className="card-pick"
-            checked={selected}
-            aria-label={card.shortId}
-            onChange={() => onToggleSelect(card.id)}
-            onClick={(event) => event.stopPropagation()}
-          />
-        ) : null}
-        <CardId shortId={card.shortId} showProject={showProject} />
-        <span className={`tag ${card.tipo}`}>{card.tipo}</span>
-        {card.isExample ? <span className="selo">{t.board.example}</span> : null}
-        {card.awaitingMyReview ? (
-          <span className="review-chip">{t.board.yourReview}</span>
-        ) : null}
-        {card.supersedes ? (
-          <span className="selo">
-            {t.board.continues} {card.supersedes.shortId}
+        <div className="id-row-main">
+          {selectable ? (
+            <input
+              type="checkbox"
+              className="card-pick"
+              checked={selected}
+              aria-label={card.shortId}
+              onChange={() => onToggleSelect(card.id)}
+              onClick={(event) => event.stopPropagation()}
+            />
+          ) : null}
+          <CardId shortId={card.shortId} showProject={showProject} />
+          {/* Type reads as a plain word in the meta line, never a coloured
+              chip (ux-v2 §3): the only scanning aid a bug keeps is the card's
+              own left border, set from the `type-bug` class above. */}
+          <span className="id-sep" aria-hidden="true">
+            ·
           </span>
-        ) : null}
-        {card.status === "descartado" ? (
-          <span className="selo">
-            {t.board.discardedTo} {card.supersededBy?.shortId ?? "—"}
-          </span>
-        ) : null}
+          <span className="card-type">{card.tipo}</span>
+          {card.isExample ? <span className="selo">{t.board.example}</span> : null}
+          {card.awaitingMyReview ? (
+            <span className="review-chip">{t.board.yourReview}</span>
+          ) : null}
+          {card.supersedes ? (
+            <span className="selo">
+              {t.board.continues} {card.supersedes.shortId}
+            </span>
+          ) : null}
+          {card.status === "descartado" ? (
+            <span className="selo">
+              {t.board.discardedTo} {card.supersededBy?.shortId ?? "—"}
+            </span>
+          ) : null}
+        </div>
+        {costSegment ? <span className="card-cost">{costSegment.text}</span> : null}
       </div>
       {/* One line on the phone: the ellipsis points here and to the panel. */}
       <h4 title={card.title}>{card.title}</h4>
@@ -485,7 +504,12 @@ function Card({
         ) : null}
         {/* The separator belongs to what comes after the harness, not to the
             harness itself: an ellipsis on the model chain would eat it. */}
-        <CardMetaTail card={card} t={t} lead={harness != null} />
+        <CardMetaTail
+          card={card}
+          t={t}
+          lead={harness != null}
+          telemetryLine={footTelemetry}
+        />
       </div>
     </div>
   );

--- a/apps/web/src/styles/nebula.css
+++ b/apps/web/src/styles/nebula.css
@@ -1212,6 +1212,11 @@ body:has(.nb) { display: block; padding: 0; background: var(--nebula-void); }
 .nb .empty-col i { font-style: italic; }
 
 .nb .card {
+  /* The rounded border is the card's actual edge, not a suggestion: nothing
+     a descendant draws — a badge, the cost, the telemetry line — may sit
+     past it (OCL-84). Everything below that could overflow it also gets a
+     real max-width, so this is a backstop, not the whole fix. */
+  overflow: hidden;
   padding: var(--nebula-space-2) var(--nebula-space-4); position: relative; cursor: pointer;
   transition:
     transform 0.35s var(--nebula-ease-atmosphere),
@@ -1224,7 +1229,20 @@ body:has(.nb) { display: block; padding: 0; background: var(--nebula-void); }
   border-color: rgb(var(--oc-white-rgb) / 0.16);
   box-shadow: var(--oc-shadow-card-hover);
 }
-.nb .card .id-row { display: flex; align-items: center; flex-wrap: wrap; gap: var(--nebula-space-1) var(--nebula-space-2); margin-bottom: var(--nebula-space-1); }
+/* A bug carries no coloured chip (ux-v2 §3): the one scanning aid left is
+   this 3px rule at 40% alpha, on the card itself. */
+.nb .card.type-bug { border-left: 3px solid rgb(var(--oc-danger-rgb) / 0.4); }
+/* The id's own line: the left group (id, type, badges) wraps and shrinks;
+   the cost is fixed at the right, exactly where §3 draws it, so the footer
+   never has to make room for it. */
+.nb .card .id-row {
+  display: flex; align-items: flex-start; justify-content: space-between;
+  gap: var(--nebula-space-2); margin-bottom: var(--nebula-space-1);
+}
+.nb .card .id-row-main {
+  display: flex; align-items: center; flex-wrap: wrap; min-width: 0;
+  gap: var(--nebula-space-1) var(--nebula-space-2);
+}
 .nb .card .cid {
   font-family: var(--nebula-font-mono); font-size: 10px;
   color: var(--nebula-text-tertiary); letter-spacing: 0.06em;
@@ -1234,10 +1252,27 @@ body:has(.nb) { display: block; padding: 0; background: var(--nebula-void); }
   color: var(--nebula-text-secondary);
   font-weight: var(--nebula-weight-medium);
 }
+.nb .card .id-sep { color: var(--nebula-text-tertiary); }
+/* The type, a plain word in the meta line — no chip, no border, no fill
+   (ux-v2 §3 item 4). */
+.nb .card .card-type {
+  font-family: var(--nebula-font-mono); font-size: 10px;
+  color: var(--nebula-text-tertiary); letter-spacing: 0.03em;
+}
+/* Cost sits top-right, data face, text-3 — the one number the id-row
+   carries, so it never has to fight the footer for room. */
+.nb .card .card-cost {
+  flex: none; font-family: var(--nebula-font-mono); font-size: 11px;
+  color: var(--nebula-text-tertiary); white-space: nowrap;
+}
 .nb .selo {
   font-family: var(--nebula-font-label); font-size: 8.5px; letter-spacing: 0.08em;
   color: var(--nebula-text-tertiary); border: 1px solid var(--nebula-glass-border);
   border-radius: var(--oc-radius-pill); padding: 1px 7px;
+  /* A badge degrades with an ellipsis before it ever pushes past the card's
+     own edge (OCL-84): overflow other than visible is what lets a flex item
+     shrink below its own content width. */
+  max-width: 100%; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
 }
 .nb .tag {
   font-family: var(--nebula-font-label); font-size: 9.5px;
@@ -1248,17 +1283,23 @@ body:has(.nb) { display: block; padding: 0; background: var(--nebula-void); }
 .nb .tag.bug { color: var(--oc-tag-bug-fg); border-color: var(--oc-tag-bug-border); }
 .nb .tag.rfc { color: var(--oc-tag-rfc-fg); border-color: var(--oc-tag-rfc-border); }
 .nb .tag.feature { color: var(--oc-tag-feature-fg); border-color: var(--oc-tag-feature-border); }
-/* o título é o herói do card: primeiro no peso, não na ordem */
+/* o título é o herói do card: primeiro no peso, não na ordem.
+   13px is the rampa's body size (ux-v2 §2); two lines is the hard cap
+   (§3) — past that the ellipsis takes over and the full title moves to
+   the title attribute, already set where this renders. */
 .nb .card h4 {
-  font-size: 14px; font-weight: var(--nebula-weight-medium);
+  font-size: 13px; font-weight: var(--nebula-weight-medium);
   letter-spacing: var(--nebula-tracking-tight); color: var(--nebula-text-primary);
   line-height: 1.35; margin-bottom: var(--nebula-space-1);
+  display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical;
+  overflow: hidden;
 }
-/* one line only: planned and actual harness, then time, tokens and cost.
-   nowrap is the whole rule. When the column cannot hold everything, the line
-   gives up characters instead of gaining a second row: tokens shrink first
-   and end in an ellipsis, the model chain second, and the clock and the cost
-   never shrink, because those two are why anyone reads this line. */
+/* one line only: planned and actual harness, then time and tokens — cost
+   moved to the id-row (ux-v2 §3) and never reaches here. nowrap is the whole
+   rule. When the column cannot hold everything, the line gives up characters
+   instead of gaining a second row: tokens shrink first and end in an
+   ellipsis, the model chain second, and the clock never shrinks, because
+   that is why anyone reads this line. */
 .nb .card-foot {
   display: flex; align-items: center; flex-wrap: nowrap; gap: 5px;
   overflow: hidden;
@@ -1324,6 +1365,7 @@ body:has(.nb) { display: block; padding: 0; background: var(--nebula-void); }
   font-family: var(--nebula-font-label); font-size: 10px; color: var(--oc-chip-review-fg);
   background: var(--oc-chip-review-bg);
   border: 1px solid var(--oc-chip-review-border); border-radius: var(--oc-radius-pill); padding: 2px 8px;
+  max-width: 100%; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
 }
 /* em execução: cantos vivos + borda com a cor de execução, bem de leve */
 .nb .card.exec { border-color: rgb(var(--oc-info-rgb) / 0.16); }


### PR DESCRIPTION
## Summary
- Cost moves to the id-row top-right (data face 11px text-3, ux-v2 §3), so the footer no longer competes with it for room — this was the root cause of the up-to-137px overflow.
- Type is now a plain word in the meta line instead of a coloured chip; a `bug` card keeps only the permitted 3px left border in `--oc-danger` at 40% alpha.
- `.card h4` clamps to 2 lines at 13px (rampa's body size), was 14px/no clamp.
- `.selo`/`.review-chip` get a real overflow/ellipsis floor so they degrade instead of overflowing; `.card` gets `overflow: hidden` as a backstop.
- Scoped strictly to `apps/web/src/app/home/board.tsx` (`Card` component) and `apps/web/src/styles/nebula.css`; tokens-only (`--oc-*`), no hex/rgba literals.

## Test plan
- [x] `npx vitest run src/styles/tokens.test.ts src/styles/layers.test.ts src/lib/board-row.test.ts src/lib/format.test.ts src/app/home/release-header.test.ts` — 50/50 pass
- [x] Full `npx vitest run` — 239/239 runnable tests pass (25 unrelated integration suites fail on this checkout because `@agent-board/mcp-core` isn't built here; confirmed pre-existing on a clean checkout via `git stash`, unrelated to this change)
- [ ] Manual visual check on the running app at 1440/1100/900/700px (not run in this session — no DB available in this worktree)

**Harness deviation:** the card's cardápio recommends `kimi · k3 · max`; per the owner's instruction this card was executed with Claude Code (Claude account 2, sonnet-5) instead. Logged on the OverClick card (OCL-84) at delivery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)