### PR TITLE
fix(pairing): make pairing repeatable, and make the installer say what actually failed

### DIFF
--- a/apps/web/src/lib/pairing.ts
+++ b/apps/web/src/lib/pairing.ts
@@ -148,6 +148,39 @@ export async function createPairingCode(
   return { id: row.id, code, expiresAt };
 }
 
+/**
+ * A workspace may not hold two tokens under the same label, and revoking one
+ * does not free it: `mcp_token_workspace_label` does not exclude revoked rows.
+ * The default label is a constant ("paired agent"), so the second pairing on a
+ * workspace collided, the insert below threw, and `/api/pair` answered 500 with
+ * no way back through the UI — the instance was simply unpairable from then on.
+ * That state is reached by the most ordinary action there is: pairing again
+ * after a first attempt died before the token reached the agent.
+ *
+ * So the label the human chose is a preference, not a key: when it is taken,
+ * the next free "<label> (n)" is used. The name still says which agent it is,
+ * and pairing stays repeatable.
+ */
+async function freeTokenLabel(
+  tx: McpDatabase,
+  workspaceId: string,
+  desired: string,
+): Promise<string> {
+  const rows = await tx
+    .select({ label: mcpToken.label })
+    .from(mcpToken)
+    .where(eq(mcpToken.workspaceId, workspaceId));
+  const taken = new Set(rows.map((r) => r.label));
+  if (!taken.has(desired)) return desired;
+  for (let n = 2; n <= 500; n += 1) {
+    const candidate = `${desired} (${n})`;
+    if (!taken.has(candidate)) return candidate;
+  }
+  // 500 tokens deep the suffix is no longer telling anyone anything; fall back
+  // to something that cannot collide rather than throwing the 500 back.
+  return `${desired} (${randomInt(1_000_000, 10_000_000)})`;
+}
+
 export type ExchangeResult =
   | { ok: true; token: string; label: string }
   | { ok: false; error: string };
@@ -191,11 +224,12 @@ export async function exchangePairingCode(
     if (consumed.expiresAt.getTime() < Date.now()) return notFound;
 
     const secret = consumed.secret;
+    const label = await freeTokenLabel(tx, consumed.workspaceId, consumed.label);
     const [token] = await tx
       .insert(mcpToken)
       .values({
         workspaceId: consumed.workspaceId,
-        label: consumed.label,
+        label,
         hash: hashToken(secret),
         tokenPrefix: secret.slice(0, 12),
         createdByUserId: consumed.createdByUserId,
@@ -209,7 +243,7 @@ export async function exchangePairingCode(
       .set({ secret: "", tokenId: token.id })
       .where(eq(pairingCode.id, consumed.id));
 
-    return { ok: true, token: secret, label: consumed.label };
+    return { ok: true, token: secret, label };
   });
 
   if (result.ok) await clearAttempts(db, scope);

--- a/apps/web/src/mcp/pairing.integration.test.ts
+++ b/apps/web/src/mcp/pairing.integration.test.ts
@@ -294,4 +294,84 @@ describe("one-time token pairing", () => {
     const live = await exchangePairingCode(world.db, second.code);
     expect(live.ok).toBe(true);
   });
+  /**
+   * The second pairing on a workspace used to be impossible.
+   *
+   * `mcp_token_workspace_label` is unique on (workspace_id, label) and the
+   * default label is a constant, so the insert threw and `/api/pair` answered
+   * 500 — permanently, because nothing in the UI can free a label. The path
+   * there is the most ordinary one there is: pair again after a first attempt
+   * died before the token reached the agent.
+   */
+  it("pairs a second agent when the default label is already taken", async () => {
+    world = await createTestWorld();
+
+    const first = await createPairingCode(world.db, {
+      workspaceId: world.workspaceId,
+      label: "paired agent",
+    });
+    const one = await exchangePairingCode(world.db, first.code, AGENT);
+    expect(one.ok).toBe(true);
+    if (one.ok) expect(one.label).toBe("paired agent");
+
+    const second = await createPairingCode(world.db, {
+      workspaceId: world.workspaceId,
+      label: "paired agent",
+    });
+    const two = await exchangePairingCode(world.db, second.code, AGENT);
+
+    // Before the fix this was `{ ok: false }` via a thrown unique violation,
+    // surfaced to the caller as HTTP 500.
+    expect(two.ok).toBe(true);
+    if (two.ok) expect(two.label).toBe("paired agent (2)");
+
+    // Two usable tokens, and the labels still tell them apart. The world is
+    // seeded with fixture tokens of its own, so look only at the ones this
+    // test paired.
+    const rows = await world.db
+      .select({ label: mcpToken.label })
+      .from(mcpToken)
+      .where(eq(mcpToken.workspaceId, world.workspaceId));
+    const paired = rows
+      .map((r) => r.label)
+      .filter((label) => label.startsWith("paired agent"))
+      .sort();
+    expect(paired).toEqual(["paired agent", "paired agent (2)"]);
+    if (one.ok) expect(await authenticateBearer(world.db, `Bearer ${one.token}`)).toBeTruthy();
+    if (two.ok) expect(await authenticateBearer(world.db, `Bearer ${two.token}`)).toBeTruthy();
+  });
+
+  /**
+   * Revoking is what an operator reaches for after a pairing goes wrong, so it
+   * is the one action that must not make the next attempt worse. The unique
+   * constraint does not exclude revoked rows, so the label outlives the token
+   * it belonged to.
+   */
+  it("does not let a revoked token hold its label hostage", async () => {
+    world = await createTestWorld();
+
+    const first = await createPairingCode(world.db, {
+      workspaceId: world.workspaceId,
+      label: "paired agent",
+    });
+    const one = await exchangePairingCode(world.db, first.code, AGENT);
+    expect(one.ok).toBe(true);
+
+    await world.db
+      .update(mcpToken)
+      .set({ revoked: true })
+      .where(eq(mcpToken.workspaceId, world.workspaceId));
+
+    const second = await createPairingCode(world.db, {
+      workspaceId: world.workspaceId,
+      label: "paired agent",
+    });
+    const two = await exchangePairingCode(world.db, second.code, AGENT);
+
+    expect(two.ok).toBe(true);
+    if (two.ok) {
+      expect(two.label).toBe("paired agent (2)");
+      expect(await authenticateBearer(world.db, `Bearer ${two.token}`)).toBeTruthy();
+    }
+  });
 });

--- a/install.sh
+++ b/install.sh
@@ -338,7 +338,7 @@ write_codex_mcp() {
 merge_json_config() {
   local mode=$1 file=$2 source_hooks=${3:-}
   mkdir -p "$(dirname -- "$file")"
-  if command -v python3 >/dev/null 2>&1; then
+  if command -v python3 >/dev/null 2>&1 && runtime_works python3; then
     OC_JSON_MODE=$mode OC_JSON_FILE=$file OC_MCP_URL=$mcp_url OC_MCP_TOKEN=$token \
       OC_HOOK_SOURCE=$source_hooks OC_PLUGIN_TARGET=$plugin_target python3 <<'PY'
 import json, os, pathlib, tempfile
@@ -397,7 +397,7 @@ PY
     return
   fi
 
-  if command -v node >/dev/null 2>&1; then
+  if command -v node >/dev/null 2>&1 && runtime_works node; then
     OC_JSON_MODE=$mode OC_JSON_FILE=$file OC_MCP_URL=$mcp_url OC_MCP_TOKEN=$token \
       OC_HOOK_SOURCE=$source_hooks OC_PLUGIN_TARGET=$plugin_target node <<'JS'
 const fs = require("node:fs");
@@ -511,7 +511,7 @@ quiet_try() {
 verify_claude_plugin() {
   local listing
   listing=$(claude plugin list --json 2>/dev/null) || return 1
-  if command -v python3 >/dev/null 2>&1; then
+  if command -v python3 >/dev/null 2>&1 && runtime_works python3; then
     printf '%s' "$listing" | python3 -c '
 import json, sys
 try:
@@ -526,7 +526,7 @@ sys.exit(1)
 '
     return $?
   fi
-  if command -v node >/dev/null 2>&1; then
+  if command -v node >/dev/null 2>&1 && runtime_works node; then
     printf '%s' "$listing" | node -e '
 let data = "";
 process.stdin.on("data", chunk => { data += chunk; });
@@ -548,7 +548,7 @@ process.stdin.on("end", () => {
 verify_codex_plugin() {
   local listing
   listing=$(codex plugin list --json 2>/dev/null) || return 1
-  if command -v python3 >/dev/null 2>&1; then
+  if command -v python3 >/dev/null 2>&1 && runtime_works python3; then
     printf '%s' "$listing" | python3 -c '
 import json, sys
 try:
@@ -727,7 +727,7 @@ KIMIPY
 
 if has_cli kimi; then
   merge_json_config mcp-kimi "$install_home/.kimi-code/mcp.json"
-  if command -v python3 >/dev/null 2>&1 && kimi_register_plugin; then
+  if command -v python3 >/dev/null 2>&1 && runtime_works python3 && kimi_register_plugin; then
     printf '%s\n' "Kimi plugin configured."
   else
     printf '%s\n' "Kimi plugin needs manual confirmation: run /plugins install $plugin_target inside Kimi Code." >&2

--- a/install.sh
+++ b/install.sh
@@ -96,9 +96,24 @@ fi
 # a JSON runtime to merge agent configs safely; the sed arm is only there so a
 # machine that has neither still gets a readable failure from the caller rather
 # than a silently empty token.
+# `command -v` answers "is there a file by that name", which is a different
+# question. Windows ships `python3.exe` by default as a Microsoft Store App
+# Execution Alias: it satisfies `command -v`, runs, prints "Python was not
+# found" and exits 0 with empty stdout. Committing to that runtime made the
+# token come back empty on every Windows install, and the sed fallback below --
+# written for exactly this machine -- was never reached, because the stub had
+# already won the branch. So probe capability, not presence.
+runtime_works() {
+  case $1 in
+    python3) python3 -c pass >/dev/null 2>&1 ;;
+    node) node -e "" >/dev/null 2>&1 ;;
+    *) return 1 ;;
+  esac
+}
+
 read_json_string() {
   local field=$1 payload=$2 value
-  if command -v python3 >/dev/null 2>&1; then
+  if command -v python3 >/dev/null 2>&1 && runtime_works python3; then
     OC_JSON_PAYLOAD=$payload OC_JSON_FIELD=$field python3 <<'PY'
 import json, os, sys
 
@@ -113,7 +128,7 @@ sys.stdout.write(value)
 PY
     return $?
   fi
-  if command -v node >/dev/null 2>&1; then
+  if command -v node >/dev/null 2>&1 && runtime_works node; then
     OC_JSON_PAYLOAD=$payload OC_JSON_FIELD=$field node <<'JS'
 let data;
 try { data = JSON.parse(process.env.OC_JSON_PAYLOAD); } catch { process.exit(1); }
@@ -138,10 +153,42 @@ exchange_pairing_code() {
     printf '%s\n' "curl is required to exchange an OverClick pairing code." >&2
     return 1
   fi
-  response=$(curl -fsS -X POST "$instance_base/api/pair" \
-    -H 'Content-Type: application/json' \
-    -d "{\"code\":\"$code\"}" 2>/dev/null) || return 1
-  read_json_string token "$response"
+  # Not `-f`: it collapses "the code was refused", "the instance is broken"
+  # and "the network is down" into one exit status, and the caller then blamed
+  # all three on an expired code -- sending users to burn a fresh code against
+  # a 500 that no code could satisfy. Read the status and say which happened;
+  # the server's own JSON error is more specific than anything invented here.
+  local body status
+  body=$(mktemp) || return 1
+  status=$(curl -sS -o "$body" -w '%{http_code}' -X POST "$instance_base/api/pair"     -H 'Content-Type: application/json'     -d "{\"code\":\"$code\"}" 2>/dev/null) || status=000
+  response=$(cat "$body" 2>/dev/null)
+  rm -f "$body"
+
+  case $status in
+    2*) ;;
+    000)
+      printf '%s
+' "Could not reach $instance_base to exchange the pairing code. Check the URL, the network, and that the instance is up." >&2
+      return 1 ;;
+    5*)
+      printf '%s
+' "The instance answered HTTP $status while exchanging the pairing code. The code was NOT spent: this is a fault on the board, not a stale code. Check the server logs." >&2
+      [ -n "$response" ] && printf '%s
+' "  response: $response" >&2
+      return 1 ;;
+    *)
+      local detail
+      detail=$(read_json_string error "$response" 2>/dev/null) || detail=""
+      printf '%s
+' "${detail:-The board refused the pairing code (HTTP $status).}" >&2
+      return 1 ;;
+  esac
+
+  if ! read_json_string token "$response"; then
+    printf '%s
+' "The board accepted the pairing code, but the token could not be read out of its reply. The code is now spent -- generate a fresh one. Install python3 or node so the installer can parse JSON." >&2
+    return 1
+  fi
 }
 
 if [[ -n "${OVERCLICK_TOKEN:-}" ]]; then
@@ -152,8 +199,10 @@ elif [[ -n "${OVERCLICK_PAIRING_CODE:-}" ]]; then
     printf '%s\n' "An OverClick pairing code is exactly six digits." >&2
     exit 1
   fi
+  # No blanket message here: exchange_pairing_code already said which failure
+  # mode happened, and overwriting it with "the code expired" is precisely what
+  # pointed the diagnosis at the one part that was working correctly.
   if ! token=$(exchange_pairing_code "$pairing_code"); then
-    printf '%s\n' "Could not exchange the pairing code. It is single use and expires in ten minutes; generate a fresh command on the board and run it again." >&2
     exit 1
   fi
   printf '%s\n' "Paired with the OverClick instance. The token was not displayed."


### PR DESCRIPTION
Fixes #60.

Found while pairing the first agent against a fresh self-hosted instance. Four defects compound: one makes pairing permanently impossible after the first attempt, and three make the failure describe the wrong component. Five pairing codes were burned before the cause was visible — and it was only ever visible from the container logs and the database, never from the installer.

## 1. `exchangePairingCode` used the label as if it were free

`mcp_token_workspace_label` is `UNIQUE(workspace_id, label)` and does not exclude revoked rows. The default label is the constant `"paired agent"`, and the exchange inserted it verbatim:

```
duplicate key value violates unique constraint "mcp_token_workspace_label"
detail: Key (workspace_id, label)=(<workspace>, paired agent) already exists.
```

So the **second** pairing on a workspace threw inside the transaction and `/api/pair` answered 500 — permanently, with no way back through the UI. Revoking the old token does not help, because the row (and its label) survives revocation.

The path there is the most ordinary one available: pair again after a first attempt died before the token reached the agent. Which is exactly what defects 2–4 cause.

The label is now a preference rather than a key — a taken one becomes `<label> (n)`. `ExchangeResult.label` returns the label actually used, so the caller and the UI agree with the database.

## 2. `curl -fsS ... 2>/dev/null` erased the distinction between failures

`-f` collapsed "the code was refused", "the instance is broken" and "the network is down" into one exit status, and the caller printed the same sentence over all three:

> Could not exchange the pairing code. It is single use and expires in ten minutes; generate a fresh command on the board and run it again.

For defect #1 that message is actively harmful: it sends the user to generate another code and spend it against a 500 that no code could ever satisfy. The board's own JSON error is more specific than anything the script can invent, and it never reached the user.

Now the status is read and branched: 4xx relays the server's message, 5xx says the fault is on the board **and that the code was not spent**, connection failure says so, and a 2xx whose body will not parse says *that* instead of blaming the code. The caller no longer overwrites the diagnosis.

## 3 & 4. `command -v python3` is a false positive on Windows

`command -v` answers "is there a file by that name", which is a different question. Windows ships `python3.exe` by default as a Microsoft Store **App Execution Alias**: it satisfies `command -v`, runs, prints `Python was not found; run without arguments to install from the Microsoft Store` and **exits 0 with empty stdout**.

`read_json_string` committed to that runtime, the token came back empty, and — through defect #2 — the user was told the code had expired. Meanwhile the exchange had already succeeded: the code was spent and an orphan token existed on the board. Note the `sed` fallback is unreachable in exactly the case its comment describes, because the stub wins the branch first.

Fixing `read_json_string` alone was not enough (that was the first commit here). Five more sites trusted `command -v python3` and two trusted `command -v node` — the plugin configuration path among them. On the same machine, pairing then succeeded but the run ended:

```
Python was not found; run without arguments to install from the Microsoft Store...
Claude plugin did not materialize: 'claude plugin list --json' shows no enabled
overclick entry with OVERCLICK.md on disk.
```

A `runtime_works` helper now probes that the interpreter *runs*, and every site uses it.

## Verification

On a self-hosted instance (Ubuntu 24.04, `deploy/deploy.sh`, Postgres), patched and rebuilt:

**Defect #1** — recreated the collision deliberately (a revoked token holding `paired agent`, plus a pending code wanting the same label — the exact state that returned 500):

```
HTTP 200
token recebido: SIM (52 chars)
confere com o segredo plantado: True
label devolvido: paired agent (2)
```

**Defects #2–4** — ran the installer from **Windows (Git Bash) with the Store alias active**, no workarounds, `command -v python3` pointing at `AppInstallerPythonRedirector.exe`:

```
Paired with the OverClick instance. The token was not displayed.
Claude marketplace configured.
Claude plugin configured.
Claude MCP configured.
Claude plugin verified: enabled and materialized at ...\plugins\cache\overclick\overclick\0.2.3.
OverClick plugin installation complete. Credentials were stored privately and were not displayed.
```

Before the patch, that same machine and instance produced `Could not exchange the pairing code`, then HTTP 500, then `Claude plugin did not materialize`.

Next.js build type-checks clean (`Finished TypeScript in 21.4s`).

## Note for existing broken instances

An instance already stuck needs its label freed once; the code fix cannot reach a row that already collides:

```sql
UPDATE mcp_token
   SET label = label || ' (revoked ' || to_char(created_at, 'HH24:MI:SS') || ')'
 WHERE revoked = true;
```

Happy to add a migration that does this automatically, or to make the constraint partial (`WHERE revoked = false`) instead of suffixing, if you prefer either shape.