### PR TITLE
claim guard: cobrir tools de shell que nao se chamam Bash (issue #72)

### DIFF
--- a/plugin/hooks/claim-guard.mjs
+++ b/plugin/hooks/claim-guard.mjs
@@ -1,5 +1,5 @@
 import {
-  bashWrites,
+  shellWrites,
   block,
   claimMarker,
   claimMarkerValid,
@@ -20,6 +20,17 @@ import {
 const CLAIM = /^(mcp__.*__)?task_claim$/;
 const RELEASE = /^(mcp__.*__)?(task_deliver|task_release)$/;
 
+// The tools that edit a file outright, and the ones that hand a command to a
+// shell. Both lists are mirrored by the PreToolUse matcher in hooks.json: a
+// name missing there means this file never runs at all.
+//
+// Windows was the hole. Claude Code names its shell tool `PowerShell` there,
+// `Edit|Write|Bash` did not match it, and the guard silently covered nothing on
+// the shell side -- `git commit` without a claim went straight through, which
+// is exactly what the OCL-37 incident is about.
+const FILE_TOOLS = /^(Edit|Write|NotebookEdit|edit|write|write_to_file|replace_file_content|edit_notebook)$/;
+const SHELL_TOOLS = /^(Bash|bash|PowerShell|pwsh|Shell|shell|Terminal|run_command|execute_command)$/;
+
 failOpen(async () => {
   const hookInput = parseJson(readStdin()) ?? {};
   const toolName = hookTool(hookInput);
@@ -39,18 +50,10 @@ failOpen(async () => {
 
   if (!enabled("enforce_claim")) return;
 
-  switch (toolName) {
-    case "Edit":
-    case "Write":
-    case "edit":
-    case "write":
-      break;
-    case "Bash":
-    case "bash":
-      if (!bashWrites(hookCommand(hookInput))) return;
-      break;
-    default:
-      return;
+  if (SHELL_TOOLS.test(toolName)) {
+    if (!shellWrites(toolName, hookCommand(hookInput))) return;
+  } else if (!FILE_TOOLS.test(toolName)) {
+    return;
   }
 
   if (claimMarkerValid(cwd, hookSession(hookInput))) return;

--- a/plugin/hooks/common.mjs
+++ b/plugin/hooks/common.mjs
@@ -261,6 +261,47 @@ export function bashWrites(command) {
   return WRITE_COMMANDS.test(command);
 }
 
+// The same question in the other dialect. WRITE_COMMANDS still applies -- git,
+// npm and the coreutils aliases (rm, mv, cp, mkdir) are all real in PowerShell
+// -- so this only adds what is native to it: the *-Item / *-Content verbs and
+// the .NET file APIs, which no amount of coreutils vocabulary would catch.
+const PS_WRITE_COMMANDS = new RegExp(
+  "(^|[;&|(){}\\s])(" +
+    "Set-Content|Add-Content|Clear-Content|Out-File|Tee-Object|" +
+    "New-Item|Remove-Item|Move-Item|Copy-Item|Rename-Item|" +
+    "New-ItemProperty|Set-ItemProperty|Remove-ItemProperty|Rename-ItemProperty|" +
+    "Export-Csv|Export-Clixml|Export-ModuleMember|Set-Acl|" +
+    "New-Item[A-Za-z]*|Write-EventLog" +
+    ")([;&|(){}\\s]|$)" +
+    // Invoke-WebRequest is a read until -OutFile turns it into a download.
+    "|(^|[;&|(){}\\s])(Invoke-WebRequest|Invoke-RestMethod|curl|wget)\\b[^;&|]*-OutFile" +
+    // [System.IO.File]::WriteAllText(...) and friends, short form included.
+    "|\\[\\s*(System\\.)?IO\\.(File|Directory|FileInfo|DirectoryInfo)\\s*\\]\\s*::" +
+    "\\s*(Write|Append|Create|Delete|Move|Copy|Replace|Encrypt|Decrypt|SetAttributes)",
+  "i",
+);
+
+export function powershellWrites(command) {
+  if (!command) return false;
+  // PowerShell discards to $null, not /dev/null, and `2>&1` is a merge rather
+  // than a write. Strip both before asking about redirection.
+  const withoutDiscards = command
+    .replace(/[0-9]*>>?\s*\$null/gi, "")
+    .replace(/[0-9]*>&[0-9]+/g, "");
+  if (REDIRECTION.test(withoutDiscards)) return true;
+  if (PS_WRITE_COMMANDS.test(command)) return true;
+  return WRITE_COMMANDS.test(command);
+}
+
+// Which dialect to ask. An unknown shell tool is NOT assumed harmless: the
+// vocabulary check is a heuristic either way, so the wider of the two runs.
+// This is still an allowlist by tool name -- see SHELL_TOOLS in claim-guard.
+export function shellWrites(toolName, command) {
+  return /^bash$/i.test(toolName ?? "")
+    ? bashWrites(command)
+    : powershellWrites(command);
+}
+
 // A hook that throws is a hook that fails closed on the wrong side: Claude Code
 // prints the stack trace and the guard decision is lost. Every entrypoint wraps
 // its body with this.

--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -64,7 +64,7 @@
         ]
       },
       {
-        "matcher": "Edit|Write|Bash",
+        "matcher": "Edit|Write|NotebookEdit|Bash|PowerShell|Shell|Terminal|run_command|execute_command|write_to_file|replace_file_content|edit_notebook",
         "hooks": [
           {
             "type": "command",


### PR DESCRIPTION
Fecha a #72. Escrito e medido na bancada onde o furo aparece: Windows 11, Claude Code, PowerShell 5.1, plugin 0.2.6.

## O furo

Com `enforce_claim=1`, o guard bloqueava `Edit`/`Write` e deixava passar **toda** mutação de shell — inclusive um commit. O operador liga a flag, vê o `Write` sendo barrado, conclui que está protegido, e o caminho mais poderoso segue aberto.

Duas causas independentes, cada uma suficiente sozinha:

- `hooks.json` casava `Edit|Write|Bash` no `PreToolUse`. O tool no Windows se chama `PowerShell`; o hook **nem era invocado**.
- `claim-guard.mjs` fazia `switch` em `"Bash"`/`"bash"` e caía em `default: return`. Teria passado mesmo se invocado.

E uma terceira que apareceria em seguida: `bashWrites()` é vocabulário POSIX. Conhece `git commit`; nunca ouviu falar de `Set-Content`, `Out-File` ou `[System.IO.File]::WriteAllText`.

## O que mudou

**`hooks.json`** — o matcher passa a nomear os tools de edição e os de shell juntos, incluindo `NotebookEdit`, que também estava descoberto.

**`claim-guard.mjs`** — duas listas explícitas, `FILE_TOOLS` e `SHELL_TOOLS`, espelhando o matcher. O comentário registra o acoplamento: **um nome que falte no `hooks.json` faz este arquivo nunca rodar** — foi exatamente isso que tornou o furo invisível.

**`common.mjs`** — `powershellWrites()` novo, e `shellWrites(toolName, command)` para escolher o dialeto. O novo cobre os verbos `*-Item` / `*-Content`, download com `-OutFile`, redirecionamento (descartando `$null` em vez do descarte POSIX) e as APIs `[System.IO.*]::` de escrita. O `WRITE_COMMANDS` continua rodando por baixo — `git`, `npm` e os aliases de coreutils são reais no PowerShell também.

**`bashWrites()` não foi tocado.** O comportamento em POSIX é byte-idêntico, e há casos na bateria assertando isso.

## Medição

Ponta a ponta, com a flag ligada e restaurada na mesma rodada:

| caso | antes | depois |
|---|---|---|
| `PowerShell` → `mkdir novapasta`, sem claim | passava | **bloqueia** |
| `PowerShell` → `git status --short` | passava | passa |
| `Write`, sem claim | bloqueava | bloqueia |

Bloqueio com a mensagem literal do `block()`: `{"decision":"block","reason":"claima um card no board antes: task_claim {id}"}`.

Mais 39 casos de vocabulário — 20 mutações do PowerShell que devem bloquear, 9 leituras que **não** podem bloquear (`Get-Content`, `Test-Path`, `[System.IO.File]::ReadAllText`, `git log -1 2>$null`, …) e 5 travando o comportamento do `bashWrites`. 0 falhas. `node --check` limpo nos dois `.mjs`, `hooks.json` valida como JSON.

## O que isto NÃO conserta

Continua sendo **allowlist por nome de tool**. Um harness cujo shell se chame outra coisa segue passando — o mesmo formato de bug, só com outro nome.

Fechar isso de verdade significa decidir **dentro** do hook em vez de no matcher: casar `*` no `PreToolUse` e tratar tool desconhecido como potencialmente mutante. O custo é um processo `node` por tool call, e essa é uma troca que é sua, não minha. Por isso deixei a allowlist explícita num comentário em vez de implícita num regex.

Se preferir esse caminho, eu faço a segunda versão — é uma mudança pequena por cima desta.

## Notas

- Não rodei em Linux/macOS; não tenho bancada. O `bashWrites` intocado deveria manter a suíte verde, mas vale confirmar antes do merge.
- Não mexi na suíte `scripts/test-plugin-package.sh` — se quiser os 39 casos lá dentro em vez de num script solto, eu porto.
- A #71 eu não peguei: precisa de coluna nova em `pairing_code` e migração. Dimensionamento nos comentários de lá.
