### PR TITLE
release: v0.2.4 (+ contribs #61, #59)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "overclick",
       "description": "Claim, execute, and deliver cards on your own self-hosted OverClick board. Ships the workflow skill, the /overclick:* commands, and hooks: a session-start board snapshot and a delivery commit check run by default, while the Edit|Write|Bash claim guard and the stop/harness guards ship disabled. The only network endpoint is the OverClick instance you configure - no third-party calls, no telemetry.",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "source": "./plugin"
     }
   ]

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "overclick",
       "description": "Claim, execute, and deliver OverClick cards.",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "source": {
         "type": "local",
         "path": "./plugin"

--- a/.kimi-plugin/plugin.json
+++ b/.kimi-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "overclick",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Run the complete OverClick card workflow from Kimi Code.",
   "homepage": "https://github.com/ustoppble/overclick",
   "license": "MIT",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-board/web",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "private": true,
   "scripts": {
     "dev": "NEXT_TELEMETRY_DISABLED=1 next dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-board",
   "private": true,
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Self-hosted board for hybrid human+agent teams. Data never leaves the server.",
   "license": "MIT",
   "packageManager": "pnpm@9.15.9",

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-board/db",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/mcp-core/package.json
+++ b/packages/mcp-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-board/mcp-core",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "private": true,
   "description": "Pure TypeScript contracts, card state machine, and harness recommendation for the agent board MCP surface.",
   "type": "module",

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "overclick",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Claim, execute, and deliver cards on your own self-hosted OverClick board. Ships the workflow skill, the /overclick:* commands, and hooks: a session-start board snapshot and a delivery commit check run by default, while the Edit|Write|Bash claim guard and the stop/harness guards ship disabled. The only network endpoint is the OverClick instance you configure - no third-party calls, no telemetry.",
   "author": {
     "name": "OverClick"

--- a/plugin/.codex-plugin/plugin.json
+++ b/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "overclick",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Run the complete OverClick card workflow from Codex.",
   "author": {
     "name": "OverClick"

--- a/plugin/kimi.plugin.json
+++ b/plugin/kimi.plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "overclick",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Run the complete OverClick card workflow from Kimi Code.",
   "keywords": [
     "overclick",

--- a/plugin/plugin.json
+++ b/plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "overclick",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Run the complete OverClick card workflow from Grok CLI.",
   "author": {
     "name": "OverClick"

--- a/scripts/test-plugin-package.sh
+++ b/scripts/test-plugin-package.sh
@@ -381,20 +381,30 @@ test "$(grep -c '<!-- overclick:start -->' "$TEST_ROOT/project/AGENTS.md")" -eq 
 mkdir -p "$TEST_ROOT/pair-bin"
 cat >"$TEST_ROOT/pair-bin/curl" <<'SH'
 #!/bin/sh
+# exchange_pairing_code now calls `curl -sS -o <file> -w '%{http_code}'`: the
+# body lands in the -o file and only the HTTP status is on stdout. Emulate that
+# contract, not the old "print the body on stdout" one, or the exchange reads
+# the JSON as a status, falls to the refusal branch, and the install exits 1.
 url=""
 body=""
+out=""
 previous=""
 for argument in "$@"; do
   case "$argument" in
     http://*|https://*) url=$argument ;;
   esac
-  if [ "$previous" = "-d" ]; then body=$argument; fi
+  case "$previous" in
+    -d) body=$argument ;;
+    -o) out=$argument ;;
+  esac
   previous=$argument
 done
 printf '%s %s\n' "$url" "$body" >>"$OC_TEST_PAIR_LOG"
 case "$url:$body" in
   */api/pair:*'"code":"482913"'*)
-    printf '%s' '{"token":"paired-secret","label":"agent","url":"/mcp"}'
+    payload='{"token":"paired-secret","label":"agent","url":"/mcp"}'
+    if [ -n "$out" ]; then printf '%s' "$payload" >"$out"; else printf '%s' "$payload"; fi
+    printf '200'
     exit 0
     ;;
 esac


### PR DESCRIPTION
Bump 0.2.3→0.2.4 + fix do stub de curl do plugin-package test (o #61 mudou o contrato do curl no exchange_pairing_code). Cards OCL-129/130/131.