### PR TITLE
[OCL-136] make the manage capability grantable where the error says it is (issue #71)

### DIFF
--- a/apps/web/src/actions/tokens.manage.test.ts
+++ b/apps/web/src/actions/tokens.manage.test.ts
@@ -1,0 +1,90 @@
+import { mcpToken } from "@agent-board/db";
+import { eq } from "drizzle-orm";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createPairingCode, exchangePairingCode } from "../lib/pairing";
+import { authenticateBearer } from "../mcp/auth";
+import { closeTestWorld, createTestWorld, type TestWorld } from "../mcp/test-db";
+
+let world: TestWorld;
+
+/** Any signed-in human: the action only asks that a session exists. */
+const OWNER_ID = "00000000-0000-4000-8000-000000000001";
+
+vi.mock("../lib/db", () => ({
+  db: () => world.db,
+  getDatabaseUrl: () => "pglite://test",
+}));
+
+vi.mock("../lib/cookies", () => ({
+  getSession: async () => ({ userId: OWNER_ID, sessionVersion: 1, email: "owner@example.com" }),
+}));
+
+vi.mock("next/cache", () => ({ revalidatePath: () => {} }));
+
+const { setTokenManageAction } = await import("./tokens");
+
+/**
+ * OCL-136 (issue #71): the manage flag could only be decided on the manual
+ * "generate token" form, and pairing — which is how the plugin installs —
+ * always produced a token without it. So the MCP refusal asked the user for a
+ * permission that no control on the board could grant, and harness_set was
+ * unreachable for anyone who paired.
+ */
+describe("granting manage on an existing token", () => {
+  afterEach(async () => {
+    if (world) await closeTestWorld(world);
+  });
+
+  async function pairToken(label: string): Promise<string> {
+    const code = await createPairingCode(world.db, {
+      workspaceId: world.workspaceId,
+      label,
+    });
+    const paired = await exchangePairingCode(world.db, code.code, "198.51.100.4");
+    if (!paired.ok) throw new Error("pairing failed");
+    return paired.token;
+  }
+
+  it("turns a freshly paired worker token into a manage token", async () => {
+    world = await createTestWorld();
+    const secret = await pairToken("claude code on this machine");
+
+    // The state the bug report starts from: brand new token, no manage.
+    const before = await authenticateBearer(world.db, `Bearer ${secret}`);
+    expect(before.ok).toBe(true);
+    if (!before.ok) return;
+    expect(before.ctx.canManage).toBe(false);
+
+    const granted = await setTokenManageAction(before.ctx.tokenId, true);
+    expect(granted).toEqual({ ok: true });
+
+    const after = await authenticateBearer(world.db, `Bearer ${secret}`);
+    expect(after.ok).toBe(true);
+    if (!after.ok) return;
+    expect(after.ctx.canManage).toBe(true);
+  });
+
+  it("takes the capability back", async () => {
+    world = await createTestWorld();
+    const off = await setTokenManageAction(world.manageTokenId, false);
+    expect(off).toEqual({ ok: true });
+
+    const [row] = await world.db
+      .select({ canManage: mcpToken.canManage })
+      .from(mcpToken)
+      .where(eq(mcpToken.id, world.manageTokenId));
+    expect(row?.canManage).toBe(false);
+  });
+
+  it("refuses to hand the capability to a revoked token", async () => {
+    world = await createTestWorld();
+    const result = await setTokenManageAction(world.revokedTokenId, true);
+    expect(result.ok).toBe(false);
+
+    const [row] = await world.db
+      .select({ canManage: mcpToken.canManage })
+      .from(mcpToken)
+      .where(eq(mcpToken.id, world.revokedTokenId));
+    expect(row?.canManage).toBe(false);
+  });
+});

--- a/apps/web/src/actions/tokens.ts
+++ b/apps/web/src/actions/tokens.ts
@@ -52,6 +52,42 @@ export async function createTokenAction(
   }
 }
 
+/**
+ * Grants or takes back the manage capability on a token that already exists.
+ *
+ * Without this the flag could only be decided at creation time, on the manual
+ * "generate token" form — and a token created by pairing, which is how the
+ * plugin installs, always landed with it off and no way up. The MCP refusal
+ * then asked for a permission the UI had no control for (OCL-136, issue #71).
+ * Revoked tokens are left alone: reviving one by capability is not a thing.
+ */
+export async function setTokenManageAction(
+  tokenId: string,
+  canManage: boolean,
+): Promise<ActionResult> {
+  const session = await getSession();
+  if (!session) return { ok: false, error: "Session expired. Sign in again." };
+
+  const ws = await db().query.workspace.findFirst();
+  if (!ws) return { ok: false, error: "Workspace not found." };
+
+  const [row] = await db()
+    .update(mcpToken)
+    .set({ canManage })
+    .where(
+      and(
+        eq(mcpToken.id, tokenId),
+        eq(mcpToken.workspaceId, ws.id),
+        eq(mcpToken.revoked, false),
+      ),
+    )
+    .returning({ id: mcpToken.id });
+  if (!row) return { ok: false, error: "Token not found, or it was revoked." };
+
+  revalidatePath("/settings");
+  return { ok: true };
+}
+
 export async function revokeTokenAction(tokenId: string): Promise<ActionResult> {
   const session = await getSession();
   if (!session) return { ok: false, error: "Session expired. Sign in again." };

--- a/apps/web/src/app/settings/settings-client.tsx
+++ b/apps/web/src/app/settings/settings-client.tsx
@@ -13,6 +13,7 @@ import {
   createPairingCodeAction,
   createTokenAction,
   revokeTokenAction,
+  setTokenManageAction,
 } from "../../actions/tokens";
 import { saveUpdateModeAction } from "../../actions/updates";
 import { NebulaAtmosphere } from "../../components/nebula-atmosphere";
@@ -434,6 +435,16 @@ export function SettingsClient({
       const r = await revokeTokenAction(id);
       if (!r.ok) setErr(r.error);
       else router.refresh();
+    });
+  // The capability is decided on the row, not only at creation: a token that
+  // arrived through pairing is born without it, and until this existed there
+  // was no control anywhere that could turn it on (OCL-136).
+  const setManage = (id: string, canManage: boolean) =>
+    start(async () => {
+      setErr(null); setMsg(null);
+      const r = await setTokenManageAction(id, canManage);
+      if (!r.ok) setErr(r.error);
+      else { setMsg(canManage ? t.settings.manageGranted : t.settings.manageRevoked); router.refresh(); }
     });
   const copyFresh = async () => {
     if (!fresh) return;
@@ -920,17 +931,25 @@ export function SettingsClient({
               tokens.map((tok) => (
                 <div key={tok.id} className={`tok${tok.revoked ? " revoked" : ""}`}>
                   <div className="meta">
-                    <div className="label">
-                      {tok.label}
-                      {tok.canManage ? (
-                        <span className="tok-cap">{t.settings.manageBadge}</span>
-                      ) : null}
-                    </div>
+                    <div className="label">{tok.label}</div>
                     <div className="sub">
                       {t.settings.created} {fmtDate(tok.createdAt, dateLocale)} ·{" "}
                       {tok.revoked ? t.settings.revoked : fmtLastUse(tok.lastUsedAt, t)}
                     </div>
                   </div>
+                  {/* The box the MCP refusal points at. It is a control and not
+                      a badge because reading "this token needs manage" and
+                      finding nothing to tick is the whole bug (OCL-136). */}
+                  <label className="tok-cap" title={t.settings.manageLabel}>
+                    <input
+                      type="checkbox"
+                      checked={tok.canManage}
+                      disabled={pending || tok.revoked}
+                      aria-label={`${t.settings.manageLabel} (${tok.label})`}
+                      onChange={(e) => setManage(tok.id, e.target.checked)}
+                    />
+                    <span>{t.settings.manageBadge}</span>
+                  </label>
                   <span className="val">{tok.masked}</span>
                   <button className="btn-rev" disabled={pending || tok.revoked} onClick={() => revoke(tok.id)}>
                     {tok.revoked ? t.settings.revoked : t.settings.revoke}

--- a/apps/web/src/lib/i18n.ts
+++ b/apps/web/src/lib/i18n.ts
@@ -4,6 +4,8 @@
  * components call dict(lang). The product voice holds in every language:
  * direct, no enthusiasm, no em-dash.
  */
+import { MANAGE_BADGE_EN, MANAGE_LABEL_EN } from "./manage-capability";
+
 export type Lang = "en" | "pt-BR";
 
 export const LANGUAGES: { value: Lang; label: string }[] = [
@@ -452,10 +454,14 @@ const en = {
     freshToken: "Token created. It is shown only once.",
     copyCommand: "Copy command",
     tokenPlaceholder: "token name (e.g. Codex CI)",
-    manageBadge: "manage",
-    manageLabel: "This token can change the workspace configuration",
+    // Shared with the MCP refusal (lib/manage-capability.ts): the error names
+    // the exact control, so the copy has one source (OCL-136).
+    manageBadge: MANAGE_BADGE_EN,
+    manageLabel: MANAGE_LABEL_EN,
     manageNote:
-      "off by default · only tick it for a token you trust to rewrite the harness policy and the executors over MCP · a worker token gets a permission error instead",
+      "off by default · a token created by pairing starts without it · tick it on a token's row to grant it later · only for a token you trust to rewrite the harness policy and the executors over MCP · a worker token gets a permission error instead",
+    manageGranted: "Token can now change the workspace configuration.",
+    manageRevoked: "Token can no longer change the workspace configuration.",
     generateTokenBtn: "+ Generate token",
     generatePairBtn: "+ Pairing code",
     freshPair: "Pairing code created. Read it to your agent; it works once and expires in 10 minutes.",
@@ -1009,7 +1015,9 @@ const ptBR: Dict = {
     manageBadge: "gerência",
     manageLabel: "Este token pode mudar a configuração do workspace",
     manageNote:
-      "desligado por padrão · marque só para um token em que você confia para reescrever a política de harness e os executores via MCP · um token de worker recebe um erro de permissão",
+      "desligado por padrão · um token criado por pareamento nasce sem ele · marque na linha do token para conceder depois · só para um token em que você confia para reescrever a política de harness e os executores via MCP · um token de worker recebe um erro de permissão",
+    manageGranted: "O token já pode mudar a configuração do workspace.",
+    manageRevoked: "O token não pode mais mudar a configuração do workspace.",
     generateTokenBtn: "+ Gerar token",
     generatePairBtn: "+ Código de pareamento",
     freshPair: "Código de pareamento criado. Leia para o seu agente; vale uma vez e expira em 10 minutos.",

--- a/apps/web/src/lib/manage-capability.ts
+++ b/apps/web/src/lib/manage-capability.ts
@@ -1,0 +1,42 @@
+/**
+ * The one place the "manage" capability is named.
+ *
+ * The MCP refusal used to invent its own wording ("tick 'can manage the
+ * workspace'") while Settings rendered a different sentence, so a user who
+ * read the error and went looking for that control found nothing and the
+ * tool was, in practice, unreachable (OCL-136, issue #71). The English
+ * checkbox copy and the refusal text now come from here, so the two cannot
+ * drift again: change the label and the error changes with it.
+ *
+ * pt-BR still translates the label in the dictionary; the MCP surface answers
+ * in English, so it quotes the English one, which is what the board shows a
+ * user who never switched language.
+ */
+
+/** Visible text of the per-token checkbox in the token list. */
+export const MANAGE_BADGE_EN = "manage";
+
+/** Full label of the capability, on the new-token form and as the row title. */
+export const MANAGE_LABEL_EN = "This token can change the workspace configuration";
+
+/**
+ * Where the human goes to grant it. Named once so the refusal cannot point at
+ * a screen that no longer exists.
+ */
+export const MANAGE_SETTINGS_PATH = "Settings › MCP tokens";
+
+/**
+ * What an MCP tool says when the token lacks the flag. It names the exact
+ * control, in the exact place, for the exact token, because the alternative
+ * is what OCL-136 reported: a permission the UI had no way to give.
+ */
+export function manageDenialMessage(tool: string, tokenLabel?: string | null): string {
+  const which = tokenLabel?.trim() ? ` ("${tokenLabel.trim()}")` : "";
+  return (
+    `This token cannot change the workspace configuration, so ${tool} is refused. ` +
+    `In ${MANAGE_SETTINGS_PATH}, find this token${which} in the list and tick the ` +
+    `"${MANAGE_BADGE_EN}" box on its row (full label: "${MANAGE_LABEL_EN}"), ` +
+    `or use a token that already has it. A token created by pairing starts without ` +
+    `the flag, so this is the way to grant it after install.`
+  );
+}

--- a/apps/web/src/mcp/policy.integration.test.ts
+++ b/apps/web/src/mcp/policy.integration.test.ts
@@ -7,6 +7,7 @@ import {
 } from "@agent-board/mcp-core";
 import { and, eq } from "drizzle-orm";
 import { afterEach, describe, expect, it } from "vitest";
+import { dict } from "../lib/i18n";
 import { closeTestWorld, createTestWorld, type TestWorld } from "./test-db";
 import { invokeToolForTests as invokeTool } from "./test-tools";
 
@@ -229,7 +230,14 @@ describe("harness_set writes the policy over MCP", () => {
     expect(set.ok).toBe(false);
     if (set.ok) return;
     expect(set.error.code).toBe("PERMISSION_DENIED");
-    expect(set.error.message).toContain("Settings");
+    // The refusal has to name a control that exists. It used to ask for
+    // "can manage the workspace", a phrase the board never showed anywhere,
+    // so the user had nothing to tick (OCL-136). Pinning it to the dictionary
+    // means renaming the checkbox renames the error too, or this fails.
+    const settings = dict("en").settings;
+    expect(set.error.message).toContain("Settings › MCP tokens");
+    expect(set.error.message).toContain(settings.manageBadge);
+    expect(set.error.message).toContain(settings.manageLabel);
 
     const after = await world.db
       .select()

--- a/apps/web/src/mcp/test-db.ts
+++ b/apps/web/src/mcp/test-db.ts
@@ -33,6 +33,8 @@ export type TestWorld = {
   /** Token with the manage flag on: the only one allowed to write the config. */
   manageSecret: string;
   manageTokenId: string;
+  /** Already revoked: nothing may be granted to it, capability included. */
+  revokedTokenId: string;
 };
 
 /**
@@ -170,6 +172,7 @@ export async function createTestWorld(): Promise<TestWorld> {
     secondTokenId: tok2.id,
     manageSecret,
     manageTokenId: manager.id,
+    revokedTokenId: revoked.id,
   };
 }
 

--- a/apps/web/src/mcp/tools.ts
+++ b/apps/web/src/mcp/tools.ts
@@ -89,6 +89,7 @@ import {
   usageHonestyNote,
   type InsightsDb,
 } from "../lib/insights";
+import { manageDenialMessage } from "../lib/manage-capability";
 import { loadModelPrices, type PricesDb } from "../lib/prices";
 import {
   bindUsageRecipe,
@@ -4105,7 +4106,17 @@ async function harnessRecommend(
   input: { type: CardapioTaskType },
 ) {
   const rec = await recommendFor(db, ctx.workspaceId, input.type);
-  if (!rec.ok) return rec;
+  if (!rec.ok) {
+    // Issue #71 item 2: pre-create.mjs saw an empty recommendation three
+    // times on 0.2.5 and could not say whether the call errored, answered
+    // 200 with nothing, or never arrived. The plugin fails closed either
+    // way; this line is the server half of the answer, so the next report
+    // comes with the reason attached instead of a shrug.
+    console.warn(
+      `[harness_recommend] refused type=${input.type} workspace=${ctx.workspaceId} code=${rec.error.code}: ${rec.error.message}`,
+    );
+    return rec;
+  }
   return rec.value;
 }
 
@@ -4578,10 +4589,7 @@ function requireManage(
   tool: string,
 ): Result<never> | null {
   if (ctx.canManage) return null;
-  return err(
-    "PERMISSION_DENIED",
-    `This token cannot change the workspace configuration, so ${tool} is refused. Ask the owner to tick "can manage the workspace" for it in Settings › MCP tokens, or use a token that already has it.`,
-  );
+  return err("PERMISSION_DENIED", manageDenialMessage(tool, ctx.tokenLabel));
 }
 
 function policyEntryFromRow(

--- a/apps/web/src/styles/nebula.css
+++ b/apps/web/src/styles/nebula.css
@@ -2325,12 +2325,24 @@ body:has(.nb) { display: block; padding: 0; background: var(--nebula-void); }
 }
 .nb .tok .meta { flex: 1; min-width: 0; }
 .nb .tok .label { font-size: 13px; font-weight: 500; margin-bottom: 2px; }
+/* Was a read-only badge; it is a checkbox now, because the capability has to
+   be grantable where the MCP error says it is (OCL-136). Unticked it reads as
+   an empty slot rather than an accent pill, so a token that holds manage is
+   still the one that stands out in the list. */
 .nb .tok-cap {
-  display: inline-block; margin-left: 8px; padding: 2px 8px; border-radius: var(--oc-radius-pill);
-  border: 1px solid rgb(var(--oc-accent-rgb) / .3); background: rgb(var(--oc-accent-rgb) / .08);
+  display: inline-flex; align-items: center; gap: 6px; flex: 0 0 auto;
+  padding: 2px 8px; border-radius: var(--oc-radius-pill);
+  border: 1px solid var(--nebula-glass-border); background: none;
   font-family: var(--nebula-font-label); font-size: 9px; letter-spacing: .08em; text-transform: uppercase;
-  color: var(--nebula-mist-light); font-weight: 400; vertical-align: middle;
+  color: var(--nebula-text-tertiary); font-weight: 400; cursor: pointer;
+  transition: border-color .15s, background .15s, color .15s;
 }
+.nb .tok-cap:has(input:checked) {
+  border-color: rgb(var(--oc-accent-rgb) / .3); background: rgb(var(--oc-accent-rgb) / .08);
+  color: var(--nebula-mist-light);
+}
+.nb .tok-cap:has(input:disabled) { cursor: default; opacity: .5; }
+.nb .tok-cap input { accent-color: rgb(var(--oc-accent-rgb)); margin: 0; cursor: inherit; }
 /* the legacy global `.sub` ends with a 28px paragraph margin, which inside a
    card is 28px of nothing under every token: a row three times the height of
    the two lines it holds */

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -278,9 +278,12 @@ two claims. So the configuration tools sit behind a per-token **manage** flag, o
 default.
 
 Tick "This token can change the workspace configuration" when generating the token in
-Settings › MCP tokens. Tokens that have it show a `manage` badge in the list. Everything
-else about the token is unchanged: same URL, same header, same tools for claiming and
-delivering.
+Settings › MCP tokens, or tick the `manage` box on the token's row in that same list to
+grant it afterwards. Granting it later is the normal path: a token created by **pairing**,
+which is how the plugin installs, always starts without the flag. Everything else about the
+token is unchanged: same URL, same header, same tools for claiming and delivering.
+
+Untick the box to take the capability back. Revoked tokens cannot be granted anything.
 
 The configuration tools behind it are `harness_set` and `executors_update`. The flag also
 lets an owner release or heartbeat another token's stuck claim; the claiming token can
@@ -303,7 +306,7 @@ error and the details stay in the server logs.
 | `INVALID_TRANSITION` | the call does not fit the card status; for example, delivering an open card returns "Card is open, call task_claim before task_deliver." |
 | `ALREADY_CLAIMED` | another executor holds the card; retry with `force: true` to take over |
 | `INVALID_ARGUMENT` | the input failed validation; the message names the field |
-| `PERMISSION_DENIED` | the token is valid but has no manage flag, so it cannot change the workspace configuration; nothing was written |
+| `PERMISSION_DENIED` | the token is valid but has no manage flag, so it cannot change the workspace configuration; nothing was written. The message names the token and the exact box to tick in Settings › MCP tokens |
 | `INTERNAL` | unexpected server error, nothing leaked; check ids and retry |
 
 ## Telemetry


### PR DESCRIPTION
Closes the item 1 of #71. Target release: v0.2.7. **Do not merge yet.**

## What was broken

`harness_set` refused a token with: *ask the owner to tick "can manage the workspace" in Settings › MCP tokens*. That control does not exist.

Three facts found while investigating:

1. The capability is real: `mcp_token.can_manage`, checked by `requireManage()` in `apps/web/src/mcp/tools.ts` (gates `harness_set`, `executors_update`, `task_update {status: descartado}`).
2. The Settings checkbox is labelled **"This token can change the workspace configuration"** — never "can manage the workspace". The error invented its own wording, so searching Settings for it found nothing.
3. Worse than a wording drift: the checkbox only fed `createTokenAction` on the manual *generate token* form. `exchangePairingCode()` inserts the token without `canManage`, and there was **no control anywhere** to change it afterwards — the list only rendered a read-only `manage` badge. A token created by pairing (the plugin install path) could never obtain the flag. That is exactly the repro: fresh token, 0.2.6, permanently refused.

## The fix — both paths from the card

- **(b) exposed in the UI:** each token row in Settings › MCP tokens now has a `manage` checkbox backed by a new `setTokenManageAction`, so an existing (including freshly paired) token can be granted or un-granted. Revoked tokens are refused.
- **(a) the message names the real control:** new `apps/web/src/lib/manage-capability.ts` is the single source for the English copy. `lib/i18n.ts` (en) and the MCP refusal both read it, so they cannot drift; `policy.integration.test.ts` asserts the refusal contains the dictionary's label and badge. The message also names the token and states that a paired token starts without the flag.

Issue #71 item 2 (intermittent empty `harness_recommend`) is not reproducible on 0.2.6 — added server-side instrumentation only: `harness_recommend` logs the refusal code/message so the next report distinguishes error vs empty-200 vs call-never-arrived.

## Verification

- `pnpm test`: 838 passing (mcp-core 140, db 130, web 568 + 1 file skipped), including 3 new tests in `actions/tokens.manage.test.ts` — a paired token authenticates with `canManage: false`, gets granted, authenticates again with `canManage: true`.
- `pnpm typecheck` and `pnpm lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)