### PR TITLE
[OCL-86] Controls da barra: gatilho de missão vira Control, Mover para missão condicional

### DIFF
--- a/apps/web/src/app/home/home-shell.tsx
+++ b/apps/web/src/app/home/home-shell.tsx
@@ -425,17 +425,24 @@ export function HomeShell({
                 {t.board.clearFilters}
               </button>
             ) : null}
-            <button
-              className={`btn-ghost move-btn${picking ? " on" : ""}`}
-              type="button"
-              onClick={() => {
-                setFiltersOpen(false);
-                if (picking) stopPicking();
-                else setPicking(true);
-              }}
-            >
-              {picking ? t.board.cancelSelection : t.board.moveToMission}
-            </button>
+            {/* ux-v2 §3: "Mover para missão" appears only with cards
+                selected, right-aligned — an impossible action with nothing
+                picked has no reason to sit on the bar (OCL-86). The trigger
+                for entering picking mode is a separate concern outside this
+                card's scope; `selected` is the real precondition. */}
+            {selected.length > 0 ? (
+              <button
+                className={`btn-ghost move-btn${picking ? " on" : ""}`}
+                type="button"
+                onClick={() => {
+                  setFiltersOpen(false);
+                  if (picking) stopPicking();
+                  else setPicking(true);
+                }}
+              >
+                {picking ? t.board.cancelSelection : t.board.moveToMission}
+              </button>
+            ) : null}
           </div>
           <button
             className="filters-btn"

--- a/apps/web/src/styles/nebula.css
+++ b/apps/web/src/styles/nebula.css
@@ -868,7 +868,7 @@ body:has(.nb) { display: block; padding: 0; background: var(--nebula-void); }
 .nb .topbar-l1 .state-chip,
 .nb .topbar-l1 .am-trigger,
 .nb .topbar-l2 .pf-trigger,
-.nb .topbar-l2 .mf-chip,
+.nb .topbar-l2 .mf-trigger,
 .nb .topbar-l2 .ff-trigger,
 .nb .topbar-l2 .filters-btn,
 .nb .topbar-l2 .btn-ghost {
@@ -888,7 +888,7 @@ body:has(.nb) { display: block; padding: 0; background: var(--nebula-void); }
 .nb .topbar-l1 .state-chip:hover,
 .nb .topbar-l1 .am-trigger:hover,
 .nb .topbar-l2 .pf-trigger:hover,
-.nb .topbar-l2 .mf-chip:hover,
+.nb .topbar-l2 .mf-trigger:hover,
 .nb .topbar-l2 .ff-trigger:hover,
 .nb .topbar-l2 .filters-btn:hover,
 .nb .topbar-l2 .btn-ghost:hover {
@@ -916,8 +916,7 @@ body:has(.nb) { display: block; padding: 0; background: var(--nebula-void); }
 }
 /* an applied filter reads as text-1 with the count badge, never as a
    colour of its own */
-.nb .topbar-l2 .ff-trigger.on,
-.nb .topbar-l2 .mf-chip.on { color: var(--nebula-text-primary); }
+.nb .topbar-l2 .ff-trigger.on { color: var(--nebula-text-primary); }
 .nb .topbar-l2 .badge {
   display: inline-flex; align-items: center; justify-content: center;
   min-width: 18px; height: 18px; padding: 0 5px; border-radius: 9px;
@@ -928,11 +927,21 @@ body:has(.nb) { display: block; padding: 0; background: var(--nebula-void); }
 .nb .topbar-l2 .ff-query-badge {
   max-width: 132px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
 }
-/* the mission chip is the bordered control; the trigger inside it stays
-   bare so the whole chip is the hit area */
-.nb .topbar-l2 .mf-trigger, .nb .topbar-l2 .mf-clear {
-  font: inherit; letter-spacing: inherit; color: inherit;
+/* the trigger itself is the bordered control (ux-v2 §3, OCL-86): the chip
+   div is a bare flex wrapper so trigger and clear sit side by side without
+   drawing a second box around the anatomy above. */
+.nb .topbar-l2 .mf-chip {
+  border: 0; border-radius: 0; padding: 0; background: transparent;
 }
+.nb .topbar-l2 .mf-chip.on .mf-trigger,
+.nb .topbar-l2 .mf-chip.on .mf-clear {
+  color: var(--nebula-text-primary);
+}
+.nb .topbar-l2 .mf-chip.on .mf-trigger {
+  border-color: var(--oc-border-strong);
+  background: var(--oc-surface-hover);
+}
+.nb .topbar-l2 .mf-clear { color: var(--nebula-text-secondary); }
 .nb .topbar-l2 .pf-trigger svg,
 .nb .topbar-l2 .mf-trigger svg,
 .nb .topbar-l2 .ff-trigger svg { flex: none; }


### PR DESCRIPTION
## Summary
- `.mf-trigger` (gatilho de missão) media 16px de altura e borda 0 porque a anatomia de Control (ux-v2 §3) estava aplicada em `.mf-chip` (o wrapper), não no botão em si. Move a anatomia (32px, borda 1px, raio 8px, gap 6px) para `.mf-trigger`, igualando `.pf-trigger`/`.ff-trigger`, e reduz `.mf-chip` a um wrapper flex sem chrome próprio.
- "Mover para missão" agora só renderiza com `selected.length > 0` (§3: "appears only with cards selected"), em vez de ocupar o canto direito permanentemente.

## Decisão registrada (desvio de leitura, não de doutrina)
`picking` foi deliberadamente removido da condição de visibilidade do botão: gatear nele seria o paradoxo ovo/galinha que eu mesmo levantei (hoje `picking` só liga clicando neste botão). Por decisão explícita do dono nesta sessão, a condição final é estritamente `selected.length > 0`. Efeito colateral aceito: como nada mais popula `selected` hoje, o botão fica oculto na prática até um card futuro abrir outra entrada para o modo de seleção dos cards do board — fora do escopo deste card (só gatilhos da L2, sem redesenhar topbar/board).

## Harness
Cardápio do card pedia `kimi · k3 · max`; executado com `claude-code · sonnet-5` por instrução direta do dono nesta sessão (desvio registrado no `task_claim`/`task_deliver`).

## Test plan
- [x] `npm run typecheck` — sem erros novos nos arquivos tocados (erros pré-existentes em `src/mcp/*` não relacionados)
- [x] `npx vitest run` (apps/web) — 503 passed, 2 skipped, guards de estilo (`tokens.test.ts`, `layers.test.ts`, `backdrop-filter.test.ts`) verdes
- [ ] Verificação visual manual em 1440/1100/900/700px (checklist do card) — pendente de revisão humana

🤖 Generated with [Claude Code](https://claude.com/claude-code)