### PR TITLE
[OCL-128] Filtro de RELEASE só lista releases; guard de linha na opção de filtro

### DIFF
--- a/apps/web/src/actions/board-filter.ts
+++ b/apps/web/src/actions/board-filter.ts
@@ -2,6 +2,7 @@
 
 import { and, eq, inArray } from "drizzle-orm";
 import { mission, project, task, user } from "@agent-board/db";
+import { isReleaseVersion } from "@agent-board/mcp-core";
 import {
   NO_MISSION,
   encodeFacetSelection,
@@ -51,6 +52,11 @@ export async function setBoardFilterAction(
     return { ok: false, error: "Task priority not found." };
   }
   if (typeof input.resolvedIn === "string") {
+    // The filter offers releases only, so only a release can be stored as
+    // one — a branch name in resolved_in is not a selection (OCL-128).
+    if (!isReleaseVersion(input.resolvedIn)) {
+      return { ok: false, error: "Release not found." };
+    }
     const ws = await db().query.workspace.findFirst({ columns: { id: true } });
     if (!ws) return { ok: false, error: "Workspace not found." };
     const [release] = await db()

--- a/apps/web/src/app/home/page.tsx
+++ b/apps/web/src/app/home/page.tsx
@@ -19,7 +19,10 @@ import {
 } from "@agent-board/db";
 import { NebulaAtmosphere } from "../../components/nebula-atmosphere";
 import { UpdateBanner } from "../../components/update-banner";
-import { resolveBoardFilter } from "../../lib/board-filter";
+import {
+  releaseValueOptions,
+  resolveBoardFilter,
+} from "../../lib/board-filter";
 import { loadBoardTotals } from "../../lib/board-totals-query";
 import { getSession } from "../../lib/cookies";
 import { db } from "../../lib/db";
@@ -657,8 +660,10 @@ export default async function HomePage() {
       and(eq(project.workspaceId, ws.id), isNotNull(task.resolvedIn)),
     )
     .orderBy(desc(task.resolvedIn));
-  const releases = releaseRows.flatMap((row) =>
-    row.value ? [{ value: row.value }] : [],
+  // Only the values that name a release. A delivery that stamped resolved_in
+  // with its branch used to hand that branch to the RELEASE filter (OCL-128).
+  const releases = releaseValueOptions(
+    releaseRows.flatMap((row) => (row.value ? [{ value: row.value }] : [])),
   );
 
   const [me] = await db()

--- a/apps/web/src/lib/board-filter.test.ts
+++ b/apps/web/src/lib/board-filter.test.ts
@@ -12,6 +12,7 @@ import {
   missionFilterOptions,
   projectFilterOptions,
   releaseFilterOptions,
+  releaseValueOptions,
   resolveBoardFilter,
   resolveReleaseSelection,
   resolveProjectSelection,
@@ -410,5 +411,63 @@ describe("the missions the filter offers", () => {
     expect(searchMissions(options, "ONBOARD").map((o) => o.id)).toEqual(["m1"]);
     expect(searchMissions(options, "  ").map((o) => o.id)).toEqual(["m1", "m2"]);
     expect(searchMissions(options, "nothing")).toEqual([]);
+  });
+});
+
+/**
+ * OCL-128: a delivery stamped `resolved_in` with its branch name, and the
+ * RELEASE filter listed the raw value beside v0.2.2 with a count of zero.
+ */
+describe("the release filter only offers releases", () => {
+  const branch =
+    "ovka-78-bug-selecao-de-texto-no-pane-anda-com-o-scroll-f@68218bba";
+
+  it("drops a value that is not a version from the options", () => {
+    expect(
+      releaseFilterOptions(
+        cards,
+        [{ value: "v1.2.0" }, { value: branch }, { value: "v1.1.0" }],
+        boardFilter({}),
+      ),
+    ).toEqual([
+      { value: "v1.2.0", count: 1 },
+      { value: "v1.1.0", count: 1 },
+      { value: null, count: 1 },
+    ]);
+  });
+
+  it("keeps the no-release bucket counting cards whose release was dropped", () => {
+    const stamped = [
+      ...cards,
+      {
+        id: "d",
+        projectId: "p1",
+        missionId: null,
+        tipo: "bug" as const,
+        priority: "baixa" as const,
+        resolvedIn: branch,
+      },
+    ];
+    const options = releaseFilterOptions(
+      stamped,
+      [{ value: "v1.2.0" }, { value: branch }],
+      boardFilter({}),
+    );
+    expect(options.map((option) => option.value)).toEqual(["v1.2.0", null]);
+  });
+
+  it("narrows a raw list to the releases worth offering", () => {
+    expect(
+      releaseValueOptions([
+        { value: "v1.2.0" },
+        { value: branch },
+        { value: "main" },
+        { value: "1.1" },
+      ]),
+    ).toEqual([{ value: "v1.2.0" }, { value: "1.1" }]);
+  });
+
+  it("refuses to restore a stored selection that is not a release", () => {
+    expect(resolveReleaseSelection(branch, [{ value: branch }])).toBeUndefined();
   });
 });

--- a/apps/web/src/lib/board-filter.ts
+++ b/apps/web/src/lib/board-filter.ts
@@ -1,4 +1,5 @@
 import type { TaskPriority, TaskType } from "@agent-board/db";
+import { isReleaseVersion } from "@agent-board/mcp-core";
 
 export const ALL_PROJECTS = "all";
 /**
@@ -89,6 +90,10 @@ export function resolveReleaseSelection(
 ): string | null | undefined {
   if (stored == null || stored.length === 0) return undefined;
   if (stored === NO_RELEASE) return null;
+  // A stored value the filter would not offer is no longer a selection: a
+  // release that was deleted, and since OCL-128 also a branch name that some
+  // delivery wrote into resolved_in.
+  if (!isReleaseVersion(stored)) return undefined;
   if (releases && !releases.some((release) => release.value === stored)) {
     return undefined;
   }
@@ -381,6 +386,23 @@ export function missionFilterOptions<T extends FilterableCard>(
 /** A release the filter can offer, with the count left by every other dimension. */
 export type ReleaseCount = { value: string | null; count: number };
 
+/**
+ * The releases worth putting on the filter (OCL-128).
+ *
+ * `resolved_in` is a free-text column, and a delivery that wrote its branch
+ * name there ("ovka-78-...-f@68218bba") became an option on the RELEASE
+ * filter, next to v0.2.2 and holding no cards. The write path refuses that
+ * value now; this is the reading end, so the rows already stamped stop
+ * polluting the menu. The cards themselves are not hidden: they stay under
+ * "all releases", which is where a card whose release this filter cannot
+ * read belongs.
+ */
+export function releaseValueOptions(
+  releases: { value: string }[],
+): { value: string }[] {
+  return releases.filter((release) => isReleaseVersion(release.value));
+}
+
 export function releaseFilterOptions<T extends FilterableCard>(
   cards: T[],
   releases: { value: string }[],
@@ -394,7 +416,7 @@ export function releaseFilterOptions<T extends FilterableCard>(
     counts.set(card.resolvedIn, (counts.get(card.resolvedIn) ?? 0) + 1);
   }
   return [
-    ...releases.map((release) => ({
+    ...releaseValueOptions(releases).map((release) => ({
       value: release.value,
       count: counts.get(release.value) ?? 0,
     })),

--- a/apps/web/src/styles/filter-option-row.test.ts
+++ b/apps/web/src/styles/filter-option-row.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { COMPONENT_SHEETS } from "./audited-sheets";
+import {
+  classSpecificity,
+  parseDeclarations,
+  parseRules,
+  splitSelectorList,
+} from "./css-rules";
+
+/**
+ * OCL-83 / OCL-128: a filter option is one row — box, then name — read from
+ * the left.
+ *
+ * The bug this guards against is a cascade trap, not a typo. `globals.css:75`
+ * still declares `label { flex-direction: column }` on a bare element (it is
+ * a known, frozen finding in `naked-element-selectors.test.ts`, with its own
+ * card in the OCL-89 mission). `.ff-opt` is a `<label>`, so the day it stops
+ * declaring `flex-direction` itself, every option in TIPO, PRIORIDADE and
+ * RELEASE stacks its box above its name and centres the pair — which is what
+ * the OCL-128 screenshot showed, taken against the v0.2.2 deploy, cut before
+ * OCL-83 landed.
+ *
+ * Same simplifications as `control-anatomy.test.ts`: class specificity and
+ * source order only, `@media` skipped.
+ */
+function resolveFlexDirection(cls: string): string | null {
+  let winner: { value: string; specificity: number } | null = null;
+  for (const css of Object.values(COMPONENT_SHEETS)) {
+    for (const rule of parseRules(css)) {
+      if (rule.insideAtRule) continue;
+      for (const simple of splitSelectorList(rule.selector)) {
+        if (!new RegExp(`\\.${cls}\\b(?![-\\w])`).test(simple)) continue;
+        for (const decl of parseDeclarations(rule.body)) {
+          if (decl.prop !== "flex-direction") continue;
+          const specificity = classSpecificity(simple);
+          if (!winner || specificity >= winner.specificity) {
+            winner = { value: decl.value.trim(), specificity };
+          }
+        }
+      }
+    }
+  }
+  return winner?.value ?? null;
+}
+
+describe("a filter option reads as one row (OCL-83)", () => {
+  it(".ff-opt declares flex-direction: row itself", () => {
+    // Declaring it is the point: the bare `label` rule wins by default.
+    expect(resolveFlexDirection("ff-opt")).toBe("row");
+  });
+
+  it("the option list stays a column, so the options stack, not their parts", () => {
+    expect(resolveFlexDirection("ff-list")).toBe("column");
+  });
+});

--- a/packages/mcp-core/src/index.ts
+++ b/packages/mcp-core/src/index.ts
@@ -1,3 +1,5 @@
+export { RELEASE_VERSION_PATTERN, isReleaseVersion } from "./release.js";
+
 export {
   ERROR_CODES,
   McpCoreError,
@@ -117,6 +119,7 @@ export {
   TaskSchema,
   TaskListItemSchema,
   TaskSummarySchema,
+  ReleaseVersionSchema,
   TaskTypeSchema,
   TranscriptRefSchema,
   UsageSchema,

--- a/packages/mcp-core/src/release.ts
+++ b/packages/mcp-core/src/release.ts
@@ -1,0 +1,21 @@
+/**
+ * What counts as a release (OCL-128).
+ *
+ * `resolved_in` names the version a card shipped in. A card delivered with a
+ * branch name there ("ovka-78-bug-...-f@68218bba") made that branch an option
+ * on the board's RELEASE filter, sitting next to v0.2.2 with a count of zero.
+ * The delivery already has a `branch` field and a `commit` field; this one is
+ * for the release, so the shape is checked where it is written and where it
+ * is offered.
+ *
+ * Deliberately a little wider than the tags this repo cuts: a two-part series
+ * ("1.2") and a pre-release or build suffix ("v1.0.0-rc.1") are versions too.
+ * What it refuses is everything that is not a numeric series — branches,
+ * commit hashes and free text.
+ */
+export const RELEASE_VERSION_PATTERN =
+  /^v?\d+\.\d+(\.\d+)*([-+][0-9A-Za-z.-]+)?$/;
+
+export function isReleaseVersion(value: string | null | undefined): boolean {
+  return typeof value === "string" && RELEASE_VERSION_PATTERN.test(value.trim());
+}

--- a/packages/mcp-core/src/schemas/common.ts
+++ b/packages/mcp-core/src/schemas/common.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { RELEASE_VERSION_PATTERN } from "../release.js";
 
 export const CardStatusSchema = z.enum([
   "aberto",
@@ -9,6 +10,26 @@ export const CardStatusSchema = z.enum([
 ]);
 
 export const TaskTypeSchema = z.enum(["feature", "bug", "rfc"]);
+
+/**
+ * The release a card shipped in, as it is written (OCL-128). A delivery that
+ * put its branch there ("ovka-78-...-f@68218bba") turned the branch into an
+ * option on the board's RELEASE filter, beside v0.2.2 and with no cards under
+ * it. A delivery already carries `branch` and `commit`; this field is the
+ * release, so it takes a version and says so when it does not get one.
+ *
+ * Only the write paths use it. Reading filters (task_list, task_search) stay
+ * permissive, so cards stamped before this guard remain findable by the exact
+ * value they carry.
+ */
+export const ReleaseVersionSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .regex(
+    RELEASE_VERSION_PATTERN,
+    "resolved_in is a release version (v1.4.0, 1.4.0, v1.0.0-rc.1); send a branch name in branch and a commit in commit",
+  );
 
 /** Keep in step with CARDAPIO_TASK_TYPES: the routing table is the source. */
 export const CardapioTaskTypeSchema = z.enum([

--- a/packages/mcp-core/src/schemas/tools.ts
+++ b/packages/mcp-core/src/schemas/tools.ts
@@ -22,6 +22,7 @@ import {
   MissionSummarySchema,
   OrigemSchema,
   PrioritySchema,
+  ReleaseVersionSchema,
   ProjectContextSourceSchema,
   ProjectDetailSchema,
   ProjectSchema,
@@ -815,7 +816,7 @@ export const TaskUpdateInputSchema = z
      * what the delivery said (a fix that only shipped in a later release);
      * null clears it. Empty string is refused: send null to clear.
      */
-    resolved_in: z.string().min(1).nullable().optional(),
+    resolved_in: ReleaseVersionSchema.nullable().optional(),
     /** Discard an in-execution card, optionally linking its existing continuation. */
     status: z.literal("descartado").optional(),
     superseded_by: TaskIdSchema.optional(),
@@ -910,9 +911,9 @@ export const TaskDeliverInputSchema = z.object({
   /**
    * Version, tag or release this delivery lands in, when the agent knows it
    * ("1.4.0"). Stored on the card as resolved_in; task_update can fill or
-   * correct it later.
+   * correct it later. A version, not a branch: OCL-128.
    */
-  resolved_in: z.string().min(1).optional(),
+  resolved_in: ReleaseVersionSchema.optional(),
   /** Mutations are compact by default; request the complete handoff explicitly. */
   return: WriteReturnSchema.optional(),
   /**

--- a/packages/mcp-core/tests/release.test.ts
+++ b/packages/mcp-core/tests/release.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { isReleaseVersion } from "../src/release.js";
+
+/**
+ * OCL-128: a card delivered with a branch name in `resolved_in` put
+ * "ovka-78-bug-...-f@68218bba" on the board's RELEASE filter, next to real
+ * releases. `resolved_in` names a release; the branch has its own field.
+ */
+describe("isReleaseVersion", () => {
+  it("accepts the release tags this repo cuts", () => {
+    for (const value of ["v0.2.2", "0.2.2", "v1.0.0", "1.4.0", "v10.20.30"]) {
+      expect(isReleaseVersion(value), value).toBe(true);
+    }
+  });
+
+  it("accepts a two-part series and a pre-release or build suffix", () => {
+    for (const value of ["v1.2", "1.2", "v1.0.0-rc.1", "v1.0.0+build.5"]) {
+      expect(isReleaseVersion(value), value).toBe(true);
+    }
+  });
+
+  it("refuses the branch name from the bug report", () => {
+    expect(
+      isReleaseVersion("ovka-78-bug-selecao-de-texto-no-pane-anda-com-o-scroll-f@68218bba"),
+    ).toBe(false);
+  });
+
+  it("refuses branches, commits and free text", () => {
+    for (const value of [
+      "main",
+      "feature/ocl-128",
+      "68218bba",
+      "68218bba1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f",
+      "sprint 12",
+      "",
+      "   ",
+      "v",
+      "v1",
+    ]) {
+      expect(isReleaseVersion(value), value).toBe(false);
+    }
+  });
+
+  it("ignores surrounding whitespace", () => {
+    expect(isReleaseVersion("  v1.2.3  ")).toBe(true);
+  });
+});

--- a/packages/mcp-core/tests/schemas.test.ts
+++ b/packages/mcp-core/tests/schemas.test.ts
@@ -943,3 +943,46 @@ describe("harness account/provider wire contract (OCL-108)", () => {
     expect(invalid.success).toBe(false);
   });
 });
+
+/**
+ * OCL-128: `resolved_in` is the release, and only the release. A delivery
+ * that put a branch name there leaked it onto the board's RELEASE filter.
+ */
+describe("resolved_in only takes a release version", () => {
+  const branch = "ovka-78-bug-selecao-de-texto-no-pane-anda-com-o-scroll-f@68218bba";
+
+  function deliver(resolved_in: string) {
+    return TaskDeliverInputSchema.safeParse({
+      task_id: "OC-1",
+      summary: "done",
+      resolved_in,
+    });
+  }
+
+  it("task_deliver keeps taking a version tag", () => {
+    for (const value of ["v1.4.0", "1.4.0", "v1.0.0-rc.1"]) {
+      expect(deliver(value).success, value).toBe(true);
+    }
+  });
+
+  it("task_deliver refuses a branch name, a commit and free text", () => {
+    for (const value of [branch, "main", "feature/ocl-128", "68218bba"]) {
+      expect(deliver(value).success, value).toBe(false);
+    }
+  });
+
+  it("task_update refuses a branch name but still clears with null", () => {
+    expect(
+      TaskUpdateInputSchema.safeParse({ task_id: "OC-1", resolved_in: branch })
+        .success,
+    ).toBe(false);
+    expect(
+      TaskUpdateInputSchema.safeParse({ task_id: "OC-1", resolved_in: "v2.0.0" })
+        .success,
+    ).toBe(true);
+    expect(
+      TaskUpdateInputSchema.safeParse({ task_id: "OC-1", resolved_in: null })
+        .success,
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## Item 1 — opção empilhada/centralizada: **gap de DEPLOY**, não regressão

Reproduzido contra a main atual: renderiza em linha alinhada à esquerda. Nenhuma mudança de CSS foi feita.

Causa raiz (o print é real, mas de outro build):

- `apps/web/src/app/globals.css:75` declara `label { display: flex; flex-direction: column; gap: 6px }` — um seletor de elemento nu. Segue vivo na main; é um finding **conhecido e congelado** em `naked-element-selectors.test.ts` (OCL-89), com card próprio para removê-lo.
- Em **v0.2.2**, `.nb .ff-opt` declarava `display: flex; align-items: center; gap: 8px` **sem** `flex-direction`. A regra nua vencia por default, e `column` + `align-items: center` dá exatamente o print: checkbox centralizado acima do label.
- OCL-83 (`1e43347`, 21/08 00:45 -03) adicionou `flex-direction: row`. A tag `v0.2.2` foi cortada em 20/08 14:03 -03 — **antes** do fix. `git merge-base --is-ancestor 1e43347 v0.2.2` → falso.

Conserto: cortar uma release nova. Não há código a mudar.

Como a armadilha de cascata continua viva, adicionei `apps/web/src/styles/filter-option-row.test.ts`: um guard no estilo do OCL-89 que resolve `flex-direction` de `.ff-opt` pela cascata das folhas auditadas e exige `row`. Verificado por mutação — removendo `flex-direction: row` de `nebula.css`, o guard fica vermelho.

## Item 2 — nome de branch como opção de RELEASE: **bug real**, corrigido

`resolved_in` é coluna de texto livre e alguma entrega gravou o nome da branch lá (`ovka-78-...-f@68218bba`). `home/page.tsx` faz `selectDistinct(resolvedIn)` e o menu listava o valor cru.

Corrigido nas duas pontas (TDD, teste vermelho antes de cada fix):

**Escrita** — novo `packages/mcp-core/src/release.ts` com `isReleaseVersion` / `RELEASE_VERSION_PATTERN` (aceita `v1.4.0`, `1.4.0`, `1.2`, `v1.0.0-rc.1`; recusa branch, sha e texto solto). `ReleaseVersionSchema` passa a validar `resolved_in` em `task_deliver` e `task_update`, com erro que aponta para `branch` e `commit`. Os **filtros de leitura** (`task_list`, `task_search`) seguem permissivos de propósito, para que cards já carimbados continuem encontráveis pelo valor exato.

**Leitura** — `releaseValueOptions` estreita a lista, `releaseFilterOptions` a aplica, `resolveReleaseSelection` recusa restaurar uma seleção que não é release, e a server action `board-filter` não persiste uma. Os cards não somem: ficam sob "todas as releases".

## Verificação

- `pnpm test`: **833 testes verdes** (mcp-core 140, db 130, web 563 + 2 skipped), 0 falhas.
- `pnpm typecheck`: verde nos 3 pacotes.
- Guards de estilo do OCL-89: 53 verdes (51 anteriores + 2 novos).

🤖 Generated with [Claude Code](https://claude.com/claude-code)