### PR TITLE
[OCL-87][OCL-88] Emendas de doutrina: piso de toque (A1) e conformidade de tema (A2)

### DIFF
--- a/docs/design/amendments.md
+++ b/docs/design/amendments.md
@@ -1,0 +1,285 @@
+# Amendments — where the doctrine contradicted itself, and what was decided
+
+> OCL-87, OCL-88. Each entry: the conflict as measured, the decision, the
+> rationale, and the tokens and files the decision touches.
+>
+> An amendment is **normative the moment it lands**: the corresponding rules in
+> [`ux-v2.md`](./ux-v2.md) are edited in the same commit, and this file is the
+> record of *why* they now read the way they do. Implementation of the code that
+> the amendment makes necessary is scoped to its own cards, listed at the end of
+> each entry.
+>
+> Relation to [`system/decisions.md`](./system/decisions.md): that file records
+> what the doctrine **did not cover**; this one records where the doctrine
+> **said two incompatible things** and which one survived.
+
+---
+
+## A1 — The touch floor is a pointer-conditional hit floor, not a control height
+
+**Card:** OCL-87 · **Origin:** design review OCL-79, finding C3
+· **Amends:** §1 (Air), §2 (token table), §3 (the Control), §5 (item 12, new item 16)
+
+### The conflict, as it stood
+
+Four passages of the doctrine could not all be true at once:
+
+| Where | Text |
+|---|---|
+| §3, the Control | `height 32px · padding 0 12px · radius --oc-radius-control` |
+| §1, Air | "Density is bought with padding and type size, never by shrinking targets (the 44px floor in `--nebula-tap` stays law)." |
+| §2, tokens | `--oc-tap` = 44px in every theme |
+| §5, item 12 | "44px touch floor held on every control (density via padding only)." |
+
+A control cannot be a 32px box and a 44px target at the same time. The
+implementation followed §3, so item 12 fails almost everywhere. Measured in
+production v0.2.1: topbar controls 32px, `.mf-trigger` 16px, cost stat 19px,
+`.am-theme-opt` 23px, `.mchip` 20px, `.seen-add` 30px, banner buttons 31px,
+modal buttons 33px. The Settings tabs (44px) are the only place the floor holds.
+
+### The decision
+
+**The 44px floor is kept, and scoped to touch. The 32px Control is kept, and
+scoped to a fine pointer. Neither number moves; what changes is what each one
+governs.** Three rules, all binary:
+
+1. **`--oc-tap` stays 44px in every theme**, and stops meaning "the height of a
+   control". It now governs one thing: **the minimum hit-target dimension,
+   both axes, under a coarse pointer.** It is never used as a `height` or a
+   `min-height` on a visual box.
+2. **A new token `--oc-tap-min: 24px`** carries the floor that holds
+   *everywhere*, pointer included — the WCAG 2.2 AA minimum target size
+   (SC 2.5.8). No interactive element in the board may have a hit box under
+   24×24 CSS px on any device.
+3. **The visual box is unchanged and stays a design decision:** 32px for
+   compact controls, 36px for form fields (system `decisions.md` D2). Density
+   is still bought with padding and type size; what §1 forbids shrinking is the
+   **hit area**, which is now a distinct thing from the box.
+
+So a 32px topbar control is compliant on a desktop (32 ≥ 24) and must present a
+44px hit area on a phone. A 16px `.mf-trigger` is a **bug in every context** —
+it fails the pointer floor too — which is the outcome that matters most here:
+the amendment must not be readable as a license for 16px triggers.
+
+### The technique, written so two executors converge
+
+The hit area grows with a non-painting `::after`, centred on the element. The
+element's box, its layout and its neighbours' positions do not move.
+
+```css
+/* Base utility. Every interactive element carries .oc-tappable, or is matched
+   by the element selectors below in the base stylesheet. */
+.oc-tappable { position: relative; }
+
+.oc-tappable::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  translate: -50% -50%;
+  width: max(100%, var(--oc-tap-min));
+  height: max(100%, var(--oc-tap-min));
+}
+
+@media (pointer: coarse) {
+  .oc-tappable::after {
+    width: max(100%, var(--oc-tap));
+    height: max(100%, var(--oc-tap));
+  }
+}
+```
+
+Four constraints that make it work, and that a reviewer checks:
+
+- **No ancestor between the control and the bar may clip it.** An
+  `overflow: hidden` on the row cuts the expanded area back to the visual box
+  and silently reverts the fix. If the row must clip, the control's own hit
+  area grows by `min-block-size` instead and the row grows with it.
+- **Neighbours need `gap`.** Two 32px controls 4px apart get 44px areas that
+  overlap; the later one in the DOM wins the tap. Any row of tappables under a
+  coarse pointer holds `gap: var(--oc-space-2)` (8px) or more — which is what
+  makes the expansion honest rather than decorative.
+- **Replaced elements have no pseudo-elements.** A bare
+  `input[type="checkbox"]` / `[type="radio"]` / `[type="range"]` cannot carry
+  `::after`. Those are wrapped in their `<label>`, and the label is the
+  `.oc-tappable`.
+- **The pseudo-element paints nothing.** No background, no border, no
+  `box-shadow`. It exists to receive pointer events; it inherits
+  `pointer-events` from the control, so a tap on it is a tap on the control.
+
+### Rationale
+
+The literal reading of §1 ("never by shrinking targets") pointed at Option A —
+a 44px area everywhere, including desktop. It was rejected on the evidence:
+
+- **It is not what accessibility actually requires.** WCAG 2.2 sets the
+  normative minimum at **24×24 CSS px (SC 2.5.8, AA)**, with an exception when
+  spacing compensates. 44×44 comes from SC 2.5.5 (**AAA**) and from touch
+  platform guidance (Apple HIG 44pt, Material 48dp) — guidance written for a
+  finger, whose contact patch is ~10mm, not for a cursor with single-pixel
+  precision. A 32px control with a mouse clears AA with 33% to spare.
+- **Invisible 44px areas on a desktop cost more than they buy.** They overlap
+  in dense bars, they steal taps from the element next door, and they make the
+  clickable region disagree with the drawn region — a worse accessibility
+  outcome for low-vision and motor-impaired pointer users than an honest 32px
+  box, because the target you see is no longer the target you hit.
+- **Desktop density is the product's direction.** This board is a work
+  instrument read at 1440px with dozens of cards in view; §1's whole thesis is
+  air *between* elements, not fat elements. Option C (44px controls
+  everywhere) inflates the topbar by 37% in height and contradicts §3 as
+  written and as already shipped.
+- **The floor still binds where the risk is real.** On a phone every one of
+  those measured elements — 16, 19, 20, 23, 30px — becomes a 44px target, which
+  is where mis-taps actually happen.
+
+The system doctrine already anticipated this: `system/decisions.md` D2 says
+"below 768px the hit area grows to `var(--oc-tap)` without changing the visual
+height". This amendment promotes that sentence into the doctrine, replaces the
+width breakpoint with `(pointer: coarse)` — the honest signal, since a 1024px
+tablet is a finger and a 700px window on a laptop is not — and adds the 24px
+floor that D2 did not have.
+
+### Tokens and files affected
+
+| What | Where | Change |
+|---|---|---|
+| `--oc-tap` | `apps/web/src/styles/themes/nebula.css:252` (inherited by `xai`, `overclock`) | Value unchanged (44px); role redefined. Doc comment updated to "coarse-pointer hit floor". |
+| `--oc-tap-min` | same file, next to `--oc-tap` | **New**, `24px`, all themes. |
+| `--nebula-tap` | `apps/web/src/styles/nebula.css:146` | Alias stays; any rule using it as a `height`/`min-height` is a violation. |
+| `.oc-tappable` | base stylesheet (`nebula.css`, control layer) | **New** utility, the block above. |
+| Failing components | `.mf-trigger` (16px), cost stat (19px), `.mchip` (20px), `.am-theme-opt` (23px), `.seen-add` (30px), banner buttons (31px), modal buttons (33px) | Adopt `.oc-tappable`; the four under 24px are pointer-floor bugs and are fixed on both pointers. |
+| Token snapshot | `apps/web/src/styles/__snapshots__/tokens.test.ts.snap` | Gains `--oc-tap-min`. |
+| Guard | `apps/web/src/styles/` (sibling of `layers.test.ts`) | **New** test, see below. |
+
+### The checklist item is now machine-checkable
+
+Item 12 becomes: measure `el.getBoundingClientRect()` unioned with the
+`::after` box for every element matching the interactive selector set, once
+with `pointer: fine` and once with `pointer: coarse` emulated. Pass = every box
+≥ 24×24 in the first pass and ≥ 44×44 in the second. No human judgement, no
+screenshot.
+
+### Follow-up cards (not this one)
+
+- **Implementation:** adopt `.oc-tappable`, add `--oc-tap-min`, fix the seven
+  measured components. Closes checklist 12.
+- **Guard:** the Playwright/JSDOM test above, so item 12 stops being an opinion.
+
+---
+
+## A2 — When an extracted palette contradicts §1: three tiers of law
+
+**Card:** OCL-88 · **Origin:** design review OCL-79, findings B1–B5
+· **Amends:** §2 (new "Theme conformance" subsection), §5 (every item tagged, new items 17–18)
+
+### The conflict, as it stood
+
+§2 wrote an exemption for exactly one theme — "`nebula` must be pixel-faithful
+to today" — and left `overclock` as a TODO. Then OCL-56 built `overclock` by
+extracting the Overclock app's palette token by token, documenting the source of
+each value, which is precisely what its scope map asked for. The result fails
+~6 of the 15 checklist items **by construction**, and the file is not wrong: the
+doctrine never said what happens when a real product's palette disagrees with
+§1's universal laws.
+
+Measured in `apps/web/src/styles/themes/overclock.css`:
+
+1. `--oc-accent-rgb: 239 68 68` and `--oc-danger-rgb: 239 68 68` — accent and
+   danger are the same `#ef4444`. Selected, primary, error and destructive are
+   visually identical.
+2. `--oc-focus-ring: 0 0 0 2px rgb(var(--oc-accent-rgb)/0.65)` and
+   `--oc-border-strong: rgb(var(--oc-accent-rgb)/0.4)` — keyboard focus and
+   every hover paint the error red.
+3. Kill-list items return: `--oc-tag-feature-fg: #22d3ee`,
+   `--oc-tag-rfc-fg: #8b5cf6`, `--oc-radius-pill: 999px`,
+   `--oc-font-label: var(--oc-font-data)`, a red `--oc-plan-glow`,
+   `--oc-warn: #facc15`, `--oc-info: #06b6d4`.
+4. The grays carry hue: `#1f2937`, `#9ca3af`, `#6b7280` (blue slate) where
+   `nebula` and `xai` use white with alpha.
+
+### The decision
+
+**Neither blanket exemption nor blanket conformance. The checklist splits into
+two kinds of law, and a theme may only diverge from one of them — in writing.**
+
+**Tier 1 — universal. No theme may break these, ever.** They are the rules
+where breaking them changes what the user *understands*, not what they see:
+
+| # | Law | Binary test |
+|---|---|---|
+| U1 | **`--oc-accent` ≠ `--oc-danger`.** A theme may not resolve both to the same colour. | The two computed colours differ by ≥25° of OKLCH hue **or** ≥0.15 of OKLCH lightness. Equal values fail. |
+| U2 | **The focus ring is neutral in every theme.** It never carries the accent when the accent is a semantic colour, and never carries `--oc-danger`. | `--oc-focus-ring`'s colour has OKLCH chroma ≤ 0.04 and is not in the danger hue family. |
+| U3 | **Hover and open borders are neutral.** `--oc-border-strong` is a gray-ladder value; colour is not decoration. | Same chroma test as U2. |
+| U4 | **`--oc-ok` / `--oc-danger` are reserved to meaning** — status dots, status text, error text, destructive actions. A theme picks its red and green; it may not spend them elsewhere. | No other token resolves to the `--oc-ok`/`--oc-danger` values. |
+| U5 | **Layout tokens are identical across themes.** A theme declares values, never a size that moves a box. | Existing checklist 14. |
+| U6 | **Type ramp, Control anatomy, and the A1 hit floors** hold in every theme. | Checklist 3, 12. |
+
+**Tier 2 — theme-scoped. A theme may diverge, and must declare it.** These are
+identity and taste: accent hue (an accent need not be white), radius family
+including pills, the label face (mono as the UI voice), tag foreground colours,
+decorative glow, extra semantic colours (`warn`, `info`), and the hue of the
+gray ladder. One guard rides along: **a Tier-2 colour may not equal `--oc-ok`
+or `--oc-danger`** — a cyan `feature` tag is identity, a red one is a lie.
+
+**Tier 3 — the declaration.** Every theme file opens with an `EXEMPTIONS`
+block, one line per Tier-2 divergence with the doctrine rule it departs from and
+the source of the value. **An undeclared divergence is a bug**; a declared one
+is the theme. `nebula`'s exemption ("pixel-faithful to today") is restated in
+this form. `xai` is the reference implementation and declares none: it is the
+only theme required to pass all 15 items.
+
+Applied to `overclock`, the theme **stays in the selector**, keeps its identity,
+and changes four values:
+
+| Token | Today | Becomes | Law |
+|---|---|---|---|
+| `--oc-danger-rgb` | `239 68 68` (= accent) | a red distinguishable from the accent — darker/deeper, e.g. the deep red already present as `--oc-danger-deep-rgb: 127 29 29`, or the accent's `#dc2626` hover shade promoted to danger with the accent staying `#ef4444` | U1 |
+| `--oc-focus-ring` | `rgb(accent / 0.65)` (red) | the neutral verbatim ring, `rgba(209,217,235,0.55)` family | U2 |
+| `--oc-focus-ring-inset` | idem | idem | U2 |
+| `--oc-border-strong` | `rgb(accent / 0.4)` (red) | a gray-ladder value, e.g. the app's own `--color-faint #4b5563` | U3 |
+
+And keeps, declared as exemptions: `--oc-radius-pill: 999px`,
+`--oc-font-label: var(--oc-font-data)`, `--oc-tag-feature-fg`,
+`--oc-tag-rfc-fg`, `--oc-plan-glow`, `--oc-warn`, `--oc-info`, and the hued
+gray ladder — all of them sourced, line by line, from the product.
+
+### Rationale
+
+- **Items 1 and 2 are usability, not taste.** If selection and error are the
+  same red, "this card is selected" and "this card is broken" are the same
+  pixel — and no amount of brand fidelity earns that. The same red on the focus
+  ring means a keyboard user walking the topbar sees every stop announce
+  itself as an error. These break comprehension in *any* palette, which is
+  what makes them universal rather than `xai`-flavoured.
+- **The rest is legitimately the product.** Pills, mono labels, the agent
+  colour spectrum, the red haze: these are what the Overclock app *is*. A
+  doctrine that forbids a theme from looking like the product it dresses has
+  no reason to offer a third theme at all. Option C (drop the theme) throws
+  away work that did exactly what it was asked to do.
+- **Blanket exemption (Option A alone) was rejected** because it makes the
+  checklist unfalsifiable: with "theme-scoped" undefined, every future review
+  reopens the same six findings and argues them again from zero. Tiers make the
+  argument once.
+- **The declaration is the cheap half of the fix.** It costs a comment block
+  and converts "this theme fails 6 items" into "this theme declares 8
+  exemptions and passes every universal law" — a sentence a reviewer can check
+  in one pass.
+
+### Tokens and files affected
+
+| What | Where | Change |
+|---|---|---|
+| Doctrine | `docs/design/ux-v2.md` §2, §5 | This card. Tier definitions, per-item `[universal]`/`[theme]` tags. |
+| `--oc-danger-rgb`, `--oc-focus-ring`, `--oc-focus-ring-inset`, `--oc-border-strong` | `apps/web/src/styles/themes/overclock.css:59, 95, 203, 205` | Four values, follow-up card. |
+| `EXEMPTIONS` block | `themes/overclock.css` header, `themes/nebula.css` header | New; `xai` states "none". |
+| `--oc-haze-rgb: 239 68 68` | `themes/overclock.css:69` | Reviewed under U4 — it feeds `--oc-plan-glow` (declared exemption), so it stays, but it may not reach a status surface. |
+| Guard | `apps/web/src/styles/tokens.test.ts` | Gains the U1–U4 assertions, run per theme. |
+
+Not touched by this card: the theme file itself. The doctrine lands first.
+
+### Follow-up cards (not this one)
+
+- **Implementation:** the four `overclock.css` values + the `EXEMPTIONS` blocks
+  in all three theme files. Closes checklist items 2 (the semantic half), 10,
+  16, 17.
+- **Guard:** U1–U4 as assertions in `tokens.test.ts`, evaluated for every theme.

--- a/docs/design/ux-v2.md
+++ b/docs/design/ux-v2.md
@@ -4,6 +4,11 @@
 > a change that contradicts it is wrong until the doctrine itself is amended.
 > Implementation is split across OCL-34 (themes), OCL-35 (topbar), OCL-36 (numbers),
 > OCL-37 (brand) — see the scope map at the end.
+>
+> Amendments in force: **A1** (touch floor, OCL-87) and **A2** (theme
+> conformance, OCL-88). The rules below already read as amended; the conflict
+> each one resolved and the reasoning behind it live in
+> [`amendments.md`](./amendments.md).
 
 Direction in one line: **the x.ai school — near-black, one typeface speaking through
 weight, one accent, generous air, and not a single decorative color.**
@@ -26,8 +31,11 @@ weight, one accent, generous air, and not a single decorative color.**
   UI face; monospace is demoted from "the whole interface" to a *data voice* — ids,
   counts, money, code. Today the entire board speaks 10–11px mono; that reads as
   terminal soup, not as x.ai.
-- **Air.** Density is bought with padding and type size, never by shrinking targets
-  (the 44px floor in `--nebula-tap` stays law).
+- **Air.** Density is bought with padding and type size, never by shrinking the
+  **hit area** (A1). The visual box may be as compact as 32px; the area that
+  receives the tap never goes under `--oc-tap-min` (24px) on any device, and never
+  under `--oc-tap` (44px) where the pointer is a finger. The box and the target are
+  two different things, and only one of them is negotiable.
 - **1px borders, low-alpha white.** Edges whisper (`rgba(255,255,255,.08)` at rest,
   `.14` on hover). No colored borders as decoration.
 
@@ -43,8 +51,8 @@ weight, one accent, generous air, and not a single decorative color.**
 | Keep | Current value | Why |
 |---|---|---|
 | Canvas | `--nebula-void: #000000` | Already the right floor |
-| Focus ring | `0 0 0 2px rgba(209,217,235,0.55)` + offset | Correct pattern: outside the control, never resizes it |
-| Tap floor | `--nebula-tap: 44px` | Accessibility law |
+| Focus ring | `0 0 0 2px rgba(209,217,235,0.55)` + offset | Correct pattern: outside the control, never resizes it — and **neutral in every theme** (A2/U2): a focus ring in the danger colour announces every keyboard stop as an error |
+| Tap floor | `--nebula-tap: 44px` | Accessibility law — under a coarse pointer. It is a **hit-area floor, never a `height`** (A1) |
 | Panel solid | `rgb(13,15,19)` | The "no glass when the panel is the screen" rule is right |
 | Spacing scale | 4/8/12/16/24/32 | Sane; gains a 48 step for section air |
 | Motion ease | `cubic-bezier(0.22,0.61,0.36,1)`, 150–300ms micro | Keep |
@@ -66,9 +74,10 @@ weight, one accent, generous air, and not a single decorative color.**
 
 All board styles migrate to `--oc-*` custom properties. A theme is a file in
 `apps/web/src/styles/themes/<name>.css` that only redefines tokens. `nebula` must be
-pixel-faithful to today; `xai` is the new direction; `overclock` is a placeholder
-until its values are extracted from the Overclock app (TODO — OCL-34 documents the
-source of each extracted value).
+pixel-faithful to today; `xai` is the reference implementation of this document;
+`overclock` is the board wearing the product's own palette, extracted from the
+Overclock app and documented value by value (OCL-56). What a theme may and may not
+diverge on is settled below, in **Theme conformance**.
 
 Type ramp (all themes): 22/16/13/12/11 px = display/title/body/label/data,
 weights 400/500/600 only. UI face: `Inter, -apple-system, sans-serif`.
@@ -94,14 +103,54 @@ Data face: `"SF Mono", ui-monospace, Menlo, monospace`.
 | `--oc-radius-control` | buttons, chips, inputs | mixed 7–999px | `8px` (uniform; pills die) | TODO |
 | `--oc-radius-panel` | cards, popovers, modal | 16px | `12px` | TODO |
 | `--oc-space-1..8` | 4/8/12/16/24/32 | same | same + `--oc-space-9: 48px` | TODO |
-| `--oc-focus-ring` | focus | current double ring | same values | TODO |
-| `--oc-tap` | touch floor | 44px | 44px | TODO |
+| `--oc-focus-ring` | focus — **neutral in every theme** (A2/U2) | current double ring | same values | same values |
+| `--oc-tap` | **coarse-pointer hit floor** (A1) — never a `height` | 44px | 44px | 44px |
+| `--oc-tap-min` | **universal hit floor**, every pointer (A1, WCAG 2.2 SC 2.5.8) | 24px | 24px | 24px |
 | `--oc-shadow-panel` | floating panels | `0 8px 32px rgba(0,0,0,0.5)` | `0 8px 24px rgba(0,0,0,0.6)` | TODO |
 | `--oc-duration` / `--oc-ease` | micro-motion | 150–300ms / atmosphere curve | same | TODO |
 
 Rules: no component may use a hex/rgba literal — tokens only. `--oc-ok`/`--oc-danger`
 may appear **only** on status dots, status text, error text and destructive actions;
 never on tags, counters, borders-as-decoration.
+
+The `overclock` column above was written before the theme existed. The theme file
+(`themes/overclock.css`) is now the source of truth for its values and documents the
+origin of each; its declared divergences from this document are listed under Theme
+conformance, below.
+
+### Theme conformance — when an extracted palette contradicts §1 (A2)
+
+A theme built by extracting a real product's palette will contradict this document,
+because the product was not designed against it. That is expected and it is not a
+defect of the theme. What follows decides which contradictions are allowed.
+
+**Tier 1 — universal. No theme may break these, in any circumstance.** These are
+the rules whose violation changes what the user *understands*, not what they see:
+
+| # | Law | Binary test |
+|---|---|---|
+| U1 | `--oc-accent` ≠ `--oc-danger`. A theme may not resolve both to the same colour. | The two computed colours differ by ≥25° of OKLCH hue **or** ≥0.15 of OKLCH lightness. Equal values fail. |
+| U2 | The focus ring is **neutral** in every theme — never `--oc-danger`, and never the accent when the accent is a semantic colour. | `--oc-focus-ring`'s colour has OKLCH chroma ≤ 0.04 and is not in the danger hue family. |
+| U3 | Hover and open borders are neutral. Colour is not decoration. | Same chroma test as U2, on `--oc-border-strong`. |
+| U4 | `--oc-ok` / `--oc-danger` are reserved to meaning: status dots, status text, error text, destructive actions. A theme picks its red and green; it may not spend them elsewhere. | No other token resolves to the `--oc-ok` / `--oc-danger` value. |
+| U5 | A theme declares values only — never a size that moves a box. | Checklist 14. |
+| U6 | Type ramp, Control anatomy and the hit floors of A1 hold in every theme. | Checklist 3, 12. |
+
+**Tier 2 — theme-scoped. A theme may diverge, and must declare it.** Identity and
+taste: accent hue (an accent need not be white), the radius family including pills,
+the label face (mono as the UI voice), tag foreground colours, decorative glow,
+extra semantic colours (`warn`, `info`), and the hue of the gray ladder. One guard
+rides along: **a Tier-2 colour may not equal `--oc-ok` or `--oc-danger`** — a cyan
+`feature` tag is identity, a red one is a lie.
+
+**Tier 3 — the declaration.** Every theme file opens with an `EXEMPTIONS` block:
+one line per Tier-2 divergence, naming the rule it departs from and the source of
+the value. **An undeclared divergence is a bug**; a declared one is the theme.
+`nebula`'s exemption is "pixel-faithful to today". `overclock`'s is "the board
+wearing the product": pills, mono labels, the agent colour spectrum on tags, the
+red haze, `warn`/`info`, and a hued gray ladder — all sourced from the Overclock
+app. `xai` declares none and is the only theme required to pass every item of the §5
+checklist, universal and theme-scoped alike.
 
 ### Layers (`--oc-z-*`, OCL-59)
 
@@ -159,6 +208,51 @@ active  → (filter applied) text-1 + count badge:
 
 The funnel icon is Lucide `filter` at 14px — never an emoji, never a toggle-switch
 graphic. Minimum 16px gap between the wordmark block and the first control.
+
+**Hit area (A1).** The 32px above is the *drawn box*. Every Control — and every
+other interactive element in the board — also carries a hit area that never falls
+below `--oc-tap-min` (24px), and grows to `--oc-tap` (44px) under a coarse pointer.
+The area grows without moving the box, with a non-painting pseudo-element:
+
+```css
+.oc-tappable { position: relative; }
+
+.oc-tappable::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  translate: -50% -50%;
+  width: max(100%, var(--oc-tap-min));
+  height: max(100%, var(--oc-tap-min));
+}
+
+@media (pointer: coarse) {
+  .oc-tappable::after {
+    width: max(100%, var(--oc-tap));
+    height: max(100%, var(--oc-tap));
+  }
+}
+```
+
+Four constraints, all of them review points:
+
+- No ancestor between the control and the bar may `overflow: hidden` it — clipping
+  reverts the fix silently. If the row must clip, the control grows its own
+  `min-block-size` instead and the row grows with it.
+- A row of tappables holds `gap: var(--oc-space-2)` (8px) or more under a coarse
+  pointer; otherwise the expanded areas overlap and the later element in the DOM
+  steals the tap.
+- Replaced elements (`input[type="checkbox"|"radio"|"range"]`) have no
+  pseudo-elements: they are wrapped in their `<label>`, and the label is the
+  `.oc-tappable`.
+- The pseudo-element paints nothing — no background, no border, no shadow. It
+  inherits `pointer-events` from the control, so a tap on it is a tap on the
+  control.
+
+`--oc-tap` is never written as a `height` or `min-height` on a visual box. A
+control that is under 24px drawn *and* under 24px in hit area is a bug on every
+device, not a dense control.
 
 ### Topbar — two levels
 
@@ -230,24 +324,46 @@ OCL-24 stays.
 
 ## 5. Acceptance checklist (binary — implementation cards cite these)
 
-1. [ ] No hex/rgba literal in any component rule; tokens only.
-2. [ ] Zero colored type/priority badges; `--oc-ok`/`--oc-danger` appear only on
-       status dots, status/error text, destructive actions.
-3. [ ] Every topbar trigger follows the Control anatomy (32px, 1px border, 8px
-       radius, 14px SVG icon); no bare-text triggers, no pill toggles.
-4. [ ] ≥16px between wordmark and first control at every width.
-5. [ ] Topbar renders as two levels ≥768px; L1 never wraps nor truncates.
-6. [ ] Mission chip shows ≥60ch before ellipsis at 1440px.
-7. [ ] UI text is the UI face; mono appears only on ids, numbers, timestamps, code.
-8. [ ] Money always labeled + currency-explicit; no unlabeled number groups.
-9. [ ] "~" explained in the stat popover with both counts.
-10. [ ] Focus ring visible on every interactive element (keyboard walk of topbar,
-        card, modal).
-11. [ ] No hover scale transforms; hover = surface/border/text change in 150–300ms.
-12. [ ] 44px touch floor held on every control (density via padding only).
-13. [ ] No horizontal scroll at 375/768/1024/1440 in any theme.
-14. [ ] Theme switch (nebula ⇄ xai) changes zero layout — only token values.
-15. [ ] `prefers-reduced-motion` disables non-essential animation.
+Every item is tagged **[universal]** — it holds in every theme, no exemption
+possible — or **[theme]** — `xai` and `nebula` must pass it, and another theme may
+diverge only by declaring it in its `EXEMPTIONS` block (§2, Theme conformance).
+
+1. [ ] **[universal]** No hex/rgba literal in any component rule; tokens only.
+2a. [ ] **[universal]** `--oc-ok`/`--oc-danger` appear only on status dots,
+        status/error text and destructive actions — never on tags, counters or
+        borders-as-decoration.
+2b. [ ] **[theme]** Zero coloured type/priority badges; type is a plain word.
+3. [ ] **[universal]** Every topbar trigger follows the Control anatomy (32px box,
+       1px border, `--oc-radius-control`, 14px SVG icon); no bare-text triggers, no
+       pill toggles. The radius *value* is [theme].
+4. [ ] **[universal]** ≥16px between wordmark and first control at every width.
+5. [ ] **[universal]** Topbar renders as two levels ≥768px; L1 never wraps nor
+       truncates.
+6. [ ] **[universal]** Mission chip shows ≥60ch before ellipsis at 1440px.
+7a. [ ] **[universal]** Ids, numbers, timestamps and code speak the data face.
+7b. [ ] **[theme]** UI text speaks the UI face (`--oc-font-label` = `--oc-font-ui`).
+8. [ ] **[universal]** Money always labeled + currency-explicit; no unlabeled
+       number groups.
+9. [ ] **[universal]** "~" explained in the stat popover with both counts.
+10. [ ] **[universal]** Focus ring visible on every interactive element (keyboard
+        walk of topbar, card, modal), and neutral per U2 — never the danger colour.
+11. [ ] **[universal]** No hover scale transforms; hover = surface/border/text
+        change in 150–300ms.
+12. [ ] **[universal]** Hit floors (A1): for every interactive element, the union of
+        its border box and its `::after` floor measures **≥24×24 CSS px with
+        `pointer: fine`** and **≥44×44 with `pointer: coarse`**. The drawn box stays
+        32px (36px for fields); density is bought with padding, never with the
+        target.
+13. [ ] **[universal]** No horizontal scroll at 375/768/1024/1440 in any theme.
+14. [ ] **[universal]** A theme switch changes zero layout — only token values.
+15. [ ] **[universal]** `prefers-reduced-motion` disables non-essential animation.
+16. [ ] **[universal]** `--oc-accent` ≠ `--oc-danger` (U1), and `--oc-border-strong`
+        is neutral (U3), in every theme.
+17. [ ] **[universal]** Every theme file opens with an `EXEMPTIONS` block; every
+        Tier-2 divergence it ships is listed there with its source. An undeclared
+        divergence fails this item.
+18. [ ] **[universal]** No Tier-2 colour (tag foregrounds, glow, `warn`, `info`)
+        resolves to the `--oc-ok` or `--oc-danger` value.
 
 ---
 
@@ -262,3 +378,12 @@ OCL-24 stays.
 
 Sequence: 34 → 35 → 36 → 37 (35+ build on tokens; each cites the checklist items it
 closes in its deliver).
+
+### Amendment follow-ups (A1, A2 — see [`amendments.md`](./amendments.md))
+
+| Card | Owns | Must not touch |
+|---|---|---|
+| **A1 implementation** | `--oc-tap-min`, the `.oc-tappable` utility, adoption on the seven measured components (`.mf-trigger`, cost stat, `.mchip`, `.am-theme-opt`, `.seen-add`, banner and modal buttons) | Theme values, layout |
+| **A1 guard** | The hit-floor test (fine + coarse pointer passes), sibling of `styles/layers.test.ts` | Component styles |
+| **A2 implementation** | Four values in `themes/overclock.css` (`--oc-danger-rgb`, `--oc-focus-ring`, `--oc-focus-ring-inset`, `--oc-border-strong`) + the `EXEMPTIONS` block in all three theme files | Component styles, layout |
+| **A2 guard** | U1–U4 as assertions in `styles/tokens.test.ts`, evaluated per theme | Theme values |


### PR DESCRIPTION
Duas emendas de doutrina, uma RFC cada. Só documentação — nenhum componente ou tema foi tocado.

## A1 — OCL-87 · o Control de 32px vs. o piso de 44px

**Decisão:** o piso de 44px é **piso de área de toque sob ponteiro grosso**, não altura de caixa.

- `--oc-tap` continua **44px** em todos os temas e passa a governar uma coisa só: a menor dimensão de alvo sob `(pointer: coarse)`. Nunca é escrito como `height`/`min-height`.
- Novo `--oc-tap-min: 24px` — o piso que vale **em todo lugar**, mouse incluído (WCAG 2.2 AA, SC 2.5.8). Isso reprova de vez `.mf-trigger` (16px), stat de custo (19px), `.mchip` (20px), `.am-theme-opt` (23px): a emenda não pode ser lida como licença para alvo de 16px.
- A caixa desenhada segue 32px (36px em campos) — densidade desktop preservada.
- §3 ganha a técnica exata (`::after` que não pinta, `max(100%, token)`, quatro restrições: sem `overflow: hidden` no ancestral, `gap` ≥8px entre tappables, `<label>` para elementos substituídos, zero pintura).
- Checklist #12 vira binário: união da border box com o `::after` ≥24×24 em `pointer: fine` e ≥44×44 em `pointer: coarse`.

**Por quê B e não A:** 44px em ponteiro fino não é requisito de acessibilidade (2.5.5 é AAA e vem de guideline de dedo), áreas invisíveis de 44px em barra densa roubam clique do vizinho e fazem o alvo clicável discordar do alvo desenhado — pior para usuário de baixa visão/motor do que uma caixa honesta de 32px.

## A2 — OCL-88 · o tema `overclock` vs. as leis universais

**Decisão:** o checklist ganha duas classes de lei.

- **Tier 1 (universal, sem exceção):** acento ≠ danger (U1), foco neutro (U2), borda de hover neutra (U3), `ok`/`danger` reservados a status (U4), tokens de layout idênticos (U5), rampa + anatomia do Control + pisos de toque (U6). Cada uma com teste binário (distância OKLCH).
- **Tier 2 (por tema, mediante declaração):** pill, mono como voz de UI, cores de tag, glow, `warn`/`info`, matiz dos cinzas — identidade legítima do produto.
- **Tier 3:** todo tema abre com um bloco `EXEMPTIONS`; divergência não declarada é bug.
- `overclock` sai de TODO, fica no seletor e muda **quatro valores** (`--oc-danger-rgb`, `--oc-focus-ring`, `--oc-focus-ring-inset`, `--oc-border-strong`) — vermelho de seleção igual a vermelho de erro é falha de compreensão em qualquer paleta.
- Checklist: cada item marcado `[universal]` ou `[theme]`, +3 itens novos (16/17/18).

## Arquivos

- `docs/design/ux-v2.md` — §1, §2 (+ subseção "Theme conformance"), §3 (+ técnica de hit area), §5 (checklist reescrito), §6 (follow-ups).
- `docs/design/amendments.md` — **novo**: conflito medido, decisão, justificativa e tokens/arquivos afetados de cada emenda.

## Implementação (cards separados, criados na missão)

A1: `--oc-tap-min` + `.oc-tappable` + os sete componentes medidos; guard de hit floor.
A2: os quatro valores em `themes/overclock.css` + blocos `EXEMPTIONS`; U1–U4 em `tokens.test.ts`.

Refs OCL-87, OCL-88.

🤖 Generated with [Claude Code](https://claude.com/claude-code)