### PR TITLE
[OCL-135] usage recipe roda no Windows: node em vez de heredoc+python3, slug do transcript com \ e :

### DIFF
--- a/apps/web/src/app/home/page.tsx
+++ b/apps/web/src/app/home/page.tsx
@@ -236,7 +236,7 @@ function toTranscriptView(
     sessionId: ref.sessionId,
     path: ref.path,
     resume: ref.resume,
-    usageCommand: recomputeUsageCommand(recipe?.command, ref.path),
+    usageCommand: recomputeUsageCommand(recipe?.command, ref.path, recipe?.source),
   };
 }
 

--- a/apps/web/src/lib/recipes.ts
+++ b/apps/web/src/lib/recipes.ts
@@ -1,5 +1,6 @@
 import { eq } from "drizzle-orm";
 import {
+  bindRecipeSettings,
   factoryUsageRecipes,
   findUsageRecipe,
   usageRecipe,
@@ -64,8 +65,14 @@ function shellValue(value: string): string {
 
 /**
  * Binds a recipe to this attempt's claim window. Every transcript-reading
- * shipped recipe understands OVERCLICK_CLAIMED_AT; Codex additionally gets
- * the exact session and harness model that select and label its rollout.
+ * shipped recipe understands claimed_at; Codex additionally gets the exact
+ * session and harness model that select and label its rollout.
+ *
+ * A shipped recipe takes them as `key=value` arguments, percent-encoded, which
+ * survive bash, zsh and PowerShell alike: the old `VAR=value command` prefix
+ * is POSIX shell syntax, and on Windows it became a stray argument that bound
+ * nothing. A recipe the workspace rewrote keeps the environment prefix — it
+ * was written against that form, and the board does not rewrite it.
  */
 export function bindUsageRecipe(
   recipe: UsageRecipeRow | null,
@@ -81,12 +88,19 @@ export function bindUsageRecipe(
     ? new Date(executor.claimedAt).toISOString()
     : null;
 
+  const isCodex = recipe.cli === "codex";
+  const settings = {
+    claimed_at: claimedAt,
+    codex_session: isCodex ? executor.sessionId : null,
+    codex_model: isCodex ? executor.model : null,
+  };
+
   const environment = [
     claimedAt ? `OVERCLICK_CLAIMED_AT=${shellValue(claimedAt)}` : null,
-    recipe.cli === "codex" && executor.sessionId
+    isCodex && executor.sessionId
       ? `CODEX_SESSION_ID=${shellValue(executor.sessionId)}`
       : null,
-    recipe.cli === "codex" && executor.model
+    isCodex && executor.model
       ? `CODEX_HARNESS_MODEL=${shellValue(executor.model)}`
       : null,
   ].filter((value): value is string => Boolean(value));
@@ -96,12 +110,16 @@ export function bindUsageRecipe(
       "work already present in this session belongs to no part of this card."
     : "";
 
+  if (!recipe.command) return { ...recipe, instructions: `${recipe.instructions}${windowInstruction}` };
+
   return {
     ...recipe,
     instructions: `${recipe.instructions}${windowInstruction}`,
     command:
-      recipe.command && environment.length
-        ? `${environment.join(" ")} ${recipe.command}`
-        : recipe.command,
+      recipe.source === "custom"
+        ? environment.length
+          ? `${environment.join(" ")} ${recipe.command}`
+          : recipe.command
+        : bindRecipeSettings(recipe.command, settings),
   };
 }

--- a/apps/web/src/mcp/briefing.test.ts
+++ b/apps/web/src/mcp/briefing.test.ts
@@ -122,7 +122,10 @@ describe("self-contained briefing markdown", () => {
     expect(recipeAt).toBeLessThan(contractAt);
     expect(md).toContain("CLAUDE_CODE_SESSION_ID");
     expect(md).toContain("cache_read_input_tokens");
-    expect(md.slice(recipeAt, contractAt)).toContain("```bash");
+    // The fence carries no language: the command is not bash-only any more.
+    expect(md.slice(recipeAt, contractAt)).toContain("```");
+    expect(md.slice(recipeAt, contractAt)).not.toContain("```bash");
+    expect(md.slice(recipeAt, contractAt)).toContain("node -e");
   });
 
   it("names the claim boundary and excludes earlier session work", () => {

--- a/apps/web/src/mcp/briefing.ts
+++ b/apps/web/src/mcp/briefing.ts
@@ -12,8 +12,11 @@ import type {
  * the delivery contract, because that is the moment the agent needs it.
  */
 function renderRecipe(recipe: UsageRecipe): string[] {
+  // No language on the fence on purpose: the shipped commands are one node
+  // invocation that bash, zsh and PowerShell all run, and labelling the block
+  // bash told a Windows agent it needed a shell it does not have.
   const block = recipe.command
-    ? ["```bash", recipe.command, "```"]
+    ? ["```", recipe.command, "```"]
     : ["(no command for this CLI yet)"];
   return [
     `## Measuring this run — ${recipe.label}`,

--- a/apps/web/src/mcp/tools.integration.test.ts
+++ b/apps/web/src/mcp/tools.integration.test.ts
@@ -414,6 +414,8 @@ describe("MCP tool edge cases against a test db", () => {
     if (!submitted.ok) return;
     const delivered = TaskDeliverOutputSchema.parse(submitted.value);
     expect(delivered.telemetry_incomplete).toBe(true);
+    // The flag alone left the agent guessing which field was missing.
+    expect(delivered.telemetry_incomplete_reason).toContain("no usage was sent");
     expect(delivered.task.status).toBe("feito");
     // Usage is required by contract: a usage-less delivery still lands, but
     // the response tells the agent how to fix it after the fact.
@@ -568,15 +570,19 @@ describe("MCP tool edge cases against a test db", () => {
     if (!claimed.ok) return;
     const payload = TaskClaimOutputSchema.parse(claimed.value);
 
+    // Settings ride as percent-encoded arguments, not as a POSIX environment
+    // prefix: PowerShell has no VAR=value syntax, so the old form bound
+    // nothing on Windows and the recipe measured the wrong session.
     expect(payload.usage_recipe?.command).toContain(
-      `CODEX_SESSION_ID='codex-session-with-'"'"'quote'`,
+      "codex_session=codex-session-with-%27quote",
     );
     expect(payload.usage_recipe?.command).toContain(
-      "CODEX_HARNESS_MODEL='gpt-5-6-sol'",
+      "codex_model=gpt-5-6-sol",
     );
     expect(payload.usage_recipe?.command).toContain(
-      `OVERCLICK_CLAIMED_AT='${payload.attempt.started_at}'`,
+      `claimed_at=${payload.attempt.started_at}`,
     );
+    expect(payload.usage_recipe?.command).not.toContain("OVERCLICK_CLAIMED_AT=");
     expect(payload.briefing_markdown).toContain(
       `claimed_at: \`${payload.attempt.started_at}\``,
     );
@@ -584,7 +590,7 @@ describe("MCP tool edge cases against a test db", () => {
       "work before the claim",
     );
     expect(payload.briefing_markdown).toContain(
-      "CODEX_HARNESS_MODEL='gpt-5-6-sol'",
+      "codex_model=gpt-5-6-sol",
     );
   });
 

--- a/apps/web/src/mcp/tools.ts
+++ b/apps/web/src/mcp/tools.ts
@@ -40,6 +40,7 @@ import {
   evaluateClaim,
   isMcpCoreError,
   isTelemetryIncomplete,
+  telemetryIncompleteReason,
   lookupCardapioPolicy,
   MCP_TOOL_NAMES,
   ok,
@@ -3790,6 +3791,9 @@ async function taskDeliver(
       ? resolveUsageSegments(input.usage, openAttempt?.model ?? null)
       : undefined;
     const incomplete = isTelemetryIncomplete(usage);
+    // A flag that only says something is missing leaves the agent guessing
+    // which field to send; the reason names them.
+    const incompleteReason = telemetryIncompleteReason(usage);
 
     // The delivery usually knows the path the claim could not: the recipe
     // only prints it once the run is done. Fields it omits keep the claimed
@@ -3944,6 +3948,7 @@ async function taskDeliver(
       proj: found.proj,
       saved,
       incomplete,
+      incompleteReason,
       usage: storedUsage,
       routedTo: reviewerFromRow(updated),
       attemptExecutor: openAttempt
@@ -3980,6 +3985,9 @@ async function taskDeliver(
         telemetry_incomplete: persisted.value.incomplete,
         ...(input.usage ? { usage_recorded: true } : {}),
       }),
+      ...(persisted.value.incompleteReason
+        ? { telemetry_incomplete_reason: persisted.value.incompleteReason }
+        : {}),
       handoff_id: persisted.value.saved.id,
       cost_usd: persisted.value.attemptCostUsd,
       delivery_unverified: persisted.value.saved.deliveryUnverified,
@@ -4016,6 +4024,9 @@ async function taskDeliver(
       created_at: iso(persisted.value.saved.createdAt),
     },
     telemetry_incomplete: persisted.value.incomplete,
+    ...(persisted.value.incompleteReason
+      ? { telemetry_incomplete_reason: persisted.value.incompleteReason }
+      : {}),
     usage_suspect: persisted.value.usageGuard.suspect,
     usage_suspect_reason: persisted.value.usageGuard.reason,
     delivery_unverified: persisted.value.saved.deliveryUnverified,

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -263,7 +263,9 @@ numbers, estimate and set `estimated: true`.
 **The transcript reference.** `task_claim` and `task_deliver` both accept
 `transcript {cli, session_id, path, resume}`, and the card detail shows it with three copy
 actions: the path, the command that reopens the session in that CLI, and the recipe
-command pinned to that transcript with `TRANSCRIPT_PATH`. Send `path` at deliver time,
+command pinned to that transcript with a `transcript=` argument (the shipped recipes are one
+`node -e` command that bash, zsh and PowerShell all run; they also still read `TRANSCRIPT_PATH`
+from the environment). Send `path` at deliver time,
 when the recipe has printed it; fields you omit keep what the claim recorded, and the
 `session_id` an executor already sends becomes the reference on its own, so a card claimed
 before this existed still points somewhere. The board stores the reference and never the

--- a/packages/db/src/domain/fixtures/claude-transcript.jsonl
+++ b/packages/db/src/domain/fixtures/claude-transcript.jsonl
@@ -1,0 +1,7 @@
+{"type":"summary","summary":"Anonymized Claude Code session, two models, one entry before the claim."}
+{"timestamp":"2026-08-18T09:59:00.000Z","type":"assistant","message":{"model":"claude-opus-5","usage":{"input_tokens":10,"output_tokens":5,"cache_read_input_tokens":100,"cache_creation_input_tokens":2}}}
+{"timestamp":"2026-08-18T10:00:00.000Z","type":"user","message":{"role":"user","content":"do the card"}}
+{"timestamp":"2026-08-18T10:00:01.000Z","type":"assistant","message":{"model":"claude-opus-5","usage":{"input_tokens":80,"output_tokens":30,"cache_read_input_tokens":160,"cache_creation_input_tokens":5}}}
+{"timestamp":"2026-08-18T10:00:02.000Z","type":"assistant","message":{"model":"claude-haiku-4-5","usage":{"input_tokens":20,"output_tokens":7,"cache_read_input_tokens":40,"cache_creation_input_tokens":1}}}
+{"not":"json at all"
+{"timestamp":"2026-08-18T10:00:03.000Z","type":"assistant","message":{"model":"claude-opus-5","usage":{"input_tokens":50,"output_tokens":20,"cache_read_input_tokens":100,"cache_creation_input_tokens":3}}}

--- a/packages/db/src/domain/index.ts
+++ b/packages/db/src/domain/index.ts
@@ -85,6 +85,8 @@ export {
   type TranscriptRefInput,
 } from "./transcript";
 export {
+  bindRecipeSettings,
+  encodeRecipeSetting,
   factoryUsageRecipes,
   findUsageRecipe,
   recipeCoverage,

--- a/packages/db/src/domain/transcript.test.ts
+++ b/packages/db/src/domain/transcript.test.ts
@@ -109,15 +109,25 @@ describe("reading what was stored", () => {
 });
 
 describe("recomputing usage from one transcript", () => {
-  it("pins the recipe command to the path", () => {
-    expect(recomputeUsageCommand("python3 count.py", "/home/a/s.jsonl")).toBe(
-      `${TRANSCRIPT_PATH_ENV}='/home/a/s.jsonl' python3 count.py`,
+  it("pins a shipped recipe to the path with an argument every shell passes", () => {
+    // The environment prefix was POSIX-only syntax: on Windows PowerShell it
+    // bound nothing and the recipe measured whichever session ran last.
+    expect(recomputeUsageCommand("node -e script", "/home/a/s.jsonl")).toBe(
+      "node -e script transcript=/home/a/s.jsonl",
     );
   });
 
-  it("quotes a path with a space so the shell keeps it whole", () => {
-    expect(recomputeUsageCommand("run", "/My Repo/s.jsonl")).toBe(
-      `${TRANSCRIPT_PATH_ENV}='/My Repo/s.jsonl' run`,
+  it("encodes a path with a space so no shell splits it", () => {
+    expect(recomputeUsageCommand("node -e script", "/My Repo/s.jsonl")).toBe(
+      "node -e script transcript=/My%20Repo/s.jsonl",
+    );
+  });
+
+  it("keeps the environment prefix for a recipe the workspace rewrote", () => {
+    // A custom command was written against the old form; the board pins it the
+    // way its author expects instead of reinterpreting it.
+    expect(recomputeUsageCommand("python3 count.py", "/My Repo/s.jsonl", "custom")).toBe(
+      `${TRANSCRIPT_PATH_ENV}='/My Repo/s.jsonl' python3 count.py`,
     );
   });
 

--- a/packages/db/src/domain/transcript.ts
+++ b/packages/db/src/domain/transcript.ts
@@ -1,3 +1,5 @@
+import { bindRecipeSettings, type RecipeSource } from "./usage-recipe";
+
 /**
  * Transcript references: the pointer back to what the agent actually did.
  *
@@ -137,13 +139,22 @@ function shellQuote(value: string): string {
  * The workspace recipe command, pinned to one transcript. Null when the CLI
  * has no command to run or the reference has no path: the board would rather
  * show no button than one that measures whichever session ran last.
+ *
+ * A shipped recipe takes the path as a `transcript=` argument, which every
+ * shell passes through, including PowerShell, where the `VAR=value command`
+ * prefix is not syntax at all. A recipe the workspace rewrote keeps the
+ * environment prefix: it was written against the old form and the board does
+ * not get to reinterpret somebody else's command.
  */
 export function recomputeUsageCommand(
   command: string | null | undefined,
   path: string | null | undefined,
+  source: RecipeSource = "seed",
 ): string | null {
   const script = clean(command);
   const target = clean(path);
   if (!script || !target) return null;
-  return `${TRANSCRIPT_PATH_ENV}=${shellQuote(target)} ${script}`;
+  return source === "custom"
+    ? `${TRANSCRIPT_PATH_ENV}=${shellQuote(target)} ${script}`
+    : bindRecipeSettings(script, { transcript: target });
 }

--- a/packages/db/src/domain/usage-recipe.test.ts
+++ b/packages/db/src/domain/usage-recipe.test.ts
@@ -1,7 +1,12 @@
 import { execFileSync } from "node:child_process";
+import { copyFileSync, mkdirSync, mkdtempSync, realpathSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 import {
+  bindRecipeSettings,
+  encodeRecipeSetting,
   factoryUsageRecipes,
   findUsageRecipe,
   recipeCoverage,
@@ -33,6 +38,131 @@ describe("usage collection recipes", () => {
     expect(claude?.command).toContain("OVERCLICK_CLAIMED_AT");
   });
 
+  // A Windows machine breaks two POSIX assumptions at once: PowerShell has no
+  // heredoc, and the python3 on PATH is the Microsoft Store alias stub, which
+  // runs, prints nothing and exits 0. Both used to be in every command.
+  it("ships every command as one node invocation, with no heredoc and no python3", () => {
+    for (const recipe of recipes.filter((r) => r.command)) {
+      expect(recipe.command.startsWith("node -e \"")).toBe(true);
+      expect(recipe.command).not.toContain("python3");
+      expect(recipe.command).not.toContain("<<");
+    }
+  });
+
+  it("keeps every script free of the characters bash and PowerShell read differently", () => {
+    for (const recipe of recipes.filter((r) => r.command)) {
+      const script = recipe.command.slice(String("node -e \"").length, -1);
+      // A double quote would close the argument, a dollar or a backtick would
+      // interpolate in one shell, a backslash would be eaten by the other, and
+      // `!word` fires history expansion in an interactive bash.
+      expect(script).not.toContain('"');
+      expect(script).not.toContain("$");
+      expect(script).not.toContain("`");
+      expect(script).not.toContain("\\");
+      expect(script).not.toMatch(/![A-Za-z_(]/);
+    }
+  });
+
+  it("turns a Windows working directory into the folder Claude Code writes", () => {
+    // The slug used to replace the forward slash only, so on Windows it
+    // matched no folder at all — or, worse, some other session's transcript.
+    const claude = findUsageRecipe(recipes, "claude-code");
+    const source = claude!.command.match(
+      /process\.cwd\(\)[\s\S]*?\.join\(''\)/,
+    );
+    expect(source).not.toBeNull();
+    const slug = new Function(
+      "cwd",
+      `const BACKSLASH = String.fromCharCode(92);
+       const process = { cwd: () => cwd };
+       return ${source![0]};`,
+    ) as (cwd: string) => string;
+
+    expect(slug("C:\\Users\\me\\repo")).toBe("C--Users-me-repo");
+    expect(slug("/Users/me/repo")).toBe("-Users-me-repo");
+  });
+
+  it("measures an anonymized Claude Code transcript from the claim boundary", () => {
+    const claude = findUsageRecipe(recipes, "claude-code");
+    const transcript = fileURLToPath(
+      new URL("./fixtures/claude-transcript.jsonl", import.meta.url),
+    );
+
+    const all = JSON.parse(
+      execFileSync("bash", ["-c", claude!.command], {
+        env: { ...process.env, TRANSCRIPT_PATH: transcript },
+        encoding: "utf8",
+      }),
+    );
+    expect(all).toMatchObject({
+      turns: 4,
+      transcript,
+      estimated: false,
+      segments: expect.arrayContaining([
+        { model: "claude-opus-5", input: 140, output: 55, cache_read: 360, cache_write: 10 },
+        { model: "claude-haiku-4-5", input: 20, output: 7, cache_read: 40, cache_write: 1 },
+      ]),
+    });
+
+    // The same command, settings bound the cross-shell way task_claim binds
+    // them: arguments, not a POSIX environment prefix.
+    const windowed = JSON.parse(
+      execFileSync("bash", [
+        "-c",
+        bindRecipeSettings(claude!.command, {
+          transcript,
+          claimed_at: "2026-08-18T10:00:00.000Z",
+        }),
+      ], { encoding: "utf8" }),
+    );
+    expect(windowed).toMatchObject({
+      turns: 3,
+      segments: expect.arrayContaining([
+        { model: "claude-opus-5", input: 130, output: 50, cache_read: 260, cache_write: 8 },
+        { model: "claude-haiku-4-5", input: 20, output: 7, cache_read: 40, cache_write: 1 },
+      ]),
+    });
+  });
+
+  it("finds the newest transcript under the slugged project folder on its own", () => {
+    const claude = findUsageRecipe(recipes, "claude-code");
+    const home = mkdtempSync(join(tmpdir(), "ocl-home-"));
+    const repo = mkdtempSync(join(tmpdir(), "ocl-repo-"));
+    const slug = realpathSync(repo).split("/").join("-");
+    const folder = join(home, ".claude", "projects", slug);
+    mkdirSync(folder, { recursive: true });
+    const fixture = fileURLToPath(
+      new URL("./fixtures/claude-transcript.jsonl", import.meta.url),
+    );
+    copyFileSync(fixture, join(folder, "session-abc.jsonl"));
+
+    const output = execFileSync("bash", ["-c", claude!.command], {
+      cwd: realpathSync(repo),
+      env: { ...process.env, HOME: home, TRANSCRIPT_PATH: "", CLAUDE_CODE_SESSION_ID: "" },
+      encoding: "utf8",
+    });
+
+    expect(JSON.parse(output)).toMatchObject({
+      turns: 4,
+      transcript: join(folder, "session-abc.jsonl"),
+    });
+  });
+
+  it("says what was missing instead of printing nothing at all", () => {
+    const claude = findUsageRecipe(recipes, "claude-code");
+    const output = execFileSync("bash", [
+      "-c",
+      bindRecipeSettings(claude!.command, {
+        transcript: "/definitely/missing/claude-transcript.jsonl",
+      }),
+    ], { encoding: "utf8" });
+    const parsed = JSON.parse(output);
+
+    expect(parsed.estimated).toBe(true);
+    expect(parsed.reason).toContain("missing or unreadable");
+    expect(parsed.segments).toEqual([]);
+  });
+
   it("gives Codex a command that attributes each turn to its model", () => {
     const codex = findUsageRecipe(recipes, "codex");
     expect(codex?.yields).toBe("tokens_per_model");
@@ -41,7 +171,7 @@ describe("usage collection recipes", () => {
     expect(codex?.command).toContain("turn_context");
     expect(codex?.command).toContain("CODEX_SESSION_ID");
     expect(codex?.command).toContain("CODEX_HARNESS_MODEL");
-    expect(codex?.command).not.toContain('model, turns = collections.defaultdict(collections.Counter), "unknown"');
+    expect(codex?.command).not.toContain("collections.defaultdict");
   });
 
   it("measures an anonymized Codex 0.148 rollout and normalizes its model", () => {
@@ -197,12 +327,12 @@ describe("usage collection recipes", () => {
     expect(kimi?.command).toContain("usage.record");
     expect(kimi?.command).toContain("session_index.jsonl");
     // The cumulative record at the end would count the run twice.
-    expect(kimi?.command).toContain('usageScope") != "turn"');
+    expect(kimi?.command).toContain("entry.usageScope !== 'turn'");
     expect(kimi?.command).toContain("segments");
     expect(kimi?.command).toContain("OVERCLICK_CLAIMED_AT");
     // wire.jsonl stamps records with "time", not "timestamp"; the field has
     // to be in the list the claim-window filter reads.
-    expect(kimi?.command).toContain('entry.get("time")');
+    expect(kimi?.command).toContain("claimWindow('time')");
   });
 
   it("measures a real wire.jsonl session, merging every agent and skipping the cumulative session record", () => {
@@ -295,6 +425,39 @@ describe("usage collection recipes", () => {
     expect(findUsageRecipe(recipes, "some-new-cli")?.cli).toBe(GENERIC_RECIPE_CLI);
     expect(findUsageRecipe(recipes, null)?.cli).toBe(GENERIC_RECIPE_CLI);
     expect(findUsageRecipe(recipes, "")?.cli).toBe(GENERIC_RECIPE_CLI);
+  });
+
+  describe("binding settings to a command", () => {
+    it("appends key=value arguments instead of a POSIX environment prefix", () => {
+      expect(
+        bindRecipeSettings("node -e x", { claimed_at: "2026-08-18T10:00:00.000Z" }),
+      ).toBe("node -e x claimed_at=2026-08-18T10:00:00.000Z");
+    });
+
+    it("percent-encodes anything a shell would read as syntax", () => {
+      // A space, a quote or a backslash inside an unquoted argument is where
+      // the old single-quoted form and PowerShell disagreed.
+      expect(encodeRecipeSetting("/My Repo/s.jsonl")).toBe("/My%20Repo/s.jsonl");
+      expect(encodeRecipeSetting("session-with-'quote")).toBe("session-with-%27quote");
+      expect(encodeRecipeSetting("C:\\Users\\me")).toBe("C:%5CUsers%5Cme");
+      expect(encodeRecipeSetting("gpt-5.6-sol")).toBe("gpt-5.6-sol");
+    });
+
+    it("drops settings with no value and leaves the command alone", () => {
+      expect(bindRecipeSettings("node -e x", { claimed_at: null })).toBe("node -e x");
+    });
+
+    it("round-trips an encoded setting back into the script", () => {
+      const claude = findUsageRecipe(recipes, "claude-code");
+      const transcript = fileURLToPath(
+        new URL("./fixtures/claude-transcript.jsonl", import.meta.url),
+      );
+      const output = execFileSync("bash", [
+        "-c",
+        bindRecipeSettings(claude!.command, { transcript }),
+      ], { encoding: "utf8" });
+      expect(JSON.parse(output).transcript).toBe(transcript);
+    });
   });
 
   it("matches the CLI case-insensitively", () => {

--- a/packages/db/src/domain/usage-recipe.test.ts
+++ b/packages/db/src/domain/usage-recipe.test.ts
@@ -67,19 +67,19 @@ describe("usage collection recipes", () => {
     // The slug used to replace the forward slash only, so on Windows it
     // matched no folder at all — or, worse, some other session's transcript.
     const claude = findUsageRecipe(recipes, "claude-code");
-    const source = claude!.command.match(
-      /process\.cwd\(\)[\s\S]*?\.join\(''\)/,
-    );
+    const source = claude!.command.match(/process\.cwd\(\)\.replace\([^;]+\)/);
     expect(source).not.toBeNull();
     const slug = new Function(
       "cwd",
-      `const BACKSLASH = String.fromCharCode(92);
-       const process = { cwd: () => cwd };
+      `const process = { cwd: () => cwd };
        return ${source![0]};`,
     ) as (cwd: string) => string;
 
     expect(slug("C:\\Users\\me\\repo")).toBe("C--Users-me-repo");
     expect(slug("/Users/me/repo")).toBe("-Users-me-repo");
+    // The dot in a worktree path is a separator to Claude Code too, which the
+    // POSIX path got wrong all along.
+    expect(slug("/Users/me/repo/.worktrees/win")).toBe("-Users-me-repo--worktrees-win");
   });
 
   it("measures an anonymized Claude Code transcript from the claim boundary", () => {
@@ -128,7 +128,7 @@ describe("usage collection recipes", () => {
     const claude = findUsageRecipe(recipes, "claude-code");
     const home = mkdtempSync(join(tmpdir(), "ocl-home-"));
     const repo = mkdtempSync(join(tmpdir(), "ocl-repo-"));
-    const slug = realpathSync(repo).split("/").join("-");
+    const slug = realpathSync(repo).replace(/[^a-zA-Z0-9]/g, "-");
     const folder = join(home, ".claude", "projects", slug);
     mkdirSync(folder, { recursive: true });
     const fixture = fileURLToPath(
@@ -138,7 +138,13 @@ describe("usage collection recipes", () => {
 
     const output = execFileSync("bash", ["-c", claude!.command], {
       cwd: realpathSync(repo),
-      env: { ...process.env, HOME: home, TRANSCRIPT_PATH: "", CLAUDE_CODE_SESSION_ID: "" },
+      env: {
+        ...process.env,
+        HOME: home,
+        TRANSCRIPT_PATH: "",
+        CLAUDE_CODE_SESSION_ID: "",
+        CLAUDE_CONFIG_DIR: "",
+      },
       encoding: "utf8",
     });
 
@@ -146,6 +152,37 @@ describe("usage collection recipes", () => {
       turns: 4,
       transcript: join(folder, "session-abc.jsonl"),
     });
+  });
+
+  it("reads the config directory Claude Code was pointed at", () => {
+    // Overclock gives each account its own CLAUDE_CONFIG_DIR; a recipe hard
+    // wired to ~/.claude measures a tree with none of this run in it.
+    const claude = findUsageRecipe(recipes, "claude-code");
+    const config = mkdtempSync(join(tmpdir(), "ocl-config-"));
+    const repo = mkdtempSync(join(tmpdir(), "ocl-repo-"));
+    const folder = join(
+      config,
+      "projects",
+      realpathSync(repo).replace(/[^a-zA-Z0-9]/g, "-"),
+    );
+    mkdirSync(folder, { recursive: true });
+    copyFileSync(
+      fileURLToPath(new URL("./fixtures/claude-transcript.jsonl", import.meta.url)),
+      join(folder, "session-xyz.jsonl"),
+    );
+
+    const output = execFileSync("bash", ["-c", claude!.command], {
+      cwd: realpathSync(repo),
+      env: {
+        ...process.env,
+        CLAUDE_CONFIG_DIR: config,
+        TRANSCRIPT_PATH: "",
+        CLAUDE_CODE_SESSION_ID: "",
+      },
+      encoding: "utf8",
+    });
+
+    expect(JSON.parse(output).transcript).toBe(join(folder, "session-xyz.jsonl"));
   });
 
   it("says what was missing instead of printing nothing at all", () => {

--- a/packages/db/src/domain/usage-recipe.ts
+++ b/packages/db/src/domain/usage-recipe.ts
@@ -104,7 +104,6 @@ const PRELUDE = `const fs = require('fs');
 const os = require('os');
 const path = require('path');
 const NL = String.fromCharCode(10);
-const BACKSLASH = String.fromCharCode(92);
 
 // Settings arrive as percent-encoded key=value arguments because PowerShell
 // has no VAR=value command prefix; the environment is still read, so a caller
@@ -203,16 +202,20 @@ let file = setting('transcript', 'TRANSCRIPT_PATH');
 const session = setting('session', 'CLAUDE_CODE_SESSION_ID');
 let folder = '';
 if (file === '') {
-  // Claude Code names that folder after the working directory with every path
-  // separator turned into a dash. On Windows the cwd carries a drive colon and
-  // backslashes, so C:[backslash]Users[backslash]me is stored as C--Users-me:
-  // replacing only the forward slash matched no folder at all, and the newest
-  // transcript of some other session was the best case.
-  const slug = process.cwd()
-    .split('')
-    .map(ch => (ch === '/' || ch === ':' || ch === BACKSLASH) ? '-' : ch)
-    .join('');
-  folder = path.join(os.homedir(), '.claude', 'projects', slug);
+  // Claude Code names that folder after the working directory with every
+  // character that is not a letter or a digit turned into a dash. Replacing
+  // only the forward slash matched no folder at all whenever the path carried
+  // a dot (/repo/.worktrees/x) and matched nothing on Windows, where the cwd
+  // carries a drive colon and backslashes: C:[backslash]Users[backslash]me is
+  // stored as C--Users-me. A miss then fell through to the newest transcript
+  // of some other session, which put someone else's tokens on the card.
+  const slug = process.cwd().replace(new RegExp('[^a-zA-Z0-9]', 'g'), '-');
+  // CLAUDE_CONFIG_DIR moves the whole config tree, which is how Overclock
+  // gives each account its own; without it the recipe reads a ~/.claude that
+  // holds no session of this run.
+  const configDir = setting('claude_config_dir', 'CLAUDE_CONFIG_DIR')
+    || path.join(os.homedir(), '.claude');
+  folder = path.join(configDir, 'projects', slug);
   if (session === '') {
     let here = [];
     try {

--- a/packages/db/src/domain/usage-recipe.ts
+++ b/packages/db/src/domain/usage-recipe.ts
@@ -7,6 +7,22 @@
  * the recipe so the briefing can hand it over at claim time, and so a CLI
  * changing its transcript format is fixed in one place instead of in every
  * agent's head.
+ *
+ * Every shipped command is a single `node -e "..."` invocation on purpose.
+ * The recipes used to be a bash heredoc feeding python3, which is two
+ * assumptions a Windows machine breaks at once: PowerShell has no heredoc, and
+ * the `python3` on PATH there is the Microsoft Store execution alias, which
+ * satisfies `command -v`, runs, prints "Python was not found" and exits 0 with
+ * empty stdout. The install script already learned to probe capability instead
+ * of presence; the recipe answers the same lesson by running on the runtime
+ * that is guaranteed to be there — Claude Code, Codex, Grok and Kimi all ship
+ * as Node programs, so node is the interpreter that really runs.
+ *
+ * The script text inside the quotes therefore contains no double quote, no
+ * dollar sign, no backtick, no backslash and no `!` before a word: those are
+ * exactly the characters bash, zsh and PowerShell disagree about inside a
+ * double-quoted argument. Keep that discipline when editing a script here, or
+ * the same command stops surviving the trip through one of the shells.
  */
 
 /** What a recipe can honestly produce. */
@@ -39,318 +55,449 @@ export type UsageRecipeRow = UsageRecipe & {
 /** The recipe used when no CLI-specific one matches. */
 export const GENERIC_RECIPE_CLI = "generic";
 
-const CLAUDE_COMMAND = `python3 - <<'PY'
-import collections, datetime, glob, json, os
+/**
+ * Characters a setting keeps as itself on the command line. Everything else is
+ * percent-encoded, so a value never needs quoting and never means something to
+ * a shell: a space, a quote, a backslash or a dollar sign travels as %20, %22,
+ * %5C or %24 and the script decodes it back.
+ */
+const SETTING_SAFE =
+  "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._:/";
 
-# TRANSCRIPT_PATH pins one transcript, which is what the card's recompute
-# button sets. Without it, Claude Code writes one jsonl per session under
-# ~/.claude/projects/<cwd slug>.
-path = os.environ.get("TRANSCRIPT_PATH")
-claimed_at = os.environ.get("OVERCLICK_CLAIMED_AT")
-if not path:
-    folder = os.path.expanduser("~/.claude/projects/" + os.getcwd().replace("/", "-"))
-    session = os.environ.get("CLAUDE_CODE_SESSION_ID")
-    path = os.path.join(folder, session + ".jsonl") if session else max(
-        glob.glob(folder + "/*.jsonl"), key=os.path.getmtime
-    )
+/** Percent-encodes one recipe setting value for any shell. */
+export function encodeRecipeSetting(value: string): string {
+  let out = "";
+  for (const byte of Buffer.from(value, "utf8")) {
+    const char = String.fromCharCode(byte);
+    out +=
+      SETTING_SAFE.includes(char) && byte < 128
+        ? char
+        : "%" + byte.toString(16).toUpperCase().padStart(2, "0");
+  }
+  return out;
+}
 
-def at_or_after_claim(entry):
-    if not claimed_at:
-        return True
-    value = entry.get("timestamp") or entry.get("created_at") or entry.get("createdAt")
-    if value is None:
-        return False
-    try:
-        at = datetime.datetime.fromisoformat(str(value).replace("Z", "+00:00"))
-        claim = datetime.datetime.fromisoformat(claimed_at.replace("Z", "+00:00"))
-        return at >= claim
-    except ValueError:
-        return False
+/**
+ * Appends `key=value` settings to a shipped recipe command.
+ *
+ * The old form was a POSIX environment prefix (`VAR=value command`), which is
+ * a bash-only syntax: PowerShell reads it as a stray argument and the recipe
+ * measures the wrong window, or nothing at all. Arguments after `node -e` land
+ * in process.argv on every platform, and the scripts still read the matching
+ * environment variable when a caller sets one.
+ */
+export function bindRecipeSettings(
+  command: string,
+  settings: Readonly<Record<string, string | null | undefined>>,
+): string {
+  const parts = Object.entries(settings)
+    .filter((entry): entry is [string, string] => Boolean(entry[1]))
+    .map(([key, value]) => `${key}=${encodeRecipeSetting(value)}`);
+  return parts.length ? `${command} ${parts.join(" ")}` : command;
+}
 
-seg, turns = collections.defaultdict(collections.Counter), 0
-for line in open(path):
-    try:
-        entry = json.loads(line)
-    except ValueError:
-        continue
-    if not at_or_after_claim(entry):
-        continue
-    message = entry.get("message") or {}
-    usage = message.get("usage")
-    if not usage:
-        continue
-    turns += 1
-    counter = seg[message.get("model") or "unknown"]
-    counter["input"] += usage.get("input_tokens", 0)
-    counter["output"] += usage.get("output_tokens", 0)
-    counter["cache_read"] += usage.get("cache_read_input_tokens", 0)
-    counter["cache_write"] += usage.get("cache_creation_input_tokens", 0)
+/**
+ * Everything the four transcript readers share: settings, line reading, the
+ * claim window filter and the output shape task_deliver takes.
+ */
+const PRELUDE = `const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const NL = String.fromCharCode(10);
+const BACKSLASH = String.fromCharCode(92);
 
-print(json.dumps({
-    "segments": [dict(model=model, **dict(counter)) for model, counter in seg.items()],
-    "turns": turns,
-    "transcript": path,
-}, indent=2))
-PY`;
+// Settings arrive as percent-encoded key=value arguments because PowerShell
+// has no VAR=value command prefix; the environment is still read, so a caller
+// that exports TRANSCRIPT_PATH or OVERCLICK_CLAIMED_AT keeps working.
+const given = {};
+for (const item of process.argv.slice(1)) {
+  const at = item.indexOf('=');
+  if (at > 0) {
+    let value = item.slice(at + 1);
+    try { value = decodeURIComponent(value); } catch (error) { }
+    given[item.slice(0, at).trim().toLowerCase()] = value;
+  }
+}
+function setting(key, variable) {
+  return given[key] || process.env[variable] || '';
+}
+function readLines(file) {
+  return fs.readFileSync(file, 'utf8').split(NL);
+}
+function parse(line) {
+  try { return JSON.parse(line); } catch (error) { return null; }
+}
+function exists(candidate) {
+  try { fs.statSync(candidate); return true; } catch (error) { return false; }
+}
+function newest(candidates) {
+  let best = '';
+  let stamp = -1;
+  for (const candidate of candidates) {
+    let at = -1;
+    try { at = fs.statSync(candidate).mtimeMs; } catch (error) { continue; }
+    if (at > stamp) { stamp = at; best = candidate; }
+  }
+  return best;
+}
+// Only entries at or after the claim count: work the session did before this
+// card was claimed belongs to no part of it. An entry with no timestamp is
+// left out rather than guessed in.
+function claimWindow(extraField) {
+  const claimedAt = setting('claimed_at', 'OVERCLICK_CLAIMED_AT');
+  const claim = claimedAt === '' ? NaN : Date.parse(claimedAt);
+  return function (entry) {
+    if (claimedAt === '' || Number.isNaN(claim)) return true;
+    let value = entry.timestamp;
+    if (value === undefined) value = entry.created_at;
+    if (value === undefined) value = entry.createdAt;
+    if (value === undefined && extraField) value = entry[extraField];
+    if (value === undefined || value === null) return false;
+    // Grok stamps epoch seconds and Kimi epoch milliseconds; the rest write
+    // ISO text.
+    const at = typeof value === 'number'
+      ? (value > 100000000000 ? value : value * 1000)
+      : Date.parse(String(value));
+    if (Number.isNaN(at)) return false;
+    return at >= claim;
+  };
+}
+function emit(payload) {
+  process.stdout.write(JSON.stringify(payload, null, 2) + NL);
+}
+function unavailable(reason) {
+  emit({
+    segments: [],
+    turns: 0,
+    estimated: true,
+    reason: reason + ' Estimate usage and send estimated: true.',
+  });
+  process.exit(0);
+}
+function bump(seg, model, counts) {
+  const key = model || 'unknown';
+  if (seg[key] === undefined) {
+    seg[key] = { input: 0, output: 0, cache_read: 0, cache_write: 0 };
+  }
+  const row = seg[key];
+  row.input += counts.input || 0;
+  row.output += counts.output || 0;
+  row.cache_read += counts.cache_read || 0;
+  row.cache_write += counts.cache_write || 0;
+}
+function segments(seg) {
+  return Object.keys(seg).map(model => Object.assign({ model: model }, seg[model]));
+}`;
 
-const CODEX_COMMAND = `python3 - <<'PY'
-import collections, datetime, glob, json, os, re
+/** Wraps a script into the one command that runs on bash, zsh and PowerShell. */
+function nodeCommand(script: string): string {
+  return `node -e "${script}"`;
+}
 
-# TRANSCRIPT_PATH pins one transcript, which is what the card's recompute
-# button sets. Without it, Codex writes one rollout jsonl per session under
-# ~/.codex/sessions/<date>/. CODEX_SESSION_ID is bound from task_claim, so a
-# busy repo never attributes the newest *other* pane's rollout to this card.
-path = os.environ.get("TRANSCRIPT_PATH")
-session = os.environ.get("CODEX_SESSION_ID") or os.environ.get("CODEX_THREAD_ID")
-fallback_model = os.environ.get("CODEX_HARNESS_MODEL")
-claimed_at = os.environ.get("OVERCLICK_CLAIMED_AT")
+const CLAUDE_COMMAND = nodeCommand(`${PRELUDE}
 
-def model_slug(value):
-    return re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-") if value else ""
+// TRANSCRIPT_PATH pins one transcript, which is what the card's recompute
+// button sets. Without it, Claude Code writes one jsonl per session under
+// ~/.claude/projects/<cwd slug>.
+let file = setting('transcript', 'TRANSCRIPT_PATH');
+const session = setting('session', 'CLAUDE_CODE_SESSION_ID');
+let folder = '';
+if (file === '') {
+  // Claude Code names that folder after the working directory with every path
+  // separator turned into a dash. On Windows the cwd carries a drive colon and
+  // backslashes, so C:[backslash]Users[backslash]me is stored as C--Users-me:
+  // replacing only the forward slash matched no folder at all, and the newest
+  // transcript of some other session was the best case.
+  const slug = process.cwd()
+    .split('')
+    .map(ch => (ch === '/' || ch === ':' || ch === BACKSLASH) ? '-' : ch)
+    .join('');
+  folder = path.join(os.homedir(), '.claude', 'projects', slug);
+  if (session === '') {
+    let here = [];
+    try {
+      here = fs.readdirSync(folder)
+        .filter(name => name.endsWith('.jsonl'))
+        .map(name => path.join(folder, name));
+    } catch (error) { here = []; }
+    file = newest(here);
+  } else {
+    file = path.join(folder, session + '.jsonl');
+  }
+}
+if (file === '') {
+  unavailable('No Claude Code transcript was found under ' + folder + '.');
+}
+if (exists(file) === false) {
+  unavailable('The Claude Code transcript ' + file + ' is missing or unreadable.');
+}
 
-def unavailable(reason):
-    print(json.dumps({
-        "segments": [],
-        "turns": 0,
-        "estimated": True,
-        "reason": reason + " Estimate usage and send estimated: true.",
-    }, indent=2))
+const keep = claimWindow();
+const seg = {};
+let turns = 0;
+for (const line of readLines(file)) {
+  const entry = parse(line);
+  if (entry === null || keep(entry) === false) continue;
+  const message = entry.message || {};
+  const usage = message.usage;
+  if (usage === undefined || usage === null) continue;
+  turns += 1;
+  bump(seg, message.model, {
+    input: usage.input_tokens,
+    output: usage.output_tokens,
+    cache_read: usage.cache_read_input_tokens,
+    cache_write: usage.cache_creation_input_tokens,
+  });
+}
 
-def at_or_after_claim(entry):
-    if not claimed_at:
-        return True
-    value = entry.get("timestamp") or entry.get("created_at") or entry.get("createdAt")
-    if value is None:
-        return False
-    try:
-        at = datetime.datetime.fromisoformat(str(value).replace("Z", "+00:00"))
-        claim = datetime.datetime.fromisoformat(claimed_at.replace("Z", "+00:00"))
-        return at >= claim
-    except ValueError:
-        return False
+if (turns === 0) {
+  unavailable('The Claude Code transcript ' + file + ' has no usage entries in the claim window.');
+}
+emit({ segments: segments(seg), turns: turns, transcript: file, estimated: false });`);
 
-def belongs_to_session(candidate):
-    if session in os.path.basename(candidate):
-        return True
-    try:
-        with open(candidate) as handle:
-            first = json.loads(handle.readline())
-    except (OSError, ValueError):
-        return False
-    payload = first.get("payload") or {}
-    return payload.get("id") == session or payload.get("session_id") == session
+const CODEX_COMMAND = nodeCommand(`${PRELUDE}
 
-if not path:
-    paths = glob.glob(os.path.expanduser("~/.codex/sessions/**/rollout-*.jsonl"), recursive=True)
-    if not session:
-        unavailable("No transcript path or Codex session id was available from task_claim.")
-        raise SystemExit
-    matches = [candidate for candidate in paths if belongs_to_session(candidate)]
-    if not matches:
-        unavailable("No readable Codex rollout matched the session id from task_claim.")
-        raise SystemExit
-    path = max(matches, key=os.path.getmtime)
+// TRANSCRIPT_PATH pins one transcript, which is what the card's recompute
+// button sets. Without it, Codex writes one rollout jsonl per session under
+// ~/.codex/sessions/<date>/. The session id is bound from task_claim, so a
+// busy repo never attributes the newest *other* pane's rollout to this card.
+let file = setting('transcript', 'TRANSCRIPT_PATH');
+const session = setting('codex_session', 'CODEX_SESSION_ID')
+  || process.env.CODEX_THREAD_ID
+  || '';
+const fallbackModel = setting('codex_model', 'CODEX_HARNESS_MODEL');
+const claimedAt = setting('claimed_at', 'OVERCLICK_CLAIMED_AT');
 
-if not os.path.isfile(path) or not os.access(path, os.R_OK):
-    unavailable("The selected Codex rollout is missing or unreadable.")
-    raise SystemExit
+function modelSlug(value) {
+  if (value === '' || value === undefined || value === null) return '';
+  let out = String(value).toLowerCase().replace(new RegExp('[^a-z0-9]+', 'g'), '-');
+  while (out.startsWith('-')) out = out.slice(1);
+  while (out.endsWith('-')) out = out.slice(0, -1);
+  return out;
+}
+function rollouts(dir) {
+  let found = [];
+  let entries = [];
+  try { entries = fs.readdirSync(dir, { withFileTypes: true }); } catch (error) { return found; }
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) found = found.concat(rollouts(full));
+    else if (entry.name.startsWith('rollout-') && entry.name.endsWith('.jsonl')) found.push(full);
+  }
+  return found;
+}
+function belongsToSession(candidate) {
+  if (path.basename(candidate).includes(session)) return true;
+  let first = null;
+  try { first = parse(readLines(candidate)[0] || ''); } catch (error) { return false; }
+  if (first === null) return false;
+  const payload = first.payload || {};
+  return payload.id === session || payload.session_id === session;
+}
 
-seg = collections.defaultdict(collections.Counter)
-model, turns = model_slug(fallback_model), 0
-with open(path) as handle:
-    for line in handle:
-        try:
-            entry = json.loads(line)
-        except ValueError:
-            continue
-        if not at_or_after_claim(entry):
-            continue
-        payload = entry.get("payload") or {}
-        if entry.get("type") == "turn_context" and payload.get("model"):
-            model = model_slug(payload["model"])
-        if payload.get("type") != "token_count":
-            continue
-        # last_token_usage is this model call's delta; total_token_usage is cumulative.
-        usage = (payload.get("info") or {}).get("last_token_usage") or {}
-        if not usage:
-            continue
-        if not model:
-            unavailable("The rollout has token counters but neither it nor the card harness names a model.")
-            raise SystemExit
-        turns += 1
-        counter = seg[model]
-        cached = usage.get("cached_input_tokens", 0)
-        counter["input"] += usage.get("input_tokens", 0) - cached
-        counter["cache_read"] += cached
-        counter["cache_write"] += usage.get("cache_write_input_tokens", 0)
-        counter["output"] += usage.get("output_tokens", 0)
+if (file === '') {
+  if (session === '') {
+    unavailable('No transcript path or Codex session id was available from task_claim.');
+  }
+  const matches = rollouts(path.join(os.homedir(), '.codex', 'sessions'))
+    .filter(belongsToSession);
+  if (matches.length === 0) {
+    unavailable('No readable Codex rollout matched the session id from task_claim.');
+  }
+  file = newest(matches);
+}
+if (exists(file) === false) {
+  unavailable('The selected Codex rollout is missing or unreadable.');
+}
 
-if not turns:
-    unavailable("The Codex rollout contains no readable last_token_usage counters.")
-    raise SystemExit
+const keep = claimWindow();
+const seg = {};
+let model = modelSlug(fallbackModel);
+let turns = 0;
+for (const line of readLines(file)) {
+  const entry = parse(line);
+  if (entry === null || keep(entry) === false) continue;
+  const payload = entry.payload || {};
+  if (entry.type === 'turn_context' && payload.model) model = modelSlug(payload.model);
+  if (payload.type !== 'token_count') continue;
+  // last_token_usage is this model call's delta; total_token_usage is cumulative.
+  const usage = (payload.info || {}).last_token_usage;
+  if (usage === undefined || usage === null) continue;
+  if (model === '') {
+    unavailable('The rollout has token counters but neither it nor the card harness names a model.');
+  }
+  turns += 1;
+  const cached = usage.cached_input_tokens || 0;
+  bump(seg, model, {
+    input: (usage.input_tokens || 0) - cached,
+    cache_read: cached,
+    cache_write: usage.cache_write_input_tokens,
+    output: usage.output_tokens,
+  });
+}
 
-print(json.dumps({
-    "segments": [dict(model=model, **dict(counter)) for model, counter in seg.items()],
-    "turns": turns,
-    "transcript": path,
-    "estimated": False,
-}, indent=2))
-PY`;
+if (turns === 0) {
+  unavailable(claimedAt === ''
+    ? 'The Codex rollout contains no readable last_token_usage counters.'
+    : 'The Codex rollout contains no readable last_token_usage counters after ' + claimedAt + '.');
+}
+emit({ segments: segments(seg), turns: turns, transcript: file, estimated: false });`);
 
-const GROK_COMMAND = `python3 - <<'PY'
-import collections, datetime, glob, json, os, urllib.parse
+const GROK_COMMAND = nodeCommand(`${PRELUDE}
 
-# TRANSCRIPT_PATH pins one transcript, which is what the card's recompute
-# button sets. Without it, Grok writes one updates.jsonl per session under
-# ~/.grok/sessions/<cwd percent-encoded>/<session uuid>/.
-path = os.environ.get("TRANSCRIPT_PATH")
-claimed_at = os.environ.get("OVERCLICK_CLAIMED_AT")
-if not path:
-    root = os.path.expanduser("~/.grok/sessions")
-    folder = os.path.join(root, urllib.parse.quote(os.getcwd(), safe=""))
-    session = os.environ.get("GROK_SESSION_ID")
-    if session:
-        path = os.path.join(folder, session, "updates.jsonl")
-    else:
-        here = glob.glob(folder + "/*/updates.jsonl")
-        path = max(here or glob.glob(root + "/*/*/updates.jsonl"), key=os.path.getmtime)
+// TRANSCRIPT_PATH pins one transcript, which is what the card's recompute
+// button sets. Without it, Grok writes one updates.jsonl per session under
+// ~/.grok/sessions/<cwd percent-encoded>/<session uuid>/.
+let file = setting('transcript', 'TRANSCRIPT_PATH');
+const session = setting('grok_session', 'GROK_SESSION_ID');
 
-def at_or_after_claim(entry):
-    if not claimed_at:
-        return True
-    value = entry.get("timestamp") or entry.get("created_at") or entry.get("createdAt")
-    if value is None:
-        return False
-    try:
-        claim = datetime.datetime.fromisoformat(claimed_at.replace("Z", "+00:00"))
-        # Grok's own "timestamp" is epoch seconds, not ISO text like the
-        # other CLIs; only strings go through fromisoformat.
-        if isinstance(value, (int, float)):
-            at = datetime.datetime.fromtimestamp(value, tz=datetime.timezone.utc)
-        else:
-            at = datetime.datetime.fromisoformat(str(value).replace("Z", "+00:00"))
-        return at >= claim
-    except (ValueError, OSError, OverflowError):
-        return False
+// Grok encodes the whole working directory, separators included, the way
+// Python's quote(safe='') does: everything outside the unreserved set becomes
+// a percent escape of its utf-8 bytes.
+function encodePath(value) {
+  const safe = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._~';
+  let out = '';
+  for (const byte of Buffer.from(value, 'utf8')) {
+    const char = String.fromCharCode(byte);
+    out += (byte < 128 && safe.includes(char))
+      ? char
+      : '%' + byte.toString(16).toUpperCase().padStart(2, '0');
+  }
+  return out;
+}
+function children(dir) {
+  try { return fs.readdirSync(dir).map(name => path.join(dir, name)); } catch (error) { return []; }
+}
+function updateLogs(dir) {
+  return children(dir)
+    .map(child => path.join(child, 'updates.jsonl'))
+    .filter(exists);
+}
 
-seg, turns = collections.defaultdict(collections.Counter), 0
-for line in open(path):
-    try:
-        entry = json.loads(line)
-    except ValueError:
-        continue
-    if not at_or_after_claim(entry):
-        continue
-    update = (entry.get("params") or {}).get("update") or {}
-    if update.get("sessionUpdate") != "turn_completed":
-        continue
-    usage = update.get("usage") or {}
-    # A turn that ended on an error carries no usage. Counting it would put a
-    # row of zeros where the honest answer is that nothing was spent.
-    if not usage:
-        continue
-    turns += usage.get("numTurns") or usage.get("modelCalls", 0)
-    # modelUsage splits the turn per model, which is what a session that
-    # switched model needs; a turn without it is all one model.
-    for model, block in (usage.get("modelUsage") or {"unknown": usage}).items():
-        counter = seg[model]
-        cached = block.get("cachedReadTokens", 0)
-        # inputTokens already contains the cached read, so the plain input is
-        # what is left after taking it out.
-        counter["input"] += block.get("inputTokens", 0) - cached
-        counter["cache_read"] += cached
-        counter["cache_write"] += block.get("cacheCreationTokens", 0)
-        counter["output"] += block.get("outputTokens", 0)
+let folder = '';
+if (file === '') {
+  const root = path.join(os.homedir(), '.grok', 'sessions');
+  folder = path.join(root, encodePath(process.cwd()));
+  if (session === '') {
+    const here = updateLogs(folder);
+    const anywhere = children(root).map(updateLogs).reduce((all, some) => all.concat(some), []);
+    file = newest(here.length > 0 ? here : anywhere);
+  } else {
+    file = path.join(folder, session, 'updates.jsonl');
+  }
+}
+if (file === '') {
+  unavailable('No Grok updates.jsonl was found under ' + folder + '.');
+}
+if (exists(file) === false) {
+  unavailable('The Grok transcript ' + file + ' is missing or unreadable.');
+}
 
-print(json.dumps({
-    "segments": [dict(model=model, **dict(counter)) for model, counter in seg.items()],
-    "turns": turns,
-    "transcript": path,
-}, indent=2))
-PY`;
+const keep = claimWindow();
+const seg = {};
+let turns = 0;
+for (const line of readLines(file)) {
+  const entry = parse(line);
+  if (entry === null || keep(entry) === false) continue;
+  const update = (entry.params || {}).update || {};
+  if (update.sessionUpdate !== 'turn_completed') continue;
+  const usage = update.usage;
+  // A turn that ended on an error carries no usage. Counting it would put a
+  // row of zeros where the honest answer is that nothing was spent.
+  if (usage === undefined || usage === null) continue;
+  turns += usage.numTurns || usage.modelCalls || 0;
+  // modelUsage splits the turn per model, which is what a session that
+  // switched model needs; a turn without it is all one model.
+  const perModel = usage.modelUsage || { unknown: usage };
+  for (const model of Object.keys(perModel)) {
+    const block = perModel[model] || {};
+    const cached = block.cachedReadTokens || 0;
+    // inputTokens already contains the cached read, so the plain input is
+    // what is left after taking it out.
+    bump(seg, model, {
+      input: (block.inputTokens || 0) - cached,
+      cache_read: cached,
+      cache_write: block.cacheCreationTokens,
+      output: block.outputTokens,
+    });
+  }
+}
 
-const KIMI_COMMAND = `python3 - <<'PY'
-import collections, datetime, glob, json, os
+emit({ segments: segments(seg), turns: turns, transcript: file, estimated: false });`);
 
-# TRANSCRIPT_PATH pins one session directory, which is what the card's
-# recompute button sets. Without it, the index Kimi keeps in its home maps
-# every session to the directory it ran in, including sessions stored outside
-# that home, so it beats globbing for them.
-home = os.environ.get("KIMI_HOME") or os.path.expanduser("~/.kimi-code")
-path = os.environ.get("TRANSCRIPT_PATH")
-claimed_at = os.environ.get("OVERCLICK_CLAIMED_AT")
-if not path:
-    here, session = os.path.realpath(os.getcwd()), os.environ.get("KIMI_SESSION_ID")
-    rows = []
-    for line in open(os.path.join(home, "session_index.jsonl")):
-        try:
-            row = json.loads(line)
-        except ValueError:
-            continue
-        if not os.path.isdir(row.get("sessionDir", "")):
-            continue
-        if session and row.get("sessionId") != session:
-            continue
-        if not session and os.path.realpath(row.get("workDir", "")) != here:
-            continue
-        rows.append(row["sessionDir"])
-    path = max(rows, key=os.path.getmtime)
+const KIMI_COMMAND = nodeCommand(`${PRELUDE}
 
-# One wire log per agent: main plus every subagent it spawned, so the tokens a
-# subagent spent land on the card that spawned it instead of nowhere.
-logs = sorted(glob.glob(os.path.join(path, "agents", "*", "wire.jsonl")))
-def at_or_after_claim(entry):
-    if not claimed_at:
-        return True
-    # Kimi's wire.jsonl stamps every record with "time", not "timestamp" or
-    # any of the other CLIs' created_at/createdAt spellings.
-    value = (
-        entry.get("timestamp")
-        or entry.get("created_at")
-        or entry.get("createdAt")
-        or entry.get("time")
-    )
-    if value is None:
-        return False
-    try:
-        claim = datetime.datetime.fromisoformat(claimed_at.replace("Z", "+00:00"))
-        # "time" is epoch milliseconds, not ISO text like the other fields.
-        if isinstance(value, (int, float)):
-            at = datetime.datetime.fromtimestamp(value / 1000, tz=datetime.timezone.utc)
-        else:
-            at = datetime.datetime.fromisoformat(str(value).replace("Z", "+00:00"))
-        return at >= claim
-    except (ValueError, OSError, OverflowError):
-        return False
+// TRANSCRIPT_PATH pins one session directory, which is what the card's
+// recompute button sets. Without it, the index Kimi keeps in its home maps
+// every session to the directory it ran in, including sessions stored outside
+// that home, so it beats globbing for them.
+const home = setting('kimi_home', 'KIMI_HOME') || path.join(os.homedir(), '.kimi-code');
+let dir = setting('transcript', 'TRANSCRIPT_PATH');
+const session = setting('kimi_session', 'KIMI_SESSION_ID');
 
-seg, turns = collections.defaultdict(collections.Counter), 0
-for log in logs:
-    for line in open(log):
-        try:
-            entry = json.loads(line)
-        except ValueError:
-            continue
-        if not at_or_after_claim(entry):
-            continue
-        # Kimi writes one record per model call with usageScope "turn", and a
-        # cumulative "session" record at the end. Summing both counts the
-        # session twice.
-        if entry.get("type") != "usage.record" or entry.get("usageScope") != "turn":
-            continue
-        usage = entry.get("usage") or {}
-        turns += 1
-        counter = seg[entry.get("model") or "unknown"]
-        counter["input"] += usage.get("inputOther", 0)
-        counter["cache_read"] += usage.get("inputCacheRead", 0)
-        counter["cache_write"] += usage.get("inputCacheCreation", 0)
-        counter["output"] += usage.get("output", 0)
+function realpath(value) {
+  try { return fs.realpathSync(value); } catch (error) { return ''; }
+}
+function isDirectory(candidate) {
+  try { return fs.statSync(candidate).isDirectory(); } catch (error) { return false; }
+}
 
-print(json.dumps({
-    "segments": [dict(model=model, **dict(counter)) for model, counter in seg.items()],
-    "turns": turns,
-    "transcript": path,
-}, indent=2))
-PY`;
+if (dir === '') {
+  const here = realpath(process.cwd());
+  const rows = [];
+  let lines = [];
+  try { lines = readLines(path.join(home, 'session_index.jsonl')); } catch (error) { lines = []; }
+  for (const line of lines) {
+    const row = parse(line);
+    if (row === null) continue;
+    const sessionDir = row.sessionDir || '';
+    if (isDirectory(sessionDir) === false) continue;
+    if (session !== '' && row.sessionId !== session) continue;
+    if (session === '' && realpath(row.workDir || '') !== here) continue;
+    rows.push(sessionDir);
+  }
+  dir = newest(rows);
+}
+if (dir === '') {
+  unavailable('No Kimi session in ' + home + ' matched this repo or the session id.');
+}
+
+// One wire log per agent: main plus every subagent it spawned, so the tokens a
+// subagent spent land on the card that spawned it instead of nowhere.
+let agents = [];
+try { agents = fs.readdirSync(path.join(dir, 'agents')).sort(); } catch (error) { agents = []; }
+const logs = agents
+  .map(agent => path.join(dir, 'agents', agent, 'wire.jsonl'))
+  .filter(exists);
+if (logs.length === 0) {
+  unavailable('The Kimi session ' + dir + ' has no readable agent wire log.');
+}
+
+// Kimi's wire.jsonl stamps every record with a time field, not the timestamp or
+// created_at the other CLIs write.
+const keep = claimWindow('time');
+const seg = {};
+let turns = 0;
+for (const log of logs) {
+  for (const line of readLines(log)) {
+    const entry = parse(line);
+    if (entry === null || keep(entry) === false) continue;
+    // Kimi writes one record per model call with usageScope of turn, and a
+    // cumulative session record at the end. Summing both counts the
+    // session twice.
+    if (entry.type !== 'usage.record' || entry.usageScope !== 'turn') continue;
+    const usage = entry.usage || {};
+    turns += 1;
+    bump(seg, entry.model, {
+      input: usage.inputOther,
+      cache_read: usage.inputCacheRead,
+      cache_write: usage.inputCacheCreation,
+      output: usage.output,
+    });
+  }
+}
+
+emit({ segments: segments(seg), turns: turns, transcript: dir, estimated: false });`);
 
 const SEED: UsageRecipe[] = [
   {
@@ -358,7 +505,7 @@ const SEED: UsageRecipe[] = [
     label: "Claude Code",
     yields: "tokens_per_model",
     instructions:
-      "Run this from the repo you worked in. It reads your own session transcript from the claim boundary and prints tokens grouped by model, ready to paste into task_deliver as usage.segments. Numbers from the transcript are measured, not guessed, so deliver them without estimated. It also prints the transcript path: send it as transcript.path and the card links back to this run.",
+      "Run this from the repo you worked in. It is one node command, no heredoc and no python3, so the same line runs on macOS, Linux and Windows PowerShell. It reads your own session transcript from the claim boundary and prints tokens grouped by model, ready to paste into task_deliver as usage.segments. Numbers from the transcript are measured, not guessed, so deliver them without estimated. It also prints the transcript path: send it as transcript.path and the card links back to this run. If it comes back with estimated: true, the reason says exactly what was missing.",
     command: CLAUDE_COMMAND,
   },
   {
@@ -366,7 +513,7 @@ const SEED: UsageRecipe[] = [
     label: "Codex",
     yields: "tokens_per_model",
     instructions:
-      "At task_claim, declare the exact model from this session's --model flag (for example gpt-5.6-sol), never the generic family label gpt-5. Run this from the repo you worked in. The board binds claimed_at, the session id and harness model declared at task_claim: the command reads that exact Codex rollout only from the claim boundary, attributes each model call to turn_context.payload.model, normalizes the model slug for pricing, and falls back to the harness model only when the rollout omits it. A readable rollout returns estimated: false. Only a missing or unreadable rollout returns estimated: true with a reason. Send the printed transcript path as transcript.path so the card links back to this run.",
+      "At task_claim, declare the exact model from this session's --model flag (for example gpt-5.6-sol), never the generic family label gpt-5. Run this from the repo you worked in: it is one node command, no heredoc and no python3, so it runs on macOS, Linux and Windows PowerShell alike. The board binds claimed_at, the session id and harness model declared at task_claim: the command reads that exact Codex rollout only from the claim boundary, attributes each model call to turn_context.payload.model, normalizes the model slug for pricing, and falls back to the harness model only when the rollout omits it. A readable rollout returns estimated: false. Only a missing or unreadable rollout returns estimated: true with a reason. Send the printed transcript path as transcript.path so the card links back to this run.",
     command: CODEX_COMMAND,
   },
   {
@@ -382,7 +529,7 @@ const SEED: UsageRecipe[] = [
     label: "Grok",
     yields: "tokens_per_model",
     instructions:
-      "Run this from the repo you worked in. Grok closes every turn with a turn_completed line carrying usage.modelUsage, tokens already split per model, and this totals only entries from the claim boundary into usage.segments. inputTokens there includes the cached read, so the command subtracts it and reports input and cache_read apart, the way the board counts them. A turn that ended on an error carries no usage and is skipped, so an aborted session reports nothing instead of a row of zeros. It also prints the transcript path: send it as transcript.path and the card links back to this run.",
+      "Run this from the repo you worked in: one node command, no heredoc and no python3, so macOS, Linux and Windows PowerShell all run it. Grok closes every turn with a turn_completed line carrying usage.modelUsage, tokens already split per model, and this totals only entries from the claim boundary into usage.segments. inputTokens there includes the cached read, so the command subtracts it and reports input and cache_read apart, the way the board counts them. A turn that ended on an error carries no usage and is skipped, so an aborted session reports nothing instead of a row of zeros. It also prints the transcript path: send it as transcript.path and the card links back to this run.",
     command: GROK_COMMAND,
   },
   {
@@ -390,7 +537,7 @@ const SEED: UsageRecipe[] = [
     label: "Kimi",
     yields: "tokens_per_model",
     instructions:
-      "Run this from the repo you worked in. Kimi writes one usage.record per model call into the wire log of every agent in the session, main and subagents, and this totals only entries from the claim boundary per model for usage.segments. It reads only the records scoped to a turn: the cumulative session record at the end would count the whole run twice. The session is found through the index Kimi keeps in its home, which maps each session to the directory it ran in. It also prints the session path: send it as transcript.path and the card links back to this run.",
+      "Run this from the repo you worked in: one node command, no heredoc and no python3, so macOS, Linux and Windows PowerShell all run it. Kimi writes one usage.record per model call into the wire log of every agent in the session, main and subagents, and this totals only entries from the claim boundary per model for usage.segments. It reads only the records scoped to a turn: the cumulative session record at the end would count the whole run twice. The session is found through the index Kimi keeps in its home, which maps each session to the directory it ran in. It also prints the session path: send it as transcript.path and the card links back to this run.",
     command: KIMI_COMMAND,
   },
   {

--- a/packages/mcp-core/src/index.ts
+++ b/packages/mcp-core/src/index.ts
@@ -128,6 +128,8 @@ export {
   WriteReturnSchema,
   branchConvention,
   isTelemetryIncomplete,
+  telemetryGaps,
+  telemetryIncompleteReason,
   type Artifact,
   type BranchConvention,
   type ConfirmationStep,

--- a/packages/mcp-core/src/schemas/common.ts
+++ b/packages/mcp-core/src/schemas/common.ts
@@ -695,6 +695,38 @@ export type TelemetryUsage = {
   turns?: number;
 };
 
+/**
+ * What the delivery still owes, field by field.
+ *
+ * `telemetry_incomplete: true` on its own tells an agent that something is
+ * missing without saying what, which is a flag it can only answer by guessing.
+ * Naming the fields turns it into a fix: send turns, send duration_ms, run the
+ * recipe again.
+ */
+export function telemetryGaps(usage?: TelemetryUsage | null): string[] {
+  if (!usage) return ["usage"];
+  const hasSegments = (usage.segments?.length ?? 0) > 0;
+  const gaps: string[] = [];
+  if (!hasSegments) {
+    if (usage.tokens_in === undefined) gaps.push("tokens_in");
+    if (usage.tokens_out === undefined) gaps.push("tokens_out");
+  }
+  if (usage.duration_ms === undefined) gaps.push("duration_ms");
+  if (usage.turns === undefined) gaps.push("turns");
+  return gaps;
+}
+
+/** One line saying what is missing, or null when nothing is. */
+export function telemetryIncompleteReason(
+  usage?: TelemetryUsage | null,
+): string | null {
+  const gaps = telemetryGaps(usage);
+  if (gaps.length === 0) return null;
+  return gaps[0] === "usage"
+    ? "no usage was sent — send it with task_update, measured or estimated"
+    : `usage is missing ${gaps.join(", ")} — send them with task_update`;
+}
+
 export function isTelemetryIncomplete(usage?: TelemetryUsage | null): boolean {
   if (!usage) {
     return true;

--- a/packages/mcp-core/src/schemas/tools.ts
+++ b/packages/mcp-core/src/schemas/tools.ts
@@ -72,6 +72,8 @@ const TaskDeliverAckSchema = TaskWriteAckSchema.extend({
   delivery_warning: z.string().nullable(),
   usage_suspect: z.boolean(),
   usage_suspect_reason: z.string().nullable(),
+  /** What telemetry is still missing, when telemetry_incomplete is true. */
+  telemetry_incomplete_reason: z.string().optional(),
 });
 
 export const MissionListInputSchema = z.object({
@@ -940,6 +942,8 @@ export const TaskDeliverFullOutputSchema = z.object({
   delivery_verification: DeliveryVerificationSchema.nullable(),
   delivery_warning: z.string().nullable(),
   telemetry_incomplete: z.boolean(),
+  /** What telemetry is still missing, when telemetry_incomplete is true. */
+  telemetry_incomplete_reason: z.string().optional(),
   usage_suspect: z.boolean(),
   usage_suspect_reason: z.string().nullable(),
   /** Actionable warning returned when the delivery came without usage. */


### PR DESCRIPTION
Fecha a issue #73 (medido no Windows, plugin 0.2.6). Card OCL-135. Entra na v0.2.7 — **não mergear ainda**.

## O que estava quebrado

A receita de uso que o `task_claim` entrega no briefing era um heredoc bash alimentando `python3`. No Windows isso quebra duas vezes:

1. **heredoc não existe no PowerShell** — não há onde colar o `<<'PY'`.
2. **`python3` no PATH é o alias stub da Microsoft Store** — satisfaz `command -v`, roda, imprime "Python was not found" e sai 0 com stdout vazio. Falha silenciosa: o agente cola a receita, não recebe nada, e o card perde a telemetria sem erro nenhum.

E o slug do transcript fazia `os.getcwd().replace('/', '-')`, trocando só a barra normal. No Windows o cwd é `C:\Users\...`: o slug não batia com pasta alguma — ou, pior, o `max(glob)` achava o transcript de OUTRA sessão e atribuía o uso errado ao card.

## O que mudou

- **Toda receita (Claude Code, Codex, Grok, Kimi) virou um único `node -e "..."`.** Node é o runtime em que esses CLIs já rodam, então é o interpretador que de fato funciona — mesma lição do `runtime_works` do `install.sh` (sondar capacidade, não presença), resolvida na raiz ao não depender de python3.
- **Disciplina cross-shell testada:** o texto do script não contém aspas duplas, `$`, crase, contrabarra nem `!palavra` — exatamente os caracteres que bash, zsh e PowerShell leem diferente dentro de um argumento entre aspas. Um teste falha se alguém quebrar isso.
- **Settings do claim viram argumentos `key=value` percent-encoded** (`claimed_at=`, `codex_session=`, `codex_model=`, `transcript=`) em vez do prefixo POSIX `VAR=value comando`, que o PowerShell nem parseia. Os scripts continuam lendo `TRANSCRIPT_PATH`/`OVERCLICK_CLAIMED_AT` do ambiente, e receita **custom** (reescrita pelo workspace) mantém o prefixo antigo intacto.
- **Slug do transcript troca `/`, `\` e `:` por `-`** — `C:\Users\me\repo` → `C--Users-me-repo`, exatamente como o Claude Code nomeia a pasta.
- **`telemetry_incomplete: true` agora diz o que falta:** `telemetry_incomplete_reason` nomeia os campos que a entrega ainda deve.
- Fence do briefing perdeu o rótulo `bash` (a linha não é mais bash-only).

## Como validei

- Os 3 ports (Codex, Grok, Kimi) foram rodados contra as fixtures existentes e devolvem **números idênticos** ao python que substituíram, incluindo os recortes por `claimed_at`.
- Nova fixture anonimizada de transcript do Claude Code + testes: janela do claim, descoberta da pasta pelo slug (HOME temporário, cwd real), transcript ausente → `estimated: true` com motivo.
- Teste unitário do slug com um cwd Windows (`C:\Users\me\repo`) e um POSIX.
- Suíte completa: `pnpm -r test` → mcp-core 140, db 141, web 565 (+2 skipped), tudo verde. `pnpm typecheck` limpo.
- Plugin não foi tocado, então `test-plugin-package.sh` não se aplica.

Fixes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)