### PR TITLE
release: v0.2.7 (estabilização Windows)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "overclick",
       "description": "Claim, execute, and deliver cards on your own self-hosted OverClick board. Ships the workflow skill, the /overclick:* commands, and hooks: a session-start board snapshot and a delivery commit check run by default, while the claim guard and the stop/harness guards ship disabled. The only network endpoint is the OverClick instance you configure - no third-party calls, no telemetry.",
-      "version": "0.2.6",
+      "version": "0.2.7",
       "source": "./plugin"
     }
   ]

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "overclick",
       "description": "Claim, execute, and deliver OverClick cards.",
-      "version": "0.2.6",
+      "version": "0.2.7",
       "source": {
         "type": "local",
         "path": "./plugin"

--- a/.kimi-plugin/plugin.json
+++ b/.kimi-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "overclick",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "Run the complete OverClick card workflow from Kimi Code.",
   "homepage": "https://github.com/ustoppble/overclick",
   "license": "MIT",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-board/web",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "private": true,
   "scripts": {
     "dev": "NEXT_TELEMETRY_DISABLED=1 next dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-board",
   "private": true,
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "Self-hosted board for hybrid human+agent teams. Data never leaves the server.",
   "license": "MIT",
   "packageManager": "pnpm@9.15.9",

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-board/db",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/mcp-core/package.json
+++ b/packages/mcp-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-board/mcp-core",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "private": true,
   "description": "Pure TypeScript contracts, card state machine, and harness recommendation for the agent board MCP surface.",
   "type": "module",

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "overclick",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "Claim, execute, and deliver cards on your own self-hosted OverClick board. Ships the workflow skill, the /overclick:* commands, and hooks: a session-start board snapshot and a delivery commit check run by default, while the claim guard and the stop/harness guards ship disabled. The only network endpoint is the OverClick instance you configure - no third-party calls, no telemetry.",
   "author": {
     "name": "OverClick"

--- a/plugin/.codex-plugin/plugin.json
+++ b/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "overclick",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "Run the complete OverClick card workflow from Codex.",
   "author": {
     "name": "OverClick"

--- a/plugin/kimi.plugin.json
+++ b/plugin/kimi.plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "overclick",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "Run the complete OverClick card workflow from Kimi Code.",
   "keywords": [
     "overclick",

--- a/plugin/plugin.json
+++ b/plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "overclick",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "Run the complete OverClick card workflow from Grok CLI.",
   "author": {
     "name": "OverClick"


### PR DESCRIPTION
Bump 0.2.6→0.2.7. Leva Windows: OCL-134/#72 (guard fail-closed), OCL-136/#71 (manage capability), OCL-135/#73 (usage recipe node).