### PR TITLE
[OCL-85][OCL-92] Insights: numbers, popover, chart, tables and chrome

### DIFF
--- a/apps/web/src/app/insights/charts.tsx
+++ b/apps/web/src/app/insights/charts.tsx
@@ -1,3 +1,4 @@
+import type React from "react";
 import type { GroupInsight } from "../../lib/insights";
 import type { InsightsCopy } from "./copy";
 import { formatMoney, formatTokens } from "../../lib/format";
@@ -27,6 +28,7 @@ export function TrendChart({
         className="ins-trend-bars"
         role="img"
         aria-label={metric === "cost" ? t.trendCostTitle : t.trendTokensTitle}
+        style={{ "--ins-points": points.length } as React.CSSProperties}
       >
         {points.map((p) => {
           const v = trendValue(p, metric);

--- a/apps/web/src/app/insights/copy.ts
+++ b/apps/web/src/app/insights/copy.ts
@@ -97,6 +97,9 @@ const en = {
   footElapsed: (items: string) => `+ elapsed, never added: ${items}`,
   footUnpriced: (items: string) => `no price: ${items}`,
   footUnverified: (items: string) => `commit not found on remote: ${items}`,
+  /** Inline key so every table symbol is readable without leaving the page. */
+  symbolsLegend:
+    "⌀ no price · ! suspect usage · + elapsed only · ≈ estimated · 0 zero usage · ○ usage not reported",
   emptyTitle: "Nothing measured yet.",
   empty:
     "No delivered work yet. When an agent claims and delivers a card, its tokens and time land here.",
@@ -217,6 +220,8 @@ const ptBR: InsightsCopy = {
   footElapsed: (items: string) => `+ decorrido, não somado: ${items}`,
   footUnpriced: (items: string) => `sem preço: ${items}`,
   footUnverified: (items: string) => `commit não encontrado no remoto: ${items}`,
+  symbolsLegend:
+    "⌀ sem preço · ! uso suspeito · + só decorrido · ≈ estimado · 0 uso reportado como zero · ○ sem uso reportado",
   emptyTitle: "Nada medido ainda.",
   empty:
     "Nenhuma entrega ainda. Quando um agente pegar e entregar um card, os tokens e o tempo aparecem aqui.",

--- a/apps/web/src/app/insights/insights.css
+++ b/apps/web/src/app/insights/insights.css
@@ -15,6 +15,24 @@
   --ins-measure: 68ch;
   max-width: 1320px;
 }
+/* The chrome speaks the same language as the board: two flat levels on the
+   canvas, one 1px line under the second. No floating glass panel. */
+.nb .ins-topbar-wrap {
+  position: relative;
+  z-index: var(--oc-z-chrome);
+  margin-bottom: var(--ins-rhythm);
+}
+.nb .ins-topbar-l1 {
+  display: flex; align-items: center; gap: var(--nebula-space-4);
+  padding: 10px 0;
+}
+.nb .ins-topbar-l1 .spacer { flex: 1; }
+.nb .ins-topbar-l2 {
+  display: flex; align-items: center; flex-wrap: wrap;
+  gap: var(--nebula-space-3);
+  padding: 0 0 12px;
+  border-bottom: 1px solid var(--nebula-glass-border);
+}
 /* The heading block is one group with one gap, so the filter line can appear
    and disappear without any margin having to be corrected against another. */
 .nb .ins-head {
@@ -74,9 +92,10 @@
    lengths still show their four figures on one line */
 .nb .ins-tile .ins-note:first-of-type { margin-top: auto; padding-top: 6px; }
 .nb .ins-tile .ins-lbl {
-  font-family: var(--nebula-font-mono);
-  font-size: 10px;
-  letter-spacing: 0.08em;
+  font-family: var(--nebula-font-label);
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.06em;
   text-transform: uppercase;
   color: var(--nebula-text-tertiary);
   margin-bottom: 8px;
@@ -105,9 +124,10 @@
   justify-content: space-between;
   gap: var(--nebula-space-3);
   margin-bottom: 12px;
-  font-family: var(--nebula-font-mono);
-  font-size: 10px;
-  letter-spacing: 0.08em;
+  font-family: var(--nebula-font-label);
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.06em;
   text-transform: uppercase;
   color: var(--nebula-text-tertiary);
 }
@@ -142,6 +162,7 @@
 .nb .ins-trend-bars {
   display: flex;
   align-items: flex-end;
+  justify-content: flex-start;
   gap: 5px;
   flex: 1;
   /* the plot answers the width it was given: on a wide page a 120px band of
@@ -149,12 +170,9 @@
   min-height: clamp(120px, 11vw, 168px);
 }
 .nb .ins-trend-col {
-  /* share the width instead of claiming a fixed 26px and leaving the rest of
-     the panel empty; a bar still never grows wider than it reads well at */
-  /* The columns span exactly the plot, because the axis under them labels the
-     first and the last one: a capped bar left the last column short of the
-     date that names it, which is the same misalignment as before, moved. */
-  flex: 1 1 0;
+  /* with few data points bars stay narrow and aligned; with many they share
+     the width without ever becoming slabs that overpower the panel. */
+  flex: 0 0 clamp(18px, calc((100% - (var(--ins-points, 1) - 1) * 5px) / var(--ins-points, 1)), 48px);
   min-width: 0;
   height: 100%;
   display: flex;
@@ -164,7 +182,7 @@
   width: 100%;
   min-height: 3px;
   border-radius: 3px 3px 1px 1px;
-  background: linear-gradient(180deg, rgb(var(--oc-accent-rgb) / 0.75), rgb(var(--oc-mist-rgb) / 0.35));
+  background: var(--nebula-text-tertiary);
   transition: filter 0.15s;
 }
 .nb .ins-trend-col:hover .ins-bar { filter: brightness(1.35); }
@@ -279,14 +297,14 @@
 .nb .ins-col-deliveries { width: 88px; }
 .nb .ins-col-rate { width: 64px; }
 .nb .ins-table th {
-  font-family: var(--nebula-font-mono);
-  font-size: 10px;
-  letter-spacing: 0.08em;
+  font-family: var(--nebula-font-label);
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.06em;
   text-transform: uppercase;
   color: var(--nebula-text-tertiary);
   text-align: left;
   padding: 0 12px 10px 0;
-  font-weight: 400;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -362,6 +380,16 @@
   font-size: 10px;
   color: var(--nebula-text-tertiary);
   cursor: help;
+}
+/* A visible key for the symbols used in every table: the reader never has to
+   leave the panel to know what ⌀, !, +, ≈, 0 and ○ mean. */
+.nb .ins-legend {
+  margin: 12px 0 0;
+  font-family: var(--nebula-font-label);
+  font-size: 10px;
+  letter-spacing: 0.02em;
+  line-height: 1.6;
+  color: var(--nebula-text-tertiary);
 }
 /* The footnote is where every qualifier on the table above is spelled out. As
    one run-on paragraph it grew to the full width of the page and became the

--- a/apps/web/src/app/insights/page.tsx
+++ b/apps/web/src/app/insights/page.tsx
@@ -97,6 +97,11 @@ function sourceNote(totals: UsageTotals, t: InsightsCopy): string {
   return parts.length > 0 ? parts.join(" · ") : t.noCostSource;
 }
 
+/** One visible key per panel: the symbols on values are explained in place. */
+function SymbolsLegend({ t }: { t: InsightsCopy }) {
+  return <p className="ins-legend">{t.symbolsLegend}</p>;
+}
+
 /**
  * The qualifiers a table's rows carry, as one quiet line under it. Markers on
  * the values point here; every count the old inline badges showed is named in
@@ -207,32 +212,51 @@ function combinedRows(
   groups: CombinedGroupInsight[],
   t: InsightsCopy,
 ): GroupTableRow[] {
-  return groups.flatMap((group) => [
-    {
-      ...group.execution,
-      key: `${group.key}:execution`,
-      label: group.label,
-      groupLabel: group.label ?? "",
-      lineLabel: t.executionLine,
-      combinedTotal: false,
-    },
-    {
-      ...group.orchestration,
-      key: `${group.key}:orchestration`,
-      label: group.label,
-      groupLabel: group.label ?? "",
-      lineLabel: t.orchestrationLine,
-      combinedTotal: false,
-    },
-    {
-      ...group.total,
-      key: `${group.key}:total`,
-      label: group.label,
-      groupLabel: group.label ?? "",
-      lineLabel: t.totalLine,
-      combinedTotal: true,
-    },
-  ]);
+  const rows: GroupTableRow[] = [];
+  for (const group of groups) {
+    const collapsed =
+      group.orchestration.tokens === 0 &&
+      group.orchestration.durationMs === 0 &&
+      group.orchestration.attempts === 0;
+    if (collapsed) {
+      rows.push({
+        ...group.total,
+        key: `${group.key}:total`,
+        label: group.label,
+        groupLabel: group.label ?? "",
+        lineLabel: undefined,
+        combinedTotal: false,
+      });
+      continue;
+    }
+    rows.push(
+      {
+        ...group.execution,
+        key: `${group.key}:execution`,
+        label: group.label,
+        groupLabel: group.label ?? "",
+        lineLabel: t.executionLine,
+        combinedTotal: false,
+      },
+      {
+        ...group.orchestration,
+        key: `${group.key}:orchestration`,
+        label: group.label,
+        groupLabel: group.label ?? "",
+        lineLabel: t.orchestrationLine,
+        combinedTotal: false,
+      },
+      {
+        ...group.total,
+        key: `${group.key}:total`,
+        label: group.label,
+        groupLabel: group.label ?? "",
+        lineLabel: t.totalLine,
+        combinedTotal: true,
+      },
+    );
+  }
+  return rows;
 }
 
 function GroupTable({
@@ -531,19 +555,23 @@ export default async function InsightsPage({
       <NebulaAtmosphere />
 
       <div className="page ins-page">
-        <div className="topbar nebula-glass">
-          <Wordmark label={shared.board.homeLink} />
-          <div className="crumb">
-            {ws.name} / <b>{t.title}</b>
+        <header className="ins-topbar-wrap">
+          <div className="ins-topbar-l1">
+            <Wordmark label={shared.board.homeLink} />
+            <div className="spacer" />
+            {/* The arrow was a character inside the label; it is the set's own
+                glyph now, silent because the word beside it says where it goes. */}
+            <a className="btn-ghost ins-back" href="/home">
+              <Icon name="back" label={null} size={14} />
+              {t.backToBoard}
+            </a>
           </div>
-          <div className="spacer" />
-          {/* The arrow was a character inside the label; it is the set's own
-              glyph now, silent because the word beside it says where it goes. */}
-          <a className="btn-ghost ins-back" href="/home">
-            <Icon name="back" label={null} size={14} />
-            {t.backToBoard}
-          </a>
-        </div>
+          <div className="ins-topbar-l2">
+            <div className="crumb">
+              {ws.name} / <b>{t.title}</b>
+            </div>
+          </div>
+        </header>
 
         {/* Title, what the page counts and the filter that qualifies both are
             one group with one gap, instead of three margins that had to be
@@ -702,6 +730,7 @@ export default async function InsightsPage({
                   t={t}
                   pricingEnabled={pricingEnabled}
                 />
+                <SymbolsLegend t={t} />
               </section>
               <section className="ins-panel nebula-glass">
                 <div className="ins-cap">
@@ -713,6 +742,7 @@ export default async function InsightsPage({
                   t={t}
                   pricingEnabled={pricingEnabled}
                 />
+                <SymbolsLegend t={t} />
               </section>
               <section className="ins-panel nebula-glass">
                 <div className="ins-cap">
@@ -725,6 +755,7 @@ export default async function InsightsPage({
                   pricingEnabled={pricingEnabled}
                   showUnverified
                 />
+                <SymbolsLegend t={t} />
               </section>
               <section className="ins-panel nebula-glass">
                 <div className="ins-cap">
@@ -738,6 +769,7 @@ export default async function InsightsPage({
                   showUnpriced
                   showUnverified
                 />
+                <SymbolsLegend t={t} />
               </section>
               <section className="ins-panel nebula-glass">
                 <div className="ins-cap">
@@ -759,6 +791,7 @@ export default async function InsightsPage({
                 lang={ws.language}
                 pricingEnabled={pricingEnabled}
               />
+              <SymbolsLegend t={t} />
             </section>
           </>
         )}

--- a/apps/web/src/styles/nebula.css
+++ b/apps/web/src/styles/nebula.css
@@ -987,16 +987,16 @@ body:has(.nb) { display: block; padding: 0; background: var(--nebula-void); }
   white-space: nowrap; overflow: hidden;
 }
 .nb .board-total .bt-lead {
-  font-family: var(--nebula-font-mono); font-size: 19px; line-height: 1;
-  color: var(--nebula-text-primary); font-weight: var(--nebula-weight-medium);
+  font-family: var(--nebula-font-mono); font-size: 16px; line-height: 1;
+  color: var(--nebula-text-primary); font-weight: 600;
   letter-spacing: var(--nebula-tracking-tight);
   font-variant-numeric: tabular-nums;
   text-shadow: var(--nebula-glow-text);
 }
 .nb .board-total:hover .bt-lead { color: var(--nebula-dust-core); }
 .nb .board-total .bt-sub {
-  font-family: var(--nebula-font-mono); font-size: 10px;
-  letter-spacing: 0.04em; color: var(--nebula-text-secondary);
+  font-family: var(--nebula-font-mono); font-size: 11px;
+  letter-spacing: 0.04em; color: var(--nebula-text-tertiary);
   font-variant-numeric: tabular-nums;
 }
 /* The break between the figure and what supports it (ux-v2 §4). Size and
@@ -1006,8 +1006,8 @@ body:has(.nb) { display: block; padding: 0; background: var(--nebula-void); }
 /* The stat's own label ("Custo"): money never leads unnamed (ux-v2 §4).
    Same quiet voice as the support numbers — the figure is the headline. */
 .nb .bt-label {
-  font-family: var(--nebula-font-mono); font-size: 10px;
-  letter-spacing: 0.04em; color: var(--nebula-text-secondary);
+  font-family: var(--nebula-font-mono); font-size: 11px;
+  letter-spacing: 0.04em; color: var(--nebula-text-tertiary);
 }
 .nb .bt-popover .bt-note {
   color: var(--nebula-text-primary);
@@ -1026,13 +1026,13 @@ body:has(.nb) { display: block; padding: 0; background: var(--nebula-void); }
 }
 .nb .bt-popover .bt-figure { display: flex; align-items: baseline; gap: 7px; }
 .nb .bt-popover .bt-figure .bt-lead {
-  font-family: var(--nebula-font-mono); font-size: 19px; line-height: 1;
-  color: var(--nebula-text-primary); font-weight: var(--nebula-weight-medium);
+  font-family: var(--nebula-font-mono); font-size: 16px; line-height: 1;
+  color: var(--nebula-text-primary); font-weight: 600;
   font-variant-numeric: tabular-nums; text-shadow: var(--nebula-glow-text);
 }
 .nb .bt-popover .bt-figure .bt-sub {
-  font-family: var(--nebula-font-mono); font-size: 10px;
-  letter-spacing: 0.04em; color: var(--nebula-text-secondary);
+  font-family: var(--nebula-font-mono); font-size: 11px;
+  letter-spacing: 0.04em; color: var(--nebula-text-tertiary);
   font-variant-numeric: tabular-nums;
 }
 .nb .bt-line {
@@ -1042,6 +1042,8 @@ body:has(.nb) { display: block; padding: 0; background: var(--nebula-void); }
 .nb a.bt-line { text-decoration: none; }
 .nb a.bt-line:hover { color: var(--nebula-text-primary); }
 .nb .bt-insights { margin-top: 2px; padding-top: 8px; border-top: 1px solid var(--nebula-glass-border); }
+.nb .board-total-wrap { position: relative; }
+.nb .board-total { min-height: 32px; }
 
 /* the columns the state chips jump to clear the bar on the way (OCL-20) */
 .nb [id^="board-col-"] { scroll-margin-top: 76px; }


### PR DESCRIPTION
Resolve OCL-85 e OCL-92 na tela de Insights.

## OCL-85
- Ajusta peso (600), tamanho (16px) e cor (text-1) do lead de custo na topbar; secundários vão para 11px/text-3.
- Garante que o popover do stat de custo apareça (board-total-wrap position:relative, botão com min-height 32px).
- Adiciona legenda visível dos símbolos nas tabelas do Insights (⌀, !, +, ≈, 0, ○).
- Confirma que todos os formatadores usam `lib/format.ts`.

## OCL-92
- Limita a largura das barras do gráfico e remove o gradiente; barras ficam alinhadas à esquerda.
- Colapsa linhas de execução/orquestração/total quando a orquestração é zero.
- Unifica a chrome do Insights com a do board: dois níveis achatados sobre --oc-bg com filete sob L2.
- Move títulos de painel, labels de tiles e cabeçalhos de tabela para a UI face; números continuam em mono.

## Como verificar
- `pnpm -r typecheck` passa.
- `pnpm --filter @agent-board/web test` passa (503 testes).
- Inspecionar `/insights` confirma o gráfico sem lajes brancas, tabelas enxutas e chrome igual ao board.

Closes OCL-85
Closes OCL-92