### PR TITLE
[OCL-134] claim guard falha fechado: cobre shell em qualquer harness (issue #72)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "overclick",
-      "description": "Claim, execute, and deliver cards on your own self-hosted OverClick board. Ships the workflow skill, the /overclick:* commands, and hooks: a session-start board snapshot and a delivery commit check run by default, while the Edit|Write|Bash claim guard and the stop/harness guards ship disabled. The only network endpoint is the OverClick instance you configure - no third-party calls, no telemetry.",
+      "description": "Claim, execute, and deliver cards on your own self-hosted OverClick board. Ships the workflow skill, the /overclick:* commands, and hooks: a session-start board snapshot and a delivery commit check run by default, while the claim guard and the stop/harness guards ship disabled. The only network endpoint is the OverClick instance you configure - no third-party calls, no telemetry.",
       "version": "0.2.6",
       "source": "./plugin"
     }

--- a/.kimi-plugin/plugin.json
+++ b/.kimi-plugin/plugin.json
@@ -43,7 +43,7 @@
     },
     {
       "event": "PreToolUse",
-      "matcher": "Edit|Write|Bash",
+      "matcher": "*",
       "command": "node \"./plugin/hooks/claim-guard.mjs\"",
       "timeout": 15
     }

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "overclick",
   "version": "0.2.6",
-  "description": "Claim, execute, and deliver cards on your own self-hosted OverClick board. Ships the workflow skill, the /overclick:* commands, and hooks: a session-start board snapshot and a delivery commit check run by default, while the Edit|Write|Bash claim guard and the stop/harness guards ship disabled. The only network endpoint is the OverClick instance you configure - no third-party calls, no telemetry.",
+  "description": "Claim, execute, and deliver cards on your own self-hosted OverClick board. Ships the workflow skill, the /overclick:* commands, and hooks: a session-start board snapshot and a delivery commit check run by default, while the claim guard and the stop/harness guards ship disabled. The only network endpoint is the OverClick instance you configure - no third-party calls, no telemetry.",
   "author": {
     "name": "OverClick"
   },

--- a/plugin/OVERCLICK.md
+++ b/plugin/OVERCLICK.md
@@ -135,12 +135,48 @@ enforce_claim=1
 The stop guard blocks exit while this token owns an executing card. The
 pre-create guard blocks a card whose harness does not match the board's live
 recommendation. The claim guard lets reads and investigation pass, but requires
-an active claim before `Edit`, `Write`, or a mutating `Bash` command. A successful
+an active claim before any mutation. A successful
 `task_claim` writes the card ID and claim time to `.overclick/claim.json` for a
 fast local check; `task_deliver` and `task_release` remove it. When that marker is
 missing, a pending mutation checks the board before it blocks with
 `claima um card no board antes: task_claim {id}`. Neither opt-in changes the card
 contract or grants permission to deploy.
+
+### What the claim guard actually covers
+
+Until 0.2.6 the guard was matched on the tool names `Edit|Write|Bash` and
+decided from that name. On Windows the shell tool is called `PowerShell`, so it
+matched nothing: `mkdir`, `git commit` and `[System.IO.File]::WriteAllText`
+all ran with the guard turned on and no claim behind them (issue #72). Since
+0.2.7 the guard is matched on **every** tool and fails closed:
+
+- **Editor tools** (`Edit`, `Write`, `NotebookEdit`, and equivalents) require a
+  claim, decided on the tool name — exact, nothing to interpret.
+- **Any tool carrying a shell command** — `Bash`, `PowerShell`, `pwsh`, a shell
+  exposed by an MCP server, a name that does not exist yet — requires a claim
+  unless the command is *provably read-only*: every segment starts with a verb
+  on the read allowlist (`ls`, `cat`, `grep`, `git status|log|diff|show`,
+  `Get-*`, `Test-Path`, `Select-String`, `dir`, `type`, …), with no redirection
+  to a file, no command substitution, and no .NET call. Anything else — an
+  unknown verb, an unknown dialect, a command the guard cannot even read — is
+  treated as a mutation. This is why `[System.IO.File]::WriteAllText`, which no
+  write-shaped regex would recognise, is blocked: it is not on the read
+  allowlist.
+- **Any tool carrying a file body** (a `content`/`path` pair, a patch, a diff)
+  requires a claim, whatever it is called.
+- **Board tools** (`task_*`, `mission_*`, `project_*`, …) always pass: claiming
+  a card is how the guard is meant to be satisfied.
+
+The known limit: a tool with no shell command and no file body — an arbitrary
+MCP call that mutates something through its own API — is not gated. Gating it
+would mean blocking every MCP read in the session, including the board itself.
+The guard covers the working tree, not every side effect a tool can have.
+
+The cost of matching every tool is one short-lived `node` process per tool call
+while `enforce_claim=1`. With the flag off — how the plugin ships — the guard
+exits on the config read without inspecting anything. That trade was taken
+deliberately: a matcher that lists shell names by hand cannot fail closed,
+because the hole it left was a shell name nobody had listed.
 
 Codex does not have a supported client-side equivalent for the claim guard, so
 the installer does not add this rule to Codex. Its coverage remains server-side:

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -72,9 +72,15 @@ marker after `task_claim` / `task_deliver` / `task_release`.
 
 The **enforcement** guards are opt-in and ship disabled (`enforce_claim=0`,
 `enforce_stop=0`, `enforce_harness=0` in the config file). `claim-guard.mjs` is the one
-matched on `Edit|Write|Bash`: with `enforce_claim=0` it exits silently without inspecting
+matched on every tool: with `enforce_claim=0` it exits silently without inspecting
 anything, and only when you deliberately turn it on does it block a write that has no
 claimed card behind it. Turning it on is a choice you make about your own workflow.
+
+It is matched on every tool rather than on `Edit|Write|Bash` because a hand-written list
+of shell names cannot fail closed — on Windows the shell tool is called `PowerShell` and
+the old list missed it entirely (issue #72). With enforcement on, a command runs unclaimed
+only when it is provably read-only; anything else, in any dialect, under any tool name,
+waits for a claim. See `OVERCLICK.md` for the exact rule and its known limit.
 
 No hook downloads or executes remote content. They are plain Node scripts, readable in
 `hooks/`, run as `node "<plugin root>/hooks/x.mjs"`, and they depend on nothing but Node

--- a/plugin/hooks/antigravity.sh
+++ b/plugin/hooks/antigravity.sh
@@ -214,7 +214,17 @@ case "$event" in
           printf '{"decision":"ask","reason":"%s"}\n' "$(oc_agy_escape "$complaint")"
         fi
         ;;
-      Bash|Edit|Write)
+      task_claim|mcp__*__task_claim|task_release|mcp__*__task_release)
+        # The marker is written by post-tool, once the board has answered. A
+        # pre-tool run would record a claim that may never happen.
+        oc_agy_allow
+        ;;
+      *)
+        # OCL-134. This used to be `Bash|Edit|Write)` with everything else
+        # allowed, which is the same fail-open hole issue #72 hit on Windows:
+        # a shell under any other name, or an MCP tool forwarded by
+        # call_mcp_tool, was waved through. claim-guard.mjs now sees every tool
+        # and decides; with enforce_claim=0 it returns silently.
         verdict=$(printf '%s' "$normalized" | node "$SCRIPT_DIR/claim-guard.mjs" 2>/dev/null || true)
         case "$verdict" in
           *'"decision":"block"'*)
@@ -223,7 +233,6 @@ case "$event" in
           *) oc_agy_allow ;;
         esac
         ;;
-      *) oc_agy_allow ;;
     esac
     ;;
 

--- a/plugin/hooks/claim-guard.mjs
+++ b/plugin/hooks/claim-guard.mjs
@@ -1,9 +1,10 @@
 import {
-  bashWrites,
   block,
   claimMarker,
   claimMarkerValid,
   clearClaimMarker,
+  commandReadOnly,
+  commandWrites,
   countTasks,
   enabled,
   hookCommand,
@@ -14,11 +15,31 @@ import {
   parseJson,
   readStdin,
   writeClaimMarker,
+  writeShapedInput,
   failOpen,
 } from "./common.mjs";
 
 const CLAIM = /^(mcp__.*__)?task_claim$/;
 const RELEASE = /^(mcp__.*__)?(task_deliver|task_release)$/;
+
+// Reading and writing the board is how an agent GETS a claim, so gating it
+// would deadlock the workflow the guard exists to enforce. These tools never
+// touch the working tree.
+const BOARD_TOOL =
+  /^(mcp__.*__)?(task_|mission_|project_|harness_|insights_|executors_|branch_register|context_ops|objective_ops)/;
+
+// Editors: gated on the TOOL, which is exact — no command text to interpret.
+const WRITE_TOOL =
+  /^(edit|multiedit|write|notebookedit|str_replace_editor|apply_patch|create_file|update_file|write_file|delete_file|move_file)$/i;
+
+// Investigation tools, allowed by name so the common path costs nothing.
+const READ_TOOL =
+  /^(read|view|glob|grep|ls|notebookread|todowrite|todoread|task|agent|webfetch|websearch|exitplanmode)$/i;
+
+// A shell by any name. Used only as a floor: if a tool that looks like a shell
+// arrives with no command the guard can read, it is not proven read-only.
+const SHELL_TOOL =
+  /(^|[_.-])(bash|sh|zsh|fish|shell|powershell|pwsh|cmd|terminal|console|command|run_command|execute_command|exec_command|run_shell|local_shell|process|exec|run)([_.-]|$)/i;
 
 failOpen(async () => {
   const hookInput = parseJson(readStdin()) ?? {};
@@ -39,19 +60,11 @@ failOpen(async () => {
 
   if (!enabled("enforce_claim")) return;
 
-  switch (toolName) {
-    case "Edit":
-    case "Write":
-    case "edit":
-    case "write":
-      break;
-    case "Bash":
-    case "bash":
-      if (!bashWrites(hookCommand(hookInput))) return;
-      break;
-    default:
-      return;
-  }
+  // OCL-134 / issue #72. The old switch ended in `default: return`, so a shell
+  // tool that was not literally called `Bash` — `PowerShell` on Windows — was
+  // waved through and mutated the repo with no claim. The default is inverted
+  // here: only what is PROVEN not to mutate returns early.
+  if (!mutationSuspected(hookInput, toolName)) return;
 
   if (claimMarkerValid(cwd, hookSession(hookInput))) return;
 
@@ -65,3 +78,23 @@ failOpen(async () => {
 
   block("claima um card no board antes: task_claim {id}");
 });
+
+function mutationSuspected(hookInput, toolName) {
+  if (BOARD_TOOL.test(toolName)) return false;
+  if (WRITE_TOOL.test(toolName)) return true;
+
+  // Whatever the tool is called, a command is judged on its own merits: proven
+  // read-only passes, everything else — unknown verb, unknown dialect,
+  // [System.IO.File]::WriteAllText — is a mutation.
+  const command = hookCommand(hookInput);
+  if (command) return commandWrites(command) || !commandReadOnly(command);
+
+  if (SHELL_TOOL.test(toolName)) return true;
+  if (READ_TOOL.test(toolName)) return false;
+  if (writeShapedInput(hookInput)) return true;
+
+  // The documented limit of the fail-closed rule: a tool with neither a command
+  // nor a file body is not evidence of a mutation, and gating every MCP call
+  // would block the board itself. See plugin/OVERCLICK.md.
+  return false;
+}

--- a/plugin/hooks/common.mjs
+++ b/plugin/hooks/common.mjs
@@ -152,8 +152,28 @@ export function hookSession(hookInput) {
   return hookInput?.session_id ?? hookInput?.sessionId ?? "";
 }
 
+// Every key a harness has been seen carrying a shell command under. A shell
+// tool whose command hides under some other key reads as empty here, and an
+// empty command is not proven read-only — so it blocks (OCL-134).
 export function hookCommand(hookInput) {
-  return hookInput?.tool_input?.command ?? hookInput?.tool_input?.cmd ?? "";
+  const input = hookInput?.tool_input ?? {};
+  for (const key of ["command", "cmd", "commandLine", "command_line", "script", "shell_command", "powershell"]) {
+    const value = input[key];
+    if (typeof value === "string" && value.trim()) return value;
+    if (Array.isArray(value) && value.every((part) => typeof part === "string")) return value.join(" ");
+  }
+  return "";
+}
+
+// A tool nobody knows, carrying a file body: a write however it is named.
+export function writeShapedInput(hookInput) {
+  const input = hookInput?.tool_input ?? {};
+  if (!input || typeof input !== "object") return false;
+  const keys = Object.keys(input);
+  if (keys.some((key) => /^(patch|diff|edits|new_string|new_str|new_source|replacement)$/i.test(key))) return true;
+  const hasBody = keys.some((key) => /^(content|contents|text|data|body|value)$/i.test(key));
+  const hasTarget = keys.some((key) => /^(path|file_path|filePath|file|filename|target|destination)$/i.test(key));
+  return hasBody && hasTarget;
 }
 
 // The marker the claim guard trusts later. Null whenever the claim did not
@@ -240,24 +260,169 @@ export function claimMarkerValid(root, expectedSession) {
   return markerValid(parseJson(raw), expectedSession);
 }
 
-// Ports the two shell greps verbatim: first any redirection that is not an
-// output-only discard, then the write-shaped command vocabulary.
-const REDIRECTION = /(^|[^<])>{1,2}\s*[^&]/;
+// ---------------------------------------------------------------------------
+// Shell command classification (OCL-134).
+//
+// The old rule asked "does this command LOOK like a write?" and let everything
+// else run. That fails OPEN for every dialect the regex does not speak: on
+// Windows the shell tool is called `PowerShell`, and
+// `[System.IO.File]::WriteAllText(...)` does not look like a write to a POSIX
+// regex — the reporter of issue #72 rewrote their own config that way with the
+// guard turned on. A guard that silently stops blocking is worse than no guard,
+// so the question is inverted: a command runs unclaimed only when it is
+// PROVABLY read-only. Unknown verb, unknown dialect, unreadable input — all
+// mutations as far as the guard is concerned.
+
+// Separators are honoured outside quotes only, so `grep 'a|b' file` stays one
+// segment instead of splitting into a bogus `b' file` command.
+function shellSegments(command) {
+  const segments = [];
+  let current = "";
+  let quote = "";
+  for (const character of command) {
+    if (quote) {
+      current += character;
+      if (character === quote) quote = "";
+      continue;
+    }
+    if (character === '"' || character === "'") {
+      quote = character;
+      current += character;
+      continue;
+    }
+    if (character === ";" || character === "|" || character === "&" || character === "\n" || character === "\r") {
+      segments.push(current);
+      current = "";
+      continue;
+    }
+    current += character;
+  }
+  segments.push(current);
+  return segments.map((segment) => segment.trim()).filter(Boolean);
+}
+
+// Anything that can smuggle a second command past the verb allowlist. Checked
+// against the raw command, quotes included: a read-only `grep '>'` blocked by
+// this is a false alarm the operator can fix with a claim, while the reverse
+// mistake is the bug this card exists to close.
+const EVALUATION_TRAPS = [
+  /\$\(/, // POSIX command substitution
+  /`/, // POSIX backtick substitution
+  /<\(/, // process substitution
+  /\$\{[^}]*[;|&]/, // parameter expansion hiding a command
+  /\[\s*(System|IO|Microsoft)\./i, // .NET type literal: [System.IO.File]::...
+  /::\s*[A-Za-z_]\w*\s*\(/, // any .NET static call
+  /(^|[\s;|&(])(eval|exec|source|iex|Invoke-Expression|Invoke-Command|Start-Process|Start-Job|xargs|env|sudo|doas|nohup|setsid|Set-Alias|New-Alias)([\s;|&)]|$)/i,
+];
+
+// Verbs that cannot mutate anything on their own. A head not listed here is not
+// "probably fine" — it is unproven, which now means blocked.
+const READ_ONLY_HEADS = new Set([
+  // POSIX / GNU
+  "ls", "ll", "cat", "bat", "head", "tail", "less", "more", "echo", "printf",
+  "pwd", "cd", "wc", "grep", "egrep", "fgrep", "rg", "ack", "file", "stat",
+  "du", "df", "tree", "which", "whereis", "whoami", "id", "hostname", "uname",
+  "date", "printenv", "basename", "dirname", "realpath", "readlink", "sort",
+  "uniq", "cut", "tr", "diff", "comm", "cmp", "column", "fold", "nl", "od",
+  "xxd", "strings", "md5sum", "sha1sum", "sha256sum", "shasum", "jq", "yq",
+  "true", "false", "test", "sleep", "man", "help", "history", "ps", "top",
+  // Windows cmd
+  "dir", "type", "where", "findstr", "ver", "systeminfo", "tasklist",
+]);
+
+// PowerShell verbs are open-ended, so the allowlist is the cmdlet name itself.
+// Get-* is safe as a family; ForEach-Object and Where-Object are NOT, because a
+// script block carries arbitrary code the allowlist never sees.
+const READ_ONLY_CMDLETS =
+  /^(Get-[A-Za-z]+|Test-Path|Test-Connection|Resolve-Path|Split-Path|Join-Path|Select-String|Select-Object|Sort-Object|Group-Object|Measure-Object|Compare-Object|Format-(List|Table|Wide|Custom)|Out-(String|Host|GridView)|Write-(Host|Output)|ConvertTo-(Json|Csv|Xml)|ConvertFrom-(Json|Csv|Xml|StringData)|Show-Command)$/i;
+
+// Subcommand-shaped tools: the head alone proves nothing.
+const READ_ONLY_SUBCOMMANDS = {
+  git: new Set([
+    "status", "log", "diff", "show", "blame", "describe", "shortlog",
+    "rev-parse", "rev-list", "ls-files", "ls-tree", "ls-remote", "cat-file",
+    "name-rev", "symbolic-ref", "whatchanged", "grep", "count-objects",
+  ]),
+  gh: new Set(["pr", "issue", "repo", "run", "api"]),
+};
+
+// Read-only heads that stop being read-only with the wrong flag.
+const HEAD_ARGUMENT_TRAPS = {
+  find: /(^|\s)-(delete|exec|execdir|ok|okdir|fls|fprint|fprintf|fprint0)\b/,
+  sed: /(^|\s)-\S*i|(^|\s)w\s|\bw\s+\S/,
+  grep: /(^|\s)-\S*[of]\s|--output/,
+  rg: /(^|\s)--files-with-matches\s*>|(^|\s)-r\b|--replace/,
+  gh: /(^|\s)(create|edit|delete|close|merge|comment|clone|sync|rerun|cancel)\b|-X\s*(POST|PUT|PATCH|DELETE)/i,
+};
+
+function segmentHead(segment) {
+  const head = segment.split(/\s+/)[0] ?? "";
+  // `FOO=bar cmd`, `(cmd`, `$cmd`, `./script` — none of them prove anything.
+  if (!head || /[=$(){}]/.test(head)) return "";
+  return head.replace(/^\.\//, "");
+}
+
+function segmentReadOnly(segment) {
+  const head = segmentHead(segment);
+  if (!head) return false;
+
+  const trap = HEAD_ARGUMENT_TRAPS[head];
+  if (trap && trap.test(segment)) return false;
+
+  const subcommands = READ_ONLY_SUBCOMMANDS[head];
+  if (subcommands) {
+    const argument = segment.split(/\s+/)[1] ?? "";
+    // `git -C other-repo commit` hides the subcommand behind a flag.
+    return subcommands.has(argument);
+  }
+
+  if (READ_ONLY_HEADS.has(head)) return true;
+  if (READ_ONLY_HEADS.has(head.toLowerCase())) return true;
+  return READ_ONLY_CMDLETS.test(head);
+}
+
+// Output-only discards are not writes: `2>/dev/null`, `>/dev/null`, `2>&1`.
+function withoutDiscards(command) {
+  return command
+    .replace(/[0-9]*>>?\s*(\/dev\/null|\$null|NUL)\b/gi, "")
+    .replace(/[0-9]*>&[0-9]+/g, "");
+}
+
+const REDIRECTION = /(^|[^<>0-9])>{1,2}\s*[^&\s]/;
+
+// The whole point of the card: proof, not vibes. Everything that is not proven
+// read-only is treated as a mutation by the callers of this function.
+export function commandReadOnly(command) {
+  if (typeof command !== "string" || !command.trim()) return false;
+  if (EVALUATION_TRAPS.some((trap) => trap.test(command))) return false;
+  const stripped = withoutDiscards(command);
+  if (REDIRECTION.test(stripped)) return false;
+  const segments = shellSegments(stripped);
+  if (!segments.length) return false;
+  return segments.every(segmentReadOnly);
+}
+
+// Kept as a second, independent opinion. commandReadOnly already blocks
+// everything below, but an accidental widening of the read allowlist would
+// still have to get past this list to relax POSIX enforcement, which OCL-134
+// explicitly forbids. It also speaks the PowerShell dialect now.
 const WRITE_COMMANDS = new RegExp(
   "(^|[;&|()\\s])(apply_patch|touch|mkdir|rmdir|rm|mv|cp|install|ln|chmod|chown|truncate|dd|tee)([;&|()\\s]|$)" +
     "|(^|[;&|()\\s])(sed\\s+(-[^\\s]*)?i|perl\\s+-[^\\s]*i)" +
     "|(^|[;&|()\\s])git\\s+(add|am|apply|branch|checkout|cherry-pick|clean|commit|merge|mv|rebase|reset|restore|revert|rm|stash|switch|tag|worktree)([;&|()\\s]|$)" +
     "|(^|[;&|()\\s])(npm|pnpm|yarn|bun)\\s+(add|install|remove|uninstall|update|upgrade|link|unlink|publish)([;&|()\\s]|$)" +
-    "|(^|[;&|()\\s])(bash|sh|zsh|python3?|node)\\s+[^;&|]*([.]sh|-[cm])[;&|\\s]*",
+    "|(^|[;&|()\\s])(bash|sh|zsh|python3?|node)\\s+[^;&|]*([.]sh|-[cm])[;&|\\s]*" +
+    // PowerShell cmdlets, cmd.exe verbs, and .NET file APIs (issue #72).
+    "|(^|[;&|()\\s])(Set-Content|Add-Content|Out-File|New-Item|Remove-Item|Move-Item|Copy-Item|Rename-Item|Clear-Content|Set-ItemProperty|New-ItemProperty|Remove-ItemProperty|Set-Acl|Export-Csv|Export-Clixml|Tee-Object|Start-Process|Invoke-Expression|New-Object|del|erase|ren|rename|move|copy|xcopy|robocopy|attrib|icacls|fsutil)([;&|()\\s]|$)" +
+    "|\\[\\s*(System\\.)?(IO\\.)?(File|Directory|FileInfo|DirectoryInfo|StreamWriter)\\s*\\]\\s*::" +
+    "|::\\s*(Write|Create|Delete|Move|Copy|Append|Replace|SetAttributes)[A-Za-z]*\\s*\\(",
   "i",
 );
 
-export function bashWrites(command) {
+export function commandWrites(command) {
   if (!command) return false;
-  const withoutDiscards = command
-    .replace(/[0-9]*>>?\s*\/dev\/null/g, "")
-    .replace(/[0-9]*>&[0-9]+/g, "");
-  if (REDIRECTION.test(withoutDiscards)) return true;
+  const stripped = withoutDiscards(command);
+  if (REDIRECTION.test(stripped)) return true;
   return WRITE_COMMANDS.test(command);
 }
 

--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -64,7 +64,7 @@
         ]
       },
       {
-        "matcher": "Edit|Write|Bash",
+        "matcher": "*",
         "hooks": [
           {
             "type": "command",

--- a/plugin/kimi.plugin.json
+++ b/plugin/kimi.plugin.json
@@ -47,7 +47,7 @@
     },
     {
       "event": "PreToolUse",
-      "matcher": "Edit|Write|Bash",
+      "matcher": "*",
       "command": "node \"./hooks/claim-guard.mjs\"",
       "timeout": 15
     }

--- a/scripts/test-plugin-package.sh
+++ b/scripts/test-plugin-package.sh
@@ -66,6 +66,15 @@ jq -e '.hooks | keys | sort == ["PostToolUse", "PreToolUse", "SessionStart", "St
   "$REPO_ROOT/plugin/hooks/hooks.json" >/dev/null
 jq -e '(.hooks.PostToolUse | length == 2) and (.hooks.PreToolUse | length == 2)' \
   "$REPO_ROOT/plugin/hooks/hooks.json" >/dev/null
+# OCL-134. A name list (Edit|Write|Bash) cannot fail closed: the hole it left on
+# Windows was PowerShell, and the next hole is whatever the next harness calls
+# its shell. The claim guard is matched on every tool and decides inside.
+jq -e '.hooks.PreToolUse | map(select(.hooks[].command | contains("claim-guard.mjs")))
+  | length == 1 and all(.matcher == "*")' "$REPO_ROOT/plugin/hooks/hooks.json" >/dev/null
+for manifest in "$REPO_ROOT/plugin/kimi.plugin.json" "$REPO_ROOT/.kimi-plugin/plugin.json"; do
+  jq -e '.hooks | map(select(.event == "PreToolUse" and (.command | contains("claim-guard.mjs"))))
+    | length == 1 and all(.matcher == "*")' "$manifest" >/dev/null
+done
 # OCL-132. Claude Code on Windows without Git Bash runs hook commands through
 # PowerShell, which cannot even parse `"${CLAUDE_PLUGIN_ROOT}"/hooks/x.sh` (the
 # bare slash after the closing quote reads as a division operator) and has no
@@ -669,6 +678,91 @@ printf '%s' "$blocked_bash" | grep -Fq 'claima um card no board antes: task_clai
 commit_bash_input=$(jq -nc --arg cwd "$TEST_ROOT/project" '{cwd:$cwd,session_id:"session-fixture",tool_name:"Bash",tool_input:{command:"git commit -m fixture >/dev/null 2>&1"}}')
 blocked_commit=$(printf '%s' "$commit_bash_input" | PATH="$HOOK_PATH" OVERCLICK_CONFIG_FILE="$HOOK_CONFIG" node "$REPO_ROOT/plugin/hooks/claim-guard.mjs")
 printf '%s' "$blocked_commit" | grep -Fq 'claima um card no board antes: task_claim {id}'
+
+# OCL-134. The guard used to key on the tool NAME (Edit|Write|Bash) and let
+# everything else through, so on Windows — where the shell tool is called
+# `PowerShell` — mkdir, git commit and [System.IO.File]::WriteAllText all ran
+# with no claim at all. The decision is now fail-closed: a command runs
+# unclaimed only when it is PROVABLY read-only, whatever the tool is called.
+guard_shell() {
+  jq -nc --arg cwd "$TEST_ROOT/project" --arg tool "$1" --arg command "$2" \
+    '{cwd:$cwd,session_id:"session-fixture",tool_name:$tool,tool_input:{command:$command}}' |
+    PATH="$HOOK_PATH" OVERCLICK_CONFIG_FILE="$HOOK_CONFIG" node "$REPO_ROOT/plugin/hooks/claim-guard.mjs"
+}
+guard_blocks() {
+  if ! guard_shell "$1" "$2" | grep -Fq 'claima um card no board antes: task_claim {id}'; then
+    echo "claim guard failed OPEN for $1: $2" >&2
+    exit 1
+  fi
+}
+guard_passes() {
+  if [ -n "$(guard_shell "$1" "$2")" ]; then
+    echo "claim guard blocked a read-only command for $1: $2" >&2
+    exit 1
+  fi
+}
+
+# The Windows report itself (issue #72): the PowerShell tool mutating unclaimed.
+guard_blocks PowerShell 'New-Item -ItemType Directory -Path fixture-dir'
+guard_blocks PowerShell 'git commit -m fixture'
+guard_blocks PowerShell 'Set-Content -Path changed.txt -Value fixture'
+guard_blocks PowerShell 'Remove-Item -Recurse -Force fixture-dir'
+guard_blocks PowerShell 'Get-Content a.txt | Out-File b.txt'
+# The case a write-shaped regex can never catch, and the reason the default had
+# to be inverted: a .NET static call does not look like a write at all.
+guard_blocks PowerShell '[System.IO.File]::WriteAllText("changed.txt", "fixture")'
+guard_blocks pwsh 'Move-Item a.txt b.txt'
+# A shell tool nobody has named yet, mutating: blocked because it is not proven
+# read-only, not because its name was on a list.
+guard_blocks mcp__acme__run_shell 'rm -rf fixture-dir'
+guard_blocks Terminal 'mkdir fixture-dir'
+# A shell tool whose command the guard cannot read is not proven read-only.
+shellless_input=$(jq -nc --arg cwd "$TEST_ROOT/project" '{cwd:$cwd,session_id:"session-fixture",tool_name:"PowerShell",tool_input:{}}')
+printf '%s' "$shellless_input" | PATH="$HOOK_PATH" OVERCLICK_CONFIG_FILE="$HOOK_CONFIG" node "$REPO_ROOT/plugin/hooks/claim-guard.mjs" |
+  grep -Fq 'claima um card no board antes: task_claim {id}'
+# Investigation still passes, in every dialect — a guard that blocks reads is a
+# guard the operator turns off.
+guard_passes PowerShell 'Get-ChildItem -Recurse'
+guard_passes PowerShell 'Test-Path changed.txt'
+guard_passes PowerShell 'Select-String -Pattern fixture -Path changed.txt'
+guard_passes mcp__acme__run_shell 'ls -la'
+guard_passes Bash 'cat changed.txt'
+guard_passes Bash 'git log --oneline -n 5'
+guard_passes Bash "grep -n 'a|b' changed.txt"
+# POSIX enforcement does not get relaxed on the way (no regression).
+guard_blocks Bash 'rm -rf fixture-dir'
+guard_blocks Bash 'echo fixture | tee changed.txt'
+guard_blocks Bash 'sed -i.bak s/a/b/ changed.txt'
+guard_blocks Bash 'npm install left-pad'
+# The matcher is now "*", so the guard sees every tool call: the read tools and
+# the board tools it does not gate must stay silent, or the session dies.
+for quiet_tool in Read Grep Glob TodoWrite WebFetch mcp__overclick__task_list mcp__acme__list_widgets; do
+  quiet_input=$(jq -nc --arg cwd "$TEST_ROOT/project" --arg tool "$quiet_tool" '{cwd:$cwd,session_id:"session-fixture",tool_name:$tool,tool_input:{file_path:"changed.txt"}}')
+  if [ -n "$(printf '%s' "$quiet_input" | PATH="$HOOK_PATH" OVERCLICK_CONFIG_FILE="$HOOK_CONFIG" node "$REPO_ROOT/plugin/hooks/claim-guard.mjs")" ]; then
+    echo "claim guard blocked the non-mutating tool $quiet_tool" >&2
+    exit 1
+  fi
+done
+# A tool nobody knows carrying a file body is a write, whatever it is called.
+unknown_write_input=$(jq -nc --arg cwd "$TEST_ROOT/project" '{cwd:$cwd,session_id:"session-fixture",tool_name:"mcp__acme__put_file",tool_input:{path:"changed.txt",content:"fixture"}}')
+printf '%s' "$unknown_write_input" | PATH="$HOOK_PATH" OVERCLICK_CONFIG_FILE="$HOOK_CONFIG" node "$REPO_ROOT/plugin/hooks/claim-guard.mjs" |
+  grep -Fq 'claima um card no board antes: task_claim {id}'
+
+# The Antigravity adapter routed pre-tool on the same name list (Bash|Edit|Write)
+# and allowed everything else, so a shell forwarded through call_mcp_tool never
+# reached the guard at all. It now routes every tool through claim-guard.mjs.
+agy_guard() {
+  (cd "$agy_plugin" && printf '%s' "$1" |
+    OVERCLICK_CONFIG_FILE="$HOOK_CONFIG" sh ./hooks/antigravity.sh pre-tool)
+}
+agy_guard '{"toolCall":{"name":"run_command","args":{"CommandLine":"rm -rf fixture-dir"}}}' |
+  grep -Fq '"decision":"deny"'
+agy_guard '{"toolCall":{"name":"write_to_file","args":{"TargetFile":"changed.txt"}}}' |
+  grep -Fq '"decision":"deny"'
+agy_guard '{"toolCall":{"name":"call_mcp_tool","args":{"ToolName":"acme__run_shell","Arguments":{"command":"New-Item -ItemType Directory -Path fixture-dir"}}}}' |
+  grep -Fq '"decision":"deny"'
+agy_guard '{"toolCall":{"name":"run_command","args":{"CommandLine":"git status --short"}}}' |
+  grep -Fq '"decision":"allow"'
 
 failed_claim_input=$(jq -nc --arg cwd "$TEST_ROOT/project" '{cwd:$cwd,session_id:"session-fixture",tool_name:"task_claim",tool_input:{task_id:"T-1"},tool_response:{isError:true,content:[{type:"text",text:"claim failed"}]}}')
 printf '%s' "$failed_claim_input" | PATH="$HOOK_PATH" OVERCLICK_CONFIG_FILE="$HOOK_CONFIG" node "$REPO_ROOT/plugin/hooks/claim-guard.mjs"


### PR DESCRIPTION
Fecha a issue #72. **Não mergear sem review — é segurança.** Vai numa v0.2.7.

## O bug

Com `enforce_claim=1` e sem claim, o guard bloqueava `Edit`/`Write` mas deixava passar mutação por shell quando o tool não se chamava `Bash`. No Windows ele se chama `PowerShell`: `mkdir`, `git commit` e `[System.IO.File]::WriteAllText` rodaram sem claim — o reporter reescreveu o próprio config assim, com a flag ligada. Três furos em série: o matcher `Edit|Write|Bash` não casava, o `switch` terminava em `default: return`, e a heurística de escrita só falava POSIX.

## O fix — falhar fechado

O default foi invertido. O guard é matcheado em **todo tool** e decide dentro do `claim-guard.mjs`:

- **Tool editor** (`Edit`/`Write`/`NotebookEdit`/…) → exige claim, pelo nome do tool (exato).
- **Qualquer tool carregando comando de shell** (`Bash`, `PowerShell`, `pwsh`, shell de MCP, nome que ainda não existe) → exige claim **a menos que o comando seja provadamente read-only**: todo segmento começa com verbo da allowlist de leitura (`ls`, `cat`, `grep`, `git status|log|diff|show`, `Get-*`, `Test-Path`, `Select-String`, `dir`, `type`…), sem redirecionamento pra arquivo, sem substituição de comando, sem chamada .NET.
- **Qualquer tool carregando corpo de arquivo** (`content`+`path`, patch, diff) → exige claim.
- **Tools do board** (`task_*`, `mission_*`, …) → sempre passam; claimar é como se satisfaz o guard.

É a inversão que pega `[System.IO.File]::WriteAllText`: nenhuma regex de "parece escrita" reconheceria aquilo — ele simplesmente não está na allowlist de leitura.

### Matcher: `*` em vez de lista explícita

Escolha deliberada. Uma lista escrita à mão (`Bash|PowerShell|pwsh|Shell|run_command|…`) **não consegue falhar fechado**: o furo que existiu foi exatamente um nome de shell que ninguém tinha listado, e o próximo furo é como o próximo harness chamar o shell dele. Custo: um processo `node` por tool call **enquanto `enforce_claim=1`** — com a flag desligada (como o plugin é entregue) o guard sai na leitura do config, sem inspecionar nada. Trade documentado no `OVERCLICK.md` e no `claim-guard.mjs`.

O adapter do Antigravity tinha a mesma lista (`Bash|Edit|Write)` + `*) allow`), então um shell encaminhado via `call_mcp_tool` nem chegava ao guard. Fechado também.

## Sem regressão no POSIX

`commandWrites()` foi mantida como segunda opinião independente (e agora fala PowerShell/.NET), pra que uma ampliação acidental da allowlist de leitura não relaxe o bloqueio POSIX.

## Limite conhecido (documentado)

Um tool sem comando de shell e sem corpo de arquivo — uma chamada MCP arbitrária que mute algo pela API dela — não é gateada. Gatear implicaria bloquear toda leitura MCP da sessão, incluindo o próprio board. O guard cobre a working tree, não todo efeito colateral possível.

## Teste

TDD: os casos novos em `scripts/test-plugin-package.sh` falham (exit 1) contra o guard pré-fix e passam depois. Cobertura nova: PowerShell mutando → BLOQUEIA; `[System.IO.File]::WriteAllText` → BLOQUEIA; tool de shell desconhecido mutando → BLOQUEIA; shell sem comando legível → BLOQUEIA; tool desconhecido com corpo de arquivo → BLOQUEIA; read-only (`Get-ChildItem`, `Test-Path`, `Select-String`, `ls`, `cat`, `git status/log`) → PASSA; Read/Grep/Glob/board → silenciosos (o matcher agora os vê); bash mutante POSIX → continua bloqueado; adapter do Antigravity → deny/allow nos mesmos casos.

Container Linux, comando do card:

    docker run --rm -v "$PWD":/repo -w /repo node:22-bookworm-slim bash -c 'apt-get update -qq && apt-get install -y -qq jq python3 git && git config --global --add safe.directory /repo && sh scripts/test-plugin-package.sh'
    → plugin package checks passed (EXIT=0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)