### PR TITLE
[OCL-133] install.sh delivers the release on Windows (MinGit) — issue #67

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -35,6 +35,74 @@ if [[ -n "${OVERCLICK_INSTALL_HOME:-}" ]]; then
   export GEMINI_HOME="$install_home/.gemini"
 fi
 
+# MinGit on Windows ships a bash but no coreutils, so `chmod` is simply absent
+# there: under `set -e` every mode-bit call below aborted the install - and did
+# it AFTER the credentials had already been written, so the run exited non-zero
+# with the configuration rewritten (OCL-133). Mode bits are hardening, not the
+# installation: on Windows these files land under the user profile, where the
+# NTFS ACL already keeps them to that account. Where chmod exists - every POSIX
+# platform - it still runs exactly as before, and only its absence, or its
+# failure, stops being fatal.
+secure_perms() {
+  local mode=$1
+  shift
+  command -v chmod >/dev/null 2>&1 || return 0
+  chmod "$mode" "$@" 2>/dev/null && return 0
+  printf '%s\n' "Could not set mode $mode on $*; the file was written and its permissions were left to the filesystem." >&2
+  return 0
+}
+
+# >>> native_path (extracted by scripts/test-plugin-package.sh)
+# A path the installer writes into a CLI's own configuration is read back by
+# that CLI, which on Windows is a native program. A MinGit shell hands us the
+# MSYS form (`/c/Users/...`) and Claude Code resolves that literally, so the
+# `@/c/Users/.../OVERCLICK.md` line written into CLAUDE.md pointed at nothing:
+# the plugin looked installed while its instructions silently stopped loading
+# every session (OCL-133). Convert to the native form before writing.
+# `cygpath -m` rather than `-w`: the same drive-letter path with forward
+# slashes, which needs no escaping inside JSON or markdown. MinGit ships no
+# cygpath at all, so the drive prefix is also rewritten by hand - but only on a
+# Windows shell, because `/c/x` on Linux is an ordinary directory that must be
+# left exactly as it is.
+native_path() {
+  local path=$1 converted drive
+  case "$(uname -s 2>/dev/null || printf 'unknown')" in
+    MINGW*|MSYS*|CYGWIN*|Windows_NT) ;;
+    *) printf '%s' "$path"; return 0 ;;
+  esac
+  if command -v cygpath >/dev/null 2>&1; then
+    converted=$(cygpath -m -- "$path" 2>/dev/null) || converted=""
+    if [[ -n "$converted" ]]; then
+      printf '%s' "$converted"
+      return 0
+    fi
+  fi
+  if [[ "$path" =~ ^/([A-Za-z])(/.*)?$ ]]; then
+    drive=$(printf '%s' "${BASH_REMATCH[1]}" | tr '[:lower:]' '[:upper:]')
+    printf '%s:%s' "$drive" "${BASH_REMATCH[2]:-/}"
+    return 0
+  fi
+  printf '%s' "$path"
+}
+# <<< native_path
+
+# `cp -R` onto an existing directory only ever adds. A file the previous release
+# shipped and this one dropped therefore survives every upgrade, so an updated
+# install stopped being a faithful copy of the release - OCL-133 found the 0.2.4
+# shell hooks still sitting beside the 0.2.5 `.mjs` ones. Replace the tree
+# instead of merging into it.
+replace_tree() {
+  local source=$1 target=$2
+  # `cp` onto itself after the `rm -rf` would be an empty install; a caller
+  # pointed at the directory it is copying from just has nothing to do.
+  if [[ -d "$target" && "$source" -ef "$target" ]]; then
+    return 0
+  fi
+  rm -rf -- "$target"
+  mkdir -p "$target"
+  cp -R "$source/." "$target/"
+}
+
 read_private_setting() {
   local key=$1 line
   [[ -f "$private_config" ]] || return 1
@@ -141,6 +209,26 @@ JS
   value=$(printf '%s' "$payload" | sed -n 's/.*"'"$field"'"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -n 1)
   [[ -n "$value" ]] || return 1
   printf '%s' "$value"
+}
+
+read_json_file_string() {
+  local field=$1 file=$2 payload
+  [[ -f "$file" ]] || return 1
+  payload=$(cat "$file") || return 1
+  read_json_string "$field" "$payload"
+}
+
+# The version a plugin directory declares. Every manifest in the package ships
+# the same version (scripts/test-plugin-package.sh guards that), so whichever
+# one a given CLI's layout happens to carry answers for all of them.
+plugin_dir_version() {
+  local dir=$1 manifest
+  for manifest in .claude-plugin/plugin.json plugin.json .codex-plugin/plugin.json; do
+    if read_json_file_string version "$dir/$manifest" 2>/dev/null; then
+      return 0
+    fi
+  done
+  return 1
 }
 
 # Trades a one-time pairing code for the real bearer token. The code is what
@@ -270,8 +358,16 @@ if [[ ! -f "$source_root/plugin/.codex-plugin/plugin.json" || ! -f "$source_root
   exit 1
 fi
 
-mkdir -p "$plugin_target"
-cp -R "$source_root/plugin/." "$plugin_target/"
+replace_tree "$source_root/plugin" "$plugin_target"
+plugin_target_native=$(native_path "$plugin_target")
+
+# The whole point of this installer is that the user ends up running the version
+# it just fetched. Nothing below can assert that without knowing which version
+# that is, so a package that will not say is a stop, not a warning (OCL-133).
+if ! package_version=$(plugin_dir_version "$source_root/plugin"); then
+  printf '%s\n' "The retrieved package declares no version, so the installer cannot confirm which version each CLI ends up running." >&2
+  exit 1
+fi
 
 enforce_stop=$(read_private_setting enforce_stop 2>/dev/null || printf '0')
 enforce_harness=$(read_private_setting enforce_harness 2>/dev/null || printf '0')
@@ -283,7 +379,7 @@ enforce_stop=$enforce_stop
 enforce_harness=$enforce_harness
 enforce_claim=$enforce_claim
 EOF
-chmod 600 "$private_config"
+secure_perms 600 "$private_config"
 
 toml_quote() {
   local value=$1
@@ -332,7 +428,7 @@ write_codex_mcp() {
     printf '%s\n' '# overclick:end'
   } >>"$temporary"
   mv "$temporary" "$file"
-  chmod 600 "$file"
+  secure_perms 600 "$file"
 }
 
 merge_json_config() {
@@ -340,7 +436,7 @@ merge_json_config() {
   mkdir -p "$(dirname -- "$file")"
   if command -v python3 >/dev/null 2>&1 && runtime_works python3; then
     OC_JSON_MODE=$mode OC_JSON_FILE=$file OC_MCP_URL=$mcp_url OC_MCP_TOKEN=$token \
-      OC_HOOK_SOURCE=$source_hooks OC_PLUGIN_TARGET=$plugin_target python3 <<'PY'
+      OC_HOOK_SOURCE=$source_hooks OC_PLUGIN_TARGET=$plugin_target_native python3 <<'PY'
 import json, os, pathlib, tempfile
 
 path = pathlib.Path(os.environ["OC_JSON_FILE"])
@@ -399,7 +495,7 @@ PY
 
   if command -v node >/dev/null 2>&1 && runtime_works node; then
     OC_JSON_MODE=$mode OC_JSON_FILE=$file OC_MCP_URL=$mcp_url OC_MCP_TOKEN=$token \
-      OC_HOOK_SOURCE=$source_hooks OC_PLUGIN_TARGET=$plugin_target node <<'JS'
+      OC_HOOK_SOURCE=$source_hooks OC_PLUGIN_TARGET=$plugin_target_native node <<'JS'
 const fs = require("node:fs");
 const path = require("node:path");
 const file = process.env.OC_JSON_FILE;
@@ -456,10 +552,10 @@ JS
 # exception below: its plugin manifest is the only channel it reads.
 
 native_marketplace="$overclick_root/native-marketplace"
-mkdir -p "$native_marketplace/.claude-plugin" "$native_marketplace/.grok-plugin" "$native_marketplace/plugin"
+mkdir -p "$native_marketplace/.claude-plugin" "$native_marketplace/.grok-plugin"
 cp "$source_root/.claude-plugin/marketplace.json" "$native_marketplace/.claude-plugin/marketplace.json"
 cp "$source_root/.grok-plugin/marketplace.json" "$native_marketplace/.grok-plugin/marketplace.json"
-cp -R "$plugin_target/." "$native_marketplace/plugin/"
+replace_tree "$plugin_target" "$native_marketplace/plugin"
 
 if [[ -n "${OVERCLICK_CLIS:-}" ]]; then
   detected_clis=",${OVERCLICK_CLIS// /},"
@@ -566,21 +662,50 @@ sys.exit(1)
   return 1
 }
 
+# "Successfully installed" is a statement about a command, not about what is on
+# disk. Each CLI caches the package, so a marketplace bumped to a new version
+# while the cached copy stays behind reports success and goes on running the old
+# code - which is how 0.2.5 was "installed" on a machine that kept running
+# 0.2.4, under a final line reading "complete" (OCL-133). Compare the version
+# that MATERIALIZED against the one being installed, and refuse to call that
+# anything but a failure.
+assert_materialized_version() {
+  local label=$1 dir=$2 found
+  if ! found=$(plugin_dir_version "$dir"); then
+    printf '%s\n' "$label materialized at $dir but declares no version, so the installer cannot confirm it is $package_version. Do not trust the earlier \"configured\" messages." >&2
+    return 1
+  fi
+  if [[ "$found" != "$package_version" ]]; then
+    printf '%s\n' "$label is still on $found after installing $package_version: the CLI kept a stale cached copy. Do not trust the earlier \"configured\" messages; run that CLI's own plugin update, or delete the cache at $dir, and install again." >&2
+    return 1
+  fi
+  printf '%s\n' "$label verified: $package_version enabled and materialized at $dir."
+  return 0
+}
+
 validation_failed=0
 
 if has_cli claude; then
-  if claude plugin marketplace add "$native_marketplace" --scope user >/dev/null 2>&1 || \
+  if claude plugin marketplace add "$(native_path "$native_marketplace")" --scope user >/dev/null 2>&1 || \
     claude plugin marketplace update overclick >/dev/null 2>&1; then
     printf '%s\n' "Claude marketplace configured."
   else
     printf '%s\n' "Claude marketplace needs manual confirmation in its native plugin manager." >&2
   fi
+  # `add` on an already-registered marketplace is a no-op that leaves the
+  # previously cached manifest in place, and `install` on an already-installed
+  # plugin is another. Both succeed, so the `||` chains above never reached the
+  # update arms and every re-run left the old version installed: landing 0.2.5
+  # took the two commands below, by hand (OCL-133). Run them unconditionally -
+  # they are the update path, not the fallback.
+  claude plugin marketplace update overclick >/dev/null 2>&1 || true
   if claude plugin install overclick@overclick --scope user >/dev/null 2>&1 || \
     claude plugin update overclick@overclick --scope user >/dev/null 2>&1; then
     printf '%s\n' "Claude plugin configured."
   else
     printf '%s\n' "Claude plugin needs manual confirmation in its native plugin manager." >&2
   fi
+  claude plugin update overclick@overclick --scope user >/dev/null 2>&1 || true
   if foreign_mcp_registration claude mcp get overclick; then
     printf '%s\n' "Claude already has an MCP server named overclick pointing at a different instance; it was left untouched. Remove it with 'claude mcp remove overclick' and re-run this installer to move to this board." >&2
   else
@@ -593,12 +718,12 @@ if has_cli claude; then
     quiet_try "Claude MCP" claude mcp add --transport http --scope user \
       overclick "$mcp_url" --header "Authorization: Bearer $token"
   fi
-  claude_block=$(printf '%s\n' '<!-- overclick:start -->' "@$plugin_target/OVERCLICK.md" '<!-- overclick:end -->')
+  claude_block=$(printf '%s\n' '<!-- overclick:start -->' "@$plugin_target_native/OVERCLICK.md" '<!-- overclick:end -->')
   replace_marked_block "$install_home/.claude/CLAUDE.md" "$claude_block"
 
   claude_install_path=$(verify_claude_plugin) || claude_install_path=""
   if [[ -n "$claude_install_path" && -f "$claude_install_path/OVERCLICK.md" ]]; then
-    printf '%s\n' "Claude plugin verified: enabled and materialized at $claude_install_path."
+    assert_materialized_version "Claude plugin" "$claude_install_path" || validation_failed=1
   else
     printf '%s\n' "Claude plugin did not materialize: 'claude plugin list --json' shows no enabled overclick entry with OVERCLICK.md on disk. Do not trust the earlier \"configured\" messages; retry or install manually." >&2
     validation_failed=1
@@ -613,8 +738,8 @@ if has_cli codex; then
   # copying it next to the manifest makes `codex plugin add` fail with
   # "plugin source path is not a directory".
   codex_plugin="$codex_marketplace/plugins/overclick"
-  mkdir -p "$codex_plugin" "$codex_marketplace/.agents/plugins"
-  cp -R "$plugin_target/." "$codex_plugin/"
+  mkdir -p "$codex_marketplace/.agents/plugins"
+  replace_tree "$plugin_target" "$codex_plugin"
   cat >"$codex_marketplace/.agents/plugins/marketplace.json" <<'JSON'
 {
   "name": "overclick",
@@ -633,13 +758,19 @@ JSON
   # so every plugin call below would fail on a machine where codex is installed
   # but has never been run.
   mkdir -p "$install_home/.codex"
-  quiet_try "Codex marketplace" codex plugin marketplace add "$codex_marketplace"
+  quiet_try "Codex marketplace" codex plugin marketplace add "$(native_path "$codex_marketplace")"
   quiet_try "Codex plugin" codex plugin add overclick@overclick
+  # Same stale-cache trap as Claude: `add` on something already added is a
+  # no-op. Codex may or may not carry these subcommands depending on its
+  # version, so they are attempted rather than required - the version assertion
+  # below is what actually decides whether the install landed (OCL-133).
+  codex plugin marketplace update overclick >/dev/null 2>&1 || true
+  codex plugin update overclick@overclick >/dev/null 2>&1 || true
   write_codex_mcp
 
   codex_install_path=$(verify_codex_plugin) || codex_install_path=""
   if [[ -n "$codex_install_path" && -f "$codex_install_path/OVERCLICK.md" ]]; then
-    printf '%s\n' "Codex plugin verified: enabled and materialized at $codex_install_path."
+    assert_materialized_version "Codex plugin" "$codex_install_path" || validation_failed=1
   else
     printf '%s\n' "Codex plugin did not materialize: 'codex plugin list --json' shows no enabled overclick entry with OVERCLICK.md on disk. Do not trust the earlier \"configured\" messages; retry or install manually." >&2
     validation_failed=1
@@ -650,18 +781,23 @@ JSON
 fi
 
 if has_cli grok; then
-  if grok plugin marketplace add "$native_marketplace" >/dev/null 2>&1 || \
+  if grok plugin marketplace add "$(native_path "$native_marketplace")" >/dev/null 2>&1 || \
     grok plugin marketplace update overclick >/dev/null 2>&1; then
     printf '%s\n' "Grok marketplace configured."
   else
     printf '%s\n' "Grok marketplace needs manual confirmation in its native plugin manager." >&2
   fi
-  if grok plugin install "$plugin_target" --trust >/dev/null 2>&1 || \
+  # As with Claude: the update is the re-run path, not the fallback for a
+  # failed add (OCL-133). Grok has no `plugin list --json`, so there is no
+  # materialization check to back it up here - running it is what there is.
+  grok plugin marketplace update overclick >/dev/null 2>&1 || true
+  if grok plugin install "$plugin_target_native" --trust >/dev/null 2>&1 || \
     grok plugin update overclick >/dev/null 2>&1; then
     printf '%s\n' "Grok plugin configured."
   else
     printf '%s\n' "Grok plugin needs manual confirmation in its native plugin manager." >&2
   fi
+  grok plugin update overclick >/dev/null 2>&1 || true
   if foreign_mcp_registration grok mcp get overclick; then
     printf '%s\n' "Grok already has an MCP server named overclick pointing at a different instance; it was left untouched. Remove it with 'grok mcp remove overclick' and re-run this installer to move to this board." >&2
   else
@@ -686,8 +822,8 @@ kimi_register_plugin() {
   rm -rf "$managed" || return 1
   cp -R "$plugin_target" "$managed" || return 1
 
-  OC_KIMI_INSTALLED="$kimi_home/plugins/installed.json" OC_KIMI_ROOT="$managed" \
-    OC_PLUGIN_TARGET="$plugin_target" python3 <<'KIMIPY'
+  OC_KIMI_INSTALLED="$kimi_home/plugins/installed.json" OC_KIMI_ROOT="$(native_path "$managed")" \
+    OC_PLUGIN_TARGET="$plugin_target_native" python3 <<'KIMIPY'
 import json, os, pathlib, tempfile
 from datetime import datetime, timezone
 
@@ -746,26 +882,24 @@ if has_cli agy; then
   # generic template.
   agy_stage="$overclick_root/antigravity/overclick"
   agy_installed="$install_home/.gemini/config/plugins/overclick"
-  rm -rf -- "$agy_stage"
-  mkdir -p "$agy_stage"
-  cp -R "$plugin_target/." "$agy_stage/"
+  replace_tree "$plugin_target" "$agy_stage"
   merge_json_config mcp-antigravity "$agy_stage/mcp_config.json"
-  chmod 600 "$agy_stage/mcp_config.json"
+  secure_perms 600 "$agy_stage/mcp_config.json"
   agy_rule_block=$(printf '%s\n' '<!-- overclick:start -->' \
-    "Read and follow $agy_installed/OVERCLICK.md for all OverClick board work." \
+    "Read and follow $(native_path "$agy_installed")/OVERCLICK.md for all OverClick board work." \
     '<!-- overclick:end -->')
   replace_marked_block "$agy_stage/rules/AGENTS.md" "$agy_rule_block"
-  quiet_try "Antigravity plugin" "$agy_bin" plugin install "$agy_stage"
+  quiet_try "Antigravity plugin" "$agy_bin" plugin install "$(native_path "$agy_stage")"
   "$agy_bin" plugin enable overclick >/dev/null 2>&1 || true
   # The manager copies the staged directory, so the credentials land in a second
   # place and need the same mode-600 the staged copy already has.
   if [[ -f "$agy_installed/mcp_config.json" ]]; then
-    chmod 600 "$agy_installed/mcp_config.json"
+    secure_perms 600 "$agy_installed/mcp_config.json"
   fi
 
   if "$agy_bin" plugin list 2>/dev/null | grep -q '"overclick"' && \
     [[ -f "$agy_installed/OVERCLICK.md" ]]; then
-    printf '%s\n' "Antigravity plugin verified: imported and materialized at $agy_installed."
+    assert_materialized_version "Antigravity plugin" "$agy_installed" || validation_failed=1
   else
     printf '%s\n' "Antigravity plugin did not materialize: 'agy plugin list' shows no overclick entry with OVERCLICK.md on disk. Retry or install manually." >&2
     validation_failed=1
@@ -774,7 +908,7 @@ fi
 
 if [[ "${OVERCLICK_AGENTS_FALLBACK:-0}" = "1" ]] || \
   { ! has_cli claude && ! has_cli codex && ! has_cli grok && ! has_cli kimi && ! has_cli agy; }; then
-  agents_block=$(printf '%s\n' '<!-- overclick:start -->' "Read and follow $plugin_target/OVERCLICK.md for all OverClick board work." '<!-- overclick:end -->')
+  agents_block=$(printf '%s\n' '<!-- overclick:start -->' "Read and follow $plugin_target_native/OVERCLICK.md for all OverClick board work." '<!-- overclick:end -->')
   replace_marked_block "$project_dir/AGENTS.md" "$agents_block"
   printf '%s\n' "No plugin-capable CLI was detected; the AGENTS.md fallback was installed."
 fi

--- a/scripts/test-plugin-package.sh
+++ b/scripts/test-plugin-package.sh
@@ -92,9 +92,20 @@ file_mode() {
   stat -c '%a' "$1" 2>/dev/null || stat -f '%Lp' "$1"
 }
 
-mkdir -p "$TEST_ROOT/bin" "$TEST_ROOT/home/.codex" "$TEST_ROOT/project" "$TEST_ROOT/claude-cache" "$TEST_ROOT/codex-cache"
-touch "$TEST_ROOT/claude-cache/OVERCLICK.md"
-touch "$TEST_ROOT/codex-cache/OVERCLICK.md"
+mkdir -p "$TEST_ROOT/bin" "$TEST_ROOT/home/.codex" "$TEST_ROOT/project"
+# OCL-133. What a CLI reports as installed is a cache directory it materialized
+# at some point, so the cache is where the installed VERSION can be read - and
+# a cache left behind at the previous version is exactly the failure the
+# installer now has to catch instead of printing "complete". Each fixture cache
+# therefore carries a manifest, and its version is the variable under test.
+stage_cache() {
+  mkdir -p "$1/.claude-plugin"
+  touch "$1/OVERCLICK.md"
+  printf '{"name":"overclick","version":"%s","source":"./plugin"}\n' "$2" \
+    >"$1/.claude-plugin/plugin.json"
+}
+stage_cache "$TEST_ROOT/claude-cache" "$PKG_VERSION"
+stage_cache "$TEST_ROOT/codex-cache" "$PKG_VERSION"
 # OCL-104 gave install.sh a `codex plugin list --json` materialization check to
 # match the Claude one, but this stub only ever answered for claude, so codex
 # verification saw empty output, install.sh exited 1, and this whole suite
@@ -334,16 +345,55 @@ if PATH="$TEST_ROOT/bin:$PATH" \
 fi
 grep -Fq 'did not materialize' "$TEST_ROOT/unverified.err"
 
+# OCL-133. The other half of that lie: the plugin DID materialize, the
+# marketplace was bumped, and the CLI kept serving the cached previous version -
+# and the installer signed it off as verified/complete. The version that
+# materialized is the only thing that settles it.
+grep -Fq "Claude plugin verified: $PKG_VERSION" "$TEST_ROOT/install.out"
+grep -Fq "Codex plugin verified: $PKG_VERSION" "$TEST_ROOT/install.out"
+grep -Fq "Antigravity plugin verified: $PKG_VERSION" "$TEST_ROOT/install.out"
+# Every re-run has to push the CLI's own update through, or an install over an
+# older version leaves the old one installed: `marketplace add` and `plugin
+# install` both succeed as no-ops, so the `||` fallback never fired.
+grep -Fq 'claude:plugin:marketplace' "$TEST_ROOT/native.log"
+test "$(grep -c '^claude:plugin:update$' "$TEST_ROOT/native.log")" -ge 1
+
+mkdir -p "$TEST_ROOT/claude-cache-stale"
+stage_cache "$TEST_ROOT/claude-cache-stale" 0.0.1
+if PATH="$TEST_ROOT/bin:$PATH" \
+  OC_TEST_NATIVE_LOG="$TEST_ROOT/native-stale.log" \
+  OC_TEST_CLAUDE_CACHE="$TEST_ROOT/claude-cache-stale" \
+  OC_TEST_CODEX_CACHE="$TEST_ROOT/codex-cache" \
+  OVERCLICK_INSTALL_HOME="$TEST_ROOT/home-stale" \
+  OVERCLICK_PROJECT_DIR="$TEST_ROOT/project" \
+  OVERCLICK_INSTANCE_URL="$FIXTURE_URL" \
+  OVERCLICK_TOKEN="fixture" \
+  OVERCLICK_CLIS="claude" \
+    "$REPO_ROOT/install.sh" >"$TEST_ROOT/stale.out" 2>"$TEST_ROOT/stale.err"; then
+  echo "installer reported success while the CLI stayed on the previous version" >&2
+  exit 1
+fi
+grep -Fq "is still on 0.0.1 after installing $PKG_VERSION" "$TEST_ROOT/stale.err"
+if grep -Fq 'installation complete' "$TEST_ROOT/stale.out"; then
+  echo "installer printed complete on a stale version" >&2
+  exit 1
+fi
+
 # `curl | bash` never gives install.sh a local checkout to reuse (OCL-103: the
 # github source was never the bug). Exercise that path directly: a bare install.sh copy, no plugin/ next
 # to it, sourcing a local git remote instead of network github.
 mkdir -p "$TEST_ROOT/plugin-remote/plugin/.codex-plugin" \
+  "$TEST_ROOT/plugin-remote/plugin/.claude-plugin" \
   "$TEST_ROOT/plugin-remote/.claude-plugin" "$TEST_ROOT/plugin-remote/.grok-plugin"
 git init -q "$TEST_ROOT/plugin-remote"
 git -C "$TEST_ROOT/plugin-remote" config user.name fixture
 git -C "$TEST_ROOT/plugin-remote" config user.email fixture@invalid
 printf 'package v1\n' >"$TEST_ROOT/plugin-remote/plugin/OVERCLICK.md"
 printf '{}' >"$TEST_ROOT/plugin-remote/plugin/.codex-plugin/plugin.json"
+# The installer refuses a package that will not say which version it is, since
+# nothing downstream could then assert that the version materialized (OCL-133).
+printf '{"name":"overclick","version":"9.9.9"}' \
+  >"$TEST_ROOT/plugin-remote/plugin/.claude-plugin/plugin.json"
 printf '{}' >"$TEST_ROOT/plugin-remote/.claude-plugin/marketplace.json"
 printf '{}' >"$TEST_ROOT/plugin-remote/.grok-plugin/marketplace.json"
 git -C "$TEST_ROOT/plugin-remote" add -A
@@ -352,7 +402,7 @@ git -C "$TEST_ROOT/plugin-remote" commit -q -m v1
 mkdir -p "$TEST_ROOT/isolated-installer" "$TEST_ROOT/clone-cache"
 cp "$REPO_ROOT/install.sh" "$TEST_ROOT/isolated-installer/install.sh"
 chmod +x "$TEST_ROOT/isolated-installer/install.sh"
-touch "$TEST_ROOT/clone-cache/OVERCLICK.md"
+stage_cache "$TEST_ROOT/clone-cache" 9.9.9
 
 run_clone_installer() {
   PATH="$TEST_ROOT/bin:$PATH" \
@@ -736,5 +786,104 @@ OVERCLICK_TOKEN="fixture" \
 OVERCLICK_CLIS="claude" \
   "$REPO_ROOT/install.sh" >"$TEST_ROOT/refresh.out" 2>"$TEST_ROOT/refresh.err"
 grep -Fq "mcp-url:$FIXTURE_URL/mcp" "$TEST_ROOT/refresh-native.log"
+
+# OCL-133 (1). MinGit on Windows is a bash with no coreutils behind it, so
+# `chmod` is not there at all. Under `set -e` that aborted the run at the first
+# mode-bit call - after the credentials had already been written, so the user
+# got a non-zero exit AND a rewritten config. What has to hold is the whole
+# install surviving, not one guarded line, so this is a full run on a PATH where
+# chmod does not exist.
+mkdir -p "$TEST_ROOT/nochmod"
+for utility in bash env sh git grep sed awk tr cat cp rm rmdir mkdir mv ln touch \
+  mktemp dirname basename head tail uname node python3 find sort wc; do
+  target=$(command -v "$utility" 2>/dev/null) && ln -sf "$target" "$TEST_ROOT/nochmod/$utility"
+done
+if PATH="$TEST_ROOT/nochmod" command -v chmod >/dev/null 2>&1; then
+  echo "the no-chmod fixture still resolves chmod" >&2
+  exit 1
+fi
+if ! PATH="$TEST_ROOT/bin:$TEST_ROOT/nochmod" \
+  OC_TEST_NATIVE_LOG="$TEST_ROOT/nochmod-native.log" \
+  OC_TEST_CLAUDE_CACHE="$TEST_ROOT/claude-cache" \
+  OC_TEST_CODEX_CACHE="$TEST_ROOT/codex-cache" \
+  OVERCLICK_INSTALL_HOME="$TEST_ROOT/home-nochmod" \
+  OVERCLICK_PROJECT_DIR="$TEST_ROOT/project" \
+  OVERCLICK_INSTANCE_URL="$FIXTURE_URL" \
+  OVERCLICK_TOKEN="fixture" \
+  OVERCLICK_CLIS="claude,codex,grok,kimi,agy" \
+    "$REPO_ROOT/install.sh" >"$TEST_ROOT/nochmod.out" 2>"$TEST_ROOT/nochmod.err"; then
+  echo "installer aborted on a PATH without chmod" >&2
+  sed -n '1,20p' "$TEST_ROOT/nochmod.err" >&2
+  exit 1
+fi
+if grep -Eq 'chmod.*(not found|No such file)' "$TEST_ROOT/nochmod.err"; then
+  echo "installer still shells out to an absent chmod" >&2
+  exit 1
+fi
+test "$(grep -c '^token=' "$TEST_ROOT/home-nochmod/.config/overclick/config")" -eq 1
+grep -Fq 'installation complete' "$TEST_ROOT/nochmod.out"
+# Skipping the mode bits is a Windows concession, not a relaxation: where chmod
+# exists it still runs, and the earlier POSIX runs above assert mode 600 on the
+# private config and on the Antigravity credentials.
+test "$(file_mode "$TEST_ROOT/home/.config/overclick/config")" -eq 600
+
+# OCL-133 (2). A MinGit shell hands the installer the MSYS form of a path
+# (`/c/Users/...`), and Claude Code on Windows resolves that literally: the
+# `@/c/Users/.../OVERCLICK.md` line it wrote into CLAUDE.md pointed at nothing,
+# so the plugin looked installed while its instructions stopped loading. The
+# converter is extracted and driven directly, because the rewrite only happens
+# under a Windows uname - which is also what keeps `/c/anything` on Linux alone.
+awk '/^# >>> native_path/{f=1} f{print} /^# <<< native_path/{f=0}' \
+  "$REPO_ROOT/install.sh" >"$TEST_ROOT/native_path.sh"
+grep -q '^native_path()' "$TEST_ROOT/native_path.sh"
+mkdir -p "$TEST_ROOT/winbin" "$TEST_ROOT/winbin-cygpath" "$TEST_ROOT/empty-bin"
+cat >"$TEST_ROOT/winbin/uname" <<'SH'
+#!/bin/sh
+printf 'MINGW64_NT-10.0-26100\n'
+SH
+chmod +x "$TEST_ROOT/winbin/uname"
+cp "$TEST_ROOT/winbin/uname" "$TEST_ROOT/winbin-cygpath/uname"
+cat >"$TEST_ROOT/winbin-cygpath/cygpath" <<'SH'
+#!/bin/sh
+printf 'D:/from-cygpath'
+SH
+chmod +x "$TEST_ROOT/winbin-cygpath/cygpath"
+
+native_path_of() {
+  PATH="$1:$PATH" bash -c '. "$1"; native_path "$2"' bash "$TEST_ROOT/native_path.sh" "$2"
+}
+test "$(native_path_of "$TEST_ROOT/winbin" '/c/Users/LASCHUK/.config/overclick/plugin')" \
+  = 'C:/Users/LASCHUK/.config/overclick/plugin'
+test "$(native_path_of "$TEST_ROOT/winbin" '/d/tools')" = 'D:/tools'
+# cygpath, when the shell has it, answers for mount points this script cannot know.
+test "$(native_path_of "$TEST_ROOT/winbin-cygpath" '/c/Users/LASCHUK')" = 'D:/from-cygpath'
+# On a POSIX host `/c/...` is an ordinary directory and nothing may touch it.
+test "$(native_path_of "$TEST_ROOT/empty-bin" '/c/Users/LASCHUK')" = '/c/Users/LASCHUK'
+test "$(native_path_of "$TEST_ROOT/empty-bin" "$TEST_ROOT/home")" = "$TEST_ROOT/home"
+
+# OCL-133 (4). `cp -R` onto an existing directory only ever adds, so a file the
+# previous release shipped and this one dropped survived every upgrade: the
+# 0.2.4 shell hooks were still sitting beside the 0.2.5 `.mjs` ones in both the
+# installed copy and the marketplace one. An installed tree has to be a faithful
+# copy of the release, so anything the release does not have must not survive.
+stale_copies="$TEST_ROOT/home/.config/overclick/plugin
+$TEST_ROOT/home/.config/overclick/native-marketplace/plugin
+$TEST_ROOT/home/.config/overclick/codex-marketplace/plugins/overclick
+$TEST_ROOT/home/.config/overclick/antigravity/overclick"
+printf '%s\n' "$stale_copies" | while IFS= read -r copy; do
+  printf 'stale\n' >"$copy/hooks/session-start.sh"
+done
+run_installer
+printf '%s\n' "$stale_copies" | while IFS= read -r copy; do
+  if [ -e "$copy/hooks/session-start.sh" ]; then
+    echo "$copy kept a file the release does not ship" >&2
+    exit 1
+  fi
+  test -f "$copy/hooks/session-start.mjs" || { echo "$copy lost the release payload" >&2; exit 1; }
+done
+# `while` runs in a subshell, so its exit status is what says the loop passed.
+test "$(printf '%s\n' "$stale_copies" | while IFS= read -r copy; do
+  [ -e "$copy/hooks/session-start.sh" ] && echo bad
+done)" = ""
 
 echo "plugin package checks passed"


### PR DESCRIPTION
Closes the install side of issue #67. The 0.2.5 hook port works on Windows; `install.sh` could not deliver it. MinGit's `usr/bin/sh.exe` is bash 5.3.15, so the script starts and then meets a shell with no coreutils behind it.

## The four fixes

1. **`chmod` absent no longer aborts.** Under `set -e` the first mode-bit call killed the run — *after* the credentials had been written, so the user got a non-zero exit and a rewritten config. `secure_perms` still chmods wherever chmod exists (POSIX security is unchanged; `umask 077` already creates these files at 600) and only stops being fatal when it is missing or fails. On Windows the files land under the user profile, where the NTFS ACL already restricts them.
2. **No more MSYS paths in CLI configs.** `@/c/Users/.../OVERCLICK.md` in `CLAUDE.md` is resolved literally by Claude Code on Windows, so the plugin looked installed while its instructions silently stopped loading. `native_path` converts first — `cygpath -m` when available, `/c/…` → `C:/…` by hand when not (MinGit ships no cygpath), identity off Windows. Applied to every place the installer injects a path into a CLI's configuration: CLAUDE.md, the Antigravity rule, the AGENTS.md fallback, the Kimi registry, the hook commands merged into `hooks.json`, and the directories passed to the plugin managers.
3. **No more "complete" on the old version.** `marketplace add` and `plugin install` succeed as no-ops once registered, so the `||` chains never reached their update arms: the marketplace went to 0.2.5 while the CLI kept serving the 0.2.4 cache, under a final line reading `complete`. `marketplace update` and `plugin update` now run unconditionally for Claude/Grok (attempted for Codex), and verification reads the version that **materialized** on disk and fails loudly with a non-zero exit when it is not the version being installed.
4. **Installed trees are faithful copies.** `cp -R` onto an existing directory only adds, so removed hooks survived upgrades (the six 0.2.4 `.sh` files sat next to the 0.2.5 `.mjs` ones). `replace_tree` replaces instead of merging, for the plugin target, the native marketplace copy, the Codex marketplace copy and the Antigravity stage.

## Verification

`scripts/test-plugin-package.sh` is green on Linux and gained coverage for each defect:

- a full install on a PATH where `chmod` does not resolve — must complete, must not shell out to an absent chmod, and the POSIX runs still assert mode 600;
- the MSYS→native conversion driven under a stubbed Windows `uname`, with and without `cygpath`, plus the POSIX case where `/c/...` must be left alone;
- a cache left at an older version — the install must exit non-zero and must not print `complete`;
- planted files the release does not ship — none may survive the next install.

```
docker run --rm -v "$PWD":/repo -w /repo node:22-bookworm-slim bash -c \
  'apt-get update -qq && apt-get install -y -qq jq python3 git && sh scripts/test-plugin-package.sh'
plugin package checks passed   # exit 0
```

Each new check was run against a mutant of the fix it covers (chmod unguarded, `native_path` disabled, `replace_tree` merging, version assertion off) — all four mutants were caught.

Not merged: for review, targeting v0.2.6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)