### PR TITLE
[OCL-93][OCL-94] Acabamento visual e segunda passada do review OCL-79

### DIFF
--- a/apps/web/src/app/error.tsx
+++ b/apps/web/src/app/error.tsx
@@ -1,21 +1,48 @@
 "use client";
 
+import { useEffect, useState } from "react";
+
 export default function ErrorPage({
   error,
+  reset,
 }: {
   error: Error & { digest?: string };
+  reset?: () => void;
 }) {
   const missingDb = /DATABASE_URL/.test(error.message);
+  const [canReload, setCanReload] = useState(false);
+
+  useEffect(() => {
+    setCanReload(true);
+  }, []);
+
+  const handleRetry = () => {
+    if (reset) reset();
+    else if (typeof window !== "undefined") window.location.reload();
+  };
 
   return (
-    <>
-      <p className="brand">local instance</p>
-      <h1>{missingDb ? "The database is missing." : "Something broke here."}</h1>
+    <div className="shell">
+      <p className="brand">overclick</p>
+      <h1>{missingDb ? "The database is missing." : "The board is unreachable."}</h1>
       <p className="sub">
         {missingDb
           ? "Set DATABASE_URL pointing to this instance's Postgres. Nothing is sent anywhere."
-          : "The error stayed on this server. There is no telemetry, check the container logs."}
+          : "The server returned an error. Wait a moment and try again, or check the instance logs if the problem persists."}
       </p>
-    </>
+      <button
+        type="button"
+        className="primary"
+        onClick={handleRetry}
+        disabled={!canReload}
+      >
+        Try again
+      </button>
+      {error.digest ? (
+        <p className="meta" style={{ marginTop: 24 }}>
+          Error digest: <span className="error">{error.digest}</span>
+        </p>
+      ) : null}
+    </div>
   );
 }

--- a/apps/web/src/app/home/board.tsx
+++ b/apps/web/src/app/home/board.tsx
@@ -688,14 +688,12 @@ function CopyButton({ label, value, t }: { label: string; value: string; t: Dict
 }
 
 /**
- * A section title of the detail panel, with the mark of what the section
- * holds (AGB-73).
+ * A section title of the detail panel.
  *
  * Ten sections stacked in one panel all announced themselves in the same
- * ten-pixel uppercase mono, which meant finding the branch was reading every
- * title in order. The mark gives each one a silhouette, so the eye jumps
- * instead of reading. It is decorative by construction: the word next to it
- * is the section's name and a reader hearing both would hear it twice.
+ * ten-pixel uppercase mono. The spec (ux-v2 §3) now makes them 11px/600
+ * uppercase text-3: the hierarchy comes from weight and colour, not from
+ * decorative marks.
  *
  * `right` is what the title line carries on its far side, which today is the
  * validation progress and nothing else.
@@ -711,10 +709,7 @@ function SectionLabel({
 }) {
   return (
     <div className="lbl">
-      <span className="lbl-name">
-        <Icon name={icon} label={null} size={13} className="icon-muted" />
-        <span>{text}</span>
-      </span>
+      <span className="lbl-name">{text}</span>
       {right}
     </div>
   );
@@ -1112,7 +1107,7 @@ function Detail({
   return (
     <div className="ov" onClick={(e) => e.target === e.currentTarget && onClose()}>
       <div
-        className="detail nebula-glass nebula-corners"
+        className="detail nebula-glass"
         role="dialog"
         aria-modal="true"
         aria-labelledby={titleId}

--- a/apps/web/src/styles/nebula.css
+++ b/apps/web/src/styles/nebula.css
@@ -196,21 +196,21 @@
 .nebula-glass-fade {
   position: absolute;
   left: 0; right: 0; bottom: 0;
-  height: 38%;
+  height: 100%;
   pointer-events: none;
-  -webkit-backdrop-filter: blur(6px);
-  backdrop-filter: blur(6px);
-  mask-image: linear-gradient(to bottom, transparent, black 70%);
-  -webkit-mask-image: linear-gradient(to bottom, transparent, black 70%);
+  -webkit-backdrop-filter: blur(4px);
+  backdrop-filter: blur(4px);
+  mask-image: linear-gradient(to bottom, transparent 0%, black 100%);
+  -webkit-mask-image: linear-gradient(to bottom, transparent 0%, black 100%);
 }
 .nebula-glass-fade::after {
   content: "";
   position: absolute;
-  inset: 30% 0 0 0;
-  -webkit-backdrop-filter: blur(18px);
-  backdrop-filter: blur(18px);
-  mask-image: linear-gradient(to bottom, transparent, black 80%);
-  -webkit-mask-image: linear-gradient(to bottom, transparent, black 80%);
+  inset: 50% 0 0 0;
+  -webkit-backdrop-filter: blur(10px);
+  backdrop-filter: blur(10px);
+  mask-image: linear-gradient(to bottom, transparent 0%, black 100%);
+  -webkit-mask-image: linear-gradient(to bottom, transparent 0%, black 100%);
 }
 .nebula-corners { position: relative; }
 .nebula-corners::before {
@@ -637,9 +637,9 @@ body:has(.nb) { display: block; padding: 0; background: var(--nebula-void); }
 }
 .nb .ff-section h3 {
   margin: 0; padding: 4px 8px;
-  color: var(--nebula-text-secondary); font-family: var(--nebula-font-label);
-  font-size: 9px; font-weight: var(--nebula-weight-medium);
-  letter-spacing: 0.08em; text-transform: uppercase;
+  color: var(--nebula-text-tertiary); font-family: var(--nebula-font-sans);
+  font-size: 11px; font-weight: 600;
+  letter-spacing: 0.06em; text-transform: uppercase;
 }
 .nb .ff-list { display: flex; flex-direction: column; }
 .nb .ff-opt {
@@ -765,25 +765,26 @@ body:has(.nb) { display: block; padding: 0; background: var(--nebula-void); }
    one is marked the way a chosen filter is marked — border and text, never
    a colour of its own. */
 .nb .am-theme {
-  display: flex; flex-direction: column; gap: 6px;
-  margin-top: 4px; padding: 8px 10px 4px;
+  display: flex; flex-direction: column; gap: 8px;
+  margin-top: 4px; padding: 8px;
   border-top: 1px solid var(--nebula-glass-border);
 }
 .nb .am-theme-lbl {
-  color: var(--nebula-text-tertiary); font-family: var(--nebula-font-label);
-  font-size: 9px; letter-spacing: 0.08em; text-transform: uppercase;
+  color: var(--nebula-text-tertiary); font-family: var(--nebula-font-sans);
+  font-size: 11px; font-weight: 600; letter-spacing: 0.06em; text-transform: uppercase;
 }
-/* the options take the width of their own names and wrap rather than
-   truncate: a theme whose name reads "Overc…" is a theme nobody can pick
-   with confidence */
-.nb .am-theme-opts { display: flex; flex-wrap: wrap; gap: 4px; }
+/* Three siblings form one group: equal columns, never an orphan stretched on
+   a second line. Each option follows the Control anatomy (32px, 8px radius,
+   13px UI face) so the picker reads as part of the same control family. */
+.nb .am-theme-opts { display: grid; grid-template-columns: repeat(3, 1fr); gap: 4px; }
 .nb .am-theme-opt {
-  flex: 1 1 auto; min-width: 0; padding: 5px 8px;
+  display: flex; align-items: center; justify-content: center;
+  min-height: 32px; padding: 0 8px;
   border: 1px solid var(--nebula-glass-border);
   border-radius: var(--oc-radius-control);
   background: transparent; color: var(--nebula-text-secondary);
-  font-family: var(--nebula-font-label); font-size: 10px;
-  letter-spacing: 0.03em; text-align: center; cursor: pointer;
+  font-family: var(--nebula-font-sans); font-size: 13px; font-weight: 500;
+  letter-spacing: 0; text-align: center; cursor: pointer;
   white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
   transition: color var(--oc-duration-micro) var(--nebula-ease-atmosphere),
     border-color var(--oc-duration-micro) var(--nebula-ease-atmosphere);
@@ -1211,7 +1212,7 @@ body:has(.nb) { display: block; padding: 0; background: var(--nebula-void); }
   text-transform: uppercase; color: var(--nebula-text-secondary);
 }
 .nb .col-head .count { color: var(--nebula-text-tertiary); }
-.nb .col { display: flex; flex-direction: column; gap: var(--nebula-space-3); min-height: 300px; }
+.nb .col { display: flex; flex-direction: column; gap: var(--nebula-space-3); min-height: 300px; padding-bottom: 48px; }
 
 .nb .empty-col {
   border: 1px dashed var(--oc-border-dashed); border-radius: var(--nebula-glass-radius);
@@ -1412,8 +1413,10 @@ body:has(.nb) { display: block; padding: 0; background: var(--nebula-void); }
   .nb .ov, .nb .detail { animation: none; }
 }
 
-/* ---------- progressive blur no rodapé do viewport ---------- */
-.nb .viewport-fade { position: fixed; height: 15vh; z-index: var(--oc-z-fade); }
+/* ---------- progressive blur no rodapé do viewport ----------
+   The fade signals "more below" but must not hide the last card. Keep it
+   short (48px) and gentle so the title of the last card stays legible. */
+.nb .viewport-fade { position: fixed; height: 48px; z-index: var(--oc-z-fade); }
 
 /* ---------- detalhe do card (overlay client-side) ---------- */
 /* The modal is the top layer of the board: above the phone's sticky bar (30)
@@ -1430,7 +1433,7 @@ body:has(.nb) { display: block; padding: 0; background: var(--nebula-void); }
    inside it; the browser's default ring around a whole panel is noise, and
    the ring that matters is the one on the controls inside. */
 .nb .detail:focus { outline: none; }
-.nb .detail { width: 700px; max-width: 96vw; padding: 26px 30px 24px; position: relative;
+.nb .detail { width: 700px; max-width: 96vw; padding: 24px; position: relative;
   background: var(--oc-modal-bg);
   animation: nb-d-in .22s cubic-bezier(.2,.8,.2,1); }
 @keyframes nb-d-in { from { opacity: 0; transform: translateY(10px) scale(.985) } to { opacity: 1; transform: none } }
@@ -1497,11 +1500,11 @@ body:has(.nb) { display: block; padding: 0; background: var(--nebula-void); }
 .nb .md .md-inline-code,
 .nb .md code {
   font-family: var(--nebula-font-mono);
-  color: var(--nebula-dust-core);
-  background: rgb(var(--oc-scrim-rgb) / 0.66);
-  border: 1px solid var(--nebula-glass-border);
+  color: var(--nebula-text-secondary);
+  background: rgb(var(--oc-scrim-rgb) / 0.22);
+  border: none;
   border-radius: var(--oc-radius-chip);
-  padding: 2px 4px;
+  padding: 1px 4px;
   font-size: 12px;
 }
 .nb .d-check-step .md code,
@@ -1561,8 +1564,8 @@ body:has(.nb) { display: block; padding: 0; background: var(--nebula-void); }
   line-height: 1.3;
 }
 .nb .d-sec .lbl { display: flex; align-items: baseline; justify-content: space-between; gap: var(--nebula-space-3);
-  font-family: var(--nebula-font-label); font-size: 10px; letter-spacing: .08em;
-  text-transform: uppercase; color: var(--nebula-mist); margin-bottom: 7px; }
+  font-family: var(--nebula-font-sans); font-size: 11px; font-weight: 600;
+  letter-spacing: .06em; text-transform: uppercase; color: var(--nebula-text-tertiary); margin-bottom: 8px; }
 .nb .d-progress { font-family: var(--nebula-font-label); font-size: 10px; letter-spacing: .04em;
   color: var(--nebula-text-tertiary); text-transform: none; }
 .nb .d-progress.done { color: var(--oc-ok); }
@@ -2010,7 +2013,7 @@ body:has(.nb) { display: block; padding: 0; background: var(--nebula-void); }
    The fade on the trailing edge is what says there is more to the right. */
 .nb .settabs {
   position: relative;
-  display: flex; gap: 22px;
+  display: flex; gap: 12px;
   margin-bottom: 22px; padding-bottom: 0;
   border-bottom: 1px solid var(--nebula-plan-divider);
   overflow-x: auto; overflow-y: hidden;

--- a/docs/design/review-2026-08-19.md
+++ b/docs/design/review-2026-08-19.md
@@ -405,3 +405,104 @@ entregar). Depois OCL-83/84 (os dois defeitos que quebram uso), depois o resto.
 
 Os achados D1 e D2 não têm card: logo e redesenho de topbar estão congelados
 aguardando o dono, conforme o contrato do OCL-79.
+
+---
+
+## Segunda passada — 2026-08-21 (OCL-94)
+
+Verificação das três lacunas declaradas no início deste documento: larguras
+1100/900/700, tema `overclock` ao vivo e estados de loading. **Método:** análise
+estática do CSS e dos componentes, porque a instância local não levantou
+(DATABASE_URL não configurada no worktree de execução) e a produção caiu nas
+tentativas anteriores. Os valores abaixo são derivados das rules e da geometria
+das media queries, não medidos em tela.
+
+### S1 · Alta · A topbar não é dois níveis entre 769px e 1050px
+
+**Especificado em ux-v2.md §3:** "Topbar renders as two levels ≥768px" e
+"<768px: L2 collapses num único Control de Filtros".
+
+**Implementado:** a colapso de L2 acontece na media query
+`@media (min-width: 769px) and (max-width: 1050px)`
+(`apps/web/src/styles/nebula.css:2466`), ou seja, L2 já vira um único botão
+`Filtros` a partir de 1050px — não de 768px. O resultado, nas larguras 900px e
+1024px, é uma barra de **um nível só**: wordmark + Filtros + stat + `⋯`.
+
+**Medido:** nessa faixa `.topbar-l1`, `.topbar.topbar-l1` e `.topbar-l2` recebem
+`display: contents` (`nebula.css:2815`), então a wrapper `.topbar-wrap` vira a
+única linha de chrome. Isso contradiz o spec de dois níveis para qualquer
+viewport ≥768px.
+
+**Doutrina:** ux-v2.md §3, checklist #5.
+
+### S2 · Alta · Rolagem horizontal do board existe em toda a faixa 769–1199px, incluindo 1024px
+
+**Especificado:** ux-v2.md §3 "no horizontal scroll anywhere" e checklist #13
+"No horizontal scroll at 375/768/1024/1440".
+
+**Implementado:** `@media (min-width: 769px) and (max-width: 1199px)` força
+`grid-template-columns: repeat(5, minmax(232px, 1fr))` com `overflow-x: auto`
+(`nebula.css:2420`). Com `.nb` usando `padding: 28px 32px 60px`
+(`nebula.css:355`), a área útil em 1024px é `1024 − 64 = 960px`. Cinco colunas
+mínimas de 232px mais quatro gaps de 24px somam `5×232 + 4×24 = 1256px`, ou
+seja, **296px além da área útil**. A rolagem horizontal é inevitável.
+
+O mesmo cálculo em 1100px dá `1036px` de área útil e 1256px de board; em 900px
+dá `836px` de área útil e 1256px de board. A faixa inteira de 769–1199px rola.
+
+**Medido:** `overflow-x: auto` está declarado na regra da faixa; não há outra
+media query que evite o scroll em 1024px.
+
+**Doutrina:** ux-v2.md §3 "Board card" / "Columns"; checklist #13.
+
+### S3 · Média · Não existem estados de loading/skeleton em nenhuma das quatro telas
+
+**Verificado em:** `apps/web/src/app/home/page.tsx`, `apps/web/src/app/home/board.tsx`,
+`apps/web/src/app/insights/page.tsx`, `apps/web/src/app/settings/settings-client.tsx`.
+
+**O que existe hoje:** as páginas são renderizadas no servidor, então o primeiro
+paint só ocorre quando os dados já chegaram. Não há `loading.tsx`, `Suspense`
+nem skeleton em nenhuma das quatro telas. Os únicos indicadores de espera são
+estados locais de ação (`pending` em `useTransition`), que mudam o texto de
+botões para "Salvando…", "Atribuindo…" etc. — nenhum deles é um estado de
+loading da tela como um todo.
+
+**Por que importa:** com dados reais a renderização do servidor pode ser rápida,
+mas qualquer ação de servidor (filtro, refresh, troca de missão) deixa a tela
+parada até a resposta. Não há feedback visual coerente entre board, modal,
+Insights e Configurações.
+
+**Doutrina:** ux-v2.md §1 "Air" e a expectativa implícita de estados vazios
+trabalhados (o board já tem empty states bem desenhados para colunas vazias).
+
+### S4 · Média · Tema `overclock`: contraste de `--oc-text-3` fica na fronteira do WCAG AA
+
+**Já coberto parcialmente em B4** (cinzas com matiz). Esta passada olhou o
+contraste real sobre o canvas preto e sobre as superfícies translúcidas.
+
+**Medido:** `--oc-text-3: #6b7280` sobre `--oc-bg: #000000` dá uma razão de
+contraste de aproximadamente **4.3:1**, abaixo do limiar WCAG 2.2 AA de 4.5:1
+para texto normal. Como `--oc-font-label` no tema `overclock` aponta para
+`var(--oc-font-data)` (Geist Mono), essa cor é usada para labels e metadados
+que a doutrina espera como UI face 11px — tamanho pequeno, mono, e agora com
+contraste insuficiente.
+
+Sobre superfícies translúcidas (`--oc-surface-2: rgb(8 8 10 / 0.65)`), o fundo
+fica mais claro que o canvas puro, o que melhora um pouco o contraste, mas o
+`backdrop-filter: blur(12px)` (`--oc-glass-blur`) espalha pixels do board por
+cima do texto, especialmente quando um painel flutua sobre colunas com cards
+brancos. Isso reduz a legibilidade real do meta-texto em painéis sobrepostos.
+
+**Nota:** OCL-123 já está aberto para reconciliar `overclock.css` com as leis
+universais. S4 é um dado adicional para aquele card (contraste real, não só
+matiz), não um card separado.
+
+### Cards abertos pela segunda passada
+
+| Card | Título | Achado | Harness |
+|---|---|---|---|
+| **OCL-124** | Responsividade: topbar vira uma linha entre 769–1050px; board rola horizontal em 1024/1100/900 | S1, S2 | kimi/k3/max |
+| **OCL-125** | Loading/skeleton states ausentes em board, modal, Insights e Configurações | S3 | kimi/k3/max |
+
+S4 foi registrado como evidência adicional no card **OCL-123** (reconciliação do
+tema `overclock`), sem card novo.


### PR DESCRIPTION
Fecha OCL-93 e OCL-94 num PR só.

## OCL-93 — Acabamento visual
- Títulos de seção do modal e do painel de Filtros unificados no spec de ux-v2 §3: 11px/600 uppercase, cor --oc-text-3, letter-spacing .06em.
- Padding do modal ajustado para 24px (escala 4/8/12/16/24/32/48).
- Régua de abas de Configurações: gap reduzido para 12px para caber sem corte em 1440px.
- Seletor de tema: três colunas iguais, sem linha órfã; label e opções na rampa tipográfica; opções com 32px de altura.
- Fade inferior reduzido para 48px com blur mais suave; colunas ganham padding-bottom de 48px para o último card não ser comido.
- Tela de queda (error.tsx) redesenhada: centralizada, com marca, explicação e botão "Try again".
- Decorações do modal removidas: colchetes .nebula-corners no desktop e ícones decorativos dos títulos de seção; realce de código inline suavizado.

## OCL-94 — Segunda passada do review OCL-79
- Adicionada seção "Segunda passada" a docs/design/review-2026-08-19.md com achados S1–S4.
- Abertos cards OCL-124 (responsividade: topbar/board) e OCL-125 (loading/skeleton states).
- S4 (contraste/glass do tema overclock) registrado como evidência adicional para OCL-123.

Não mergear — aguarda revisão.
