### PR TITLE
[OCL-83] Filtros: corrige layout das opções e adiciona rolagem ao painel

### DIFF
--- a/apps/web/src/styles/nebula.css
+++ b/apps/web/src/styles/nebula.css
@@ -605,6 +605,7 @@ body:has(.nb) { display: block; padding: 0; background: var(--nebula-void); }
 .nb .ff-panel {
   position: absolute; z-index: var(--oc-z-panel); top: calc(100% + 6px); left: 0;
   width: 240px; max-width: min(320px, calc(100vw - 32px));
+  max-height: 46vh; overflow-y: auto;
   padding: 8px; background: var(--oc-panel-bg);
 }
 .nb .ff-search-row {
@@ -643,7 +644,7 @@ body:has(.nb) { display: block; padding: 0; background: var(--nebula-void); }
 }
 .nb .ff-list { display: flex; flex-direction: column; }
 .nb .ff-opt {
-  display: flex; align-items: center; gap: 8px; width: 100%;
+  display: flex; flex-direction: row; align-items: center; gap: 8px; width: 100%;
   padding: 6px 8px; border-radius: var(--oc-radius-control); color: var(--nebula-text-secondary);
   font-family: var(--nebula-font-label); font-size: 11px;
   letter-spacing: 0.04em; cursor: pointer;


### PR DESCRIPTION
Corrige o painel de Filtros (`.ff-panel`):

- Cada opção agora renderiza em uma linha só (caixa + rótulo), forçando `flex-direction: row` em `.nb .ff-opt` para anular o `label { flex-direction: column }` global de `globals.css`.
- Adiciona `max-height: 46vh` e `overflow-y: auto` ao painel de Filtros, igual aos painéis irmãos `.pf-list` e `.mf-list`.

Escopo isolado em `apps/web/src/styles/nebula.css`; nenhuma alteração em topbar, temas, logo ou formulários globais.

### Verificação
- `pnpm --filter @agent-board/web test` passou (503 tests, 2 skipped).
- Guards de estilo `styles/tokens.test.ts` e `styles/layers.test.ts` passaram.