### PR TITLE
[OCL-137] wizard: setup commands that run in bash and PowerShell alike

### DIFF
--- a/apps/web/src/app/onboarding/commands.test.ts
+++ b/apps/web/src/app/onboarding/commands.test.ts
@@ -1,0 +1,110 @@
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { commandFor } from "./commands";
+
+const URL = "https://board.example/api/mcp";
+const SECRET = "ocb_deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
+const RUNNABLE = ["claude-code", "codex", "gemini-cli"];
+
+/**
+ * The command is copied into a terminal we do not control: it may be bash or
+ * PowerShell. These are the constructs that only work in one of them.
+ */
+describe.each(RUNNABLE)("commandFor(%s)", (cli) => {
+  const command = commandFor(cli, URL, SECRET);
+
+  it("is a single line, because a trailing backslash means nothing in PowerShell", () => {
+    expect(command).not.toContain("\n");
+    expect(command).not.toContain("\\");
+  });
+
+  it("uses no heredoc, no ~ and no cat >>, which PowerShell does not have", () => {
+    expect(command).not.toContain("<<");
+    expect(command).not.toContain("~");
+    expect(command).not.toContain("cat >>");
+  });
+
+  it("carries nothing either shell would expand inside double quotes", () => {
+    // `$` expands in both; the backtick is command substitution in bash and
+    // the escape character in PowerShell.
+    expect(command).not.toContain("$");
+    expect(command).not.toContain("`");
+    // `!` is history expansion in an interactive bash, even inside quotes.
+    expect(command).not.toContain("!");
+  });
+
+  it("carries the instance and the token", () => {
+    expect(command).toContain(URL);
+    expect(command).toContain(SECRET);
+  });
+});
+
+describe("commandFor(claude-code) / commandFor(gemini-cli)", () => {
+  it("adds the remote server in one `mcp add` call with the auth header", () => {
+    expect(commandFor("claude-code", URL, SECRET)).toBe(
+      `claude mcp add --transport http overclick ${URL} --header "Authorization: Bearer ${SECRET}"`,
+    );
+    expect(commandFor("gemini-cli", URL, SECRET)).toBe(
+      `gemini mcp add --transport http overclick ${URL} --header "Authorization: Bearer ${SECRET}"`,
+    );
+  });
+});
+
+describe("commandFor(codex)", () => {
+  // `codex mcp add` has no --header flag, so the config.toml is written
+  // directly — by node, not by a bash heredoc.
+  const command = commandFor("codex", URL, SECRET);
+
+  it("is a node one-liner, not a shell built-in", () => {
+    expect(command.startsWith('node -e "')).toBe(true);
+    expect(command.endsWith('"')).toBe(true);
+  });
+
+  /** Runs the emitted script the way a shell would, against a fake CODEX_HOME. */
+  function run(home: string): string {
+    const script = command.slice('node -e "'.length, -1);
+    execFileSync(process.execPath, ["-e", script], {
+      env: { ...process.env, CODEX_HOME: home },
+      stdio: "pipe",
+    });
+    return readFileSync(join(home, "config.toml"), "utf8");
+  }
+
+  it("writes the overclick server into CODEX_HOME/config.toml", () => {
+    const written = run(mkdtempSync(join(tmpdir(), "codex-")));
+
+    expect(written).toContain("[mcp_servers.overclick]");
+    expect(written).toContain(`url = "${URL}"`);
+    expect(written).toContain(
+      `http_headers = { Authorization = "Bearer ${SECRET}" }`,
+    );
+  });
+
+  it("keeps whatever else the config already held", () => {
+    const home = mkdtempSync(join(tmpdir(), "codex-"));
+    writeFileSync(join(home, "config.toml"), 'model = "gpt-5"\n');
+
+    expect(run(home)).toContain('model = "gpt-5"');
+  });
+
+  it("replaces its own block instead of appending a second one", () => {
+    const home = mkdtempSync(join(tmpdir(), "codex-"));
+    run(home);
+    const written = run(home);
+
+    expect(written.split("[mcp_servers.overclick]").length - 1).toBe(1);
+    expect(written.split("# overclick:start").length - 1).toBe(1);
+  });
+});
+
+describe("commandFor(anything else)", () => {
+  it("is a comment block, which `#` opens in bash and PowerShell alike", () => {
+    const lines = commandFor("outro", URL, SECRET).split("\n");
+
+    expect(lines.every((line) => line.startsWith("#"))).toBe(true);
+    expect(lines.join("\n")).toContain(`Authorization: Bearer ${SECRET}`);
+  });
+});

--- a/apps/web/src/app/onboarding/commands.ts
+++ b/apps/web/src/app/onboarding/commands.ts
@@ -1,0 +1,79 @@
+/**
+ * The setup command the wizard shows for each CLI.
+ *
+ * Whatever we print here gets copied into a terminal we cannot see: it may be
+ * bash, zsh, cmd or PowerShell, and the wizard has no way to know which. So
+ * every command below is written to run, unchanged, in all of them. In
+ * practice that means three rules:
+ *
+ *   1. ONE line. A trailing `\` continues a line in bash and means nothing in
+ *      PowerShell, so a pasted multi-line block errors out there.
+ *   2. No heredoc, no `~`, no `cat >>`. PowerShell has none of them.
+ *   3. Inside the double quotes, no `$` and no backtick — PowerShell expands
+ *      both, bash expands `$`. Our own values (an https URL and an
+ *      `ocb_<hex>` token) never contain them, and `assertCrossShell` below
+ *      keeps it that way.
+ *
+ * Codex is the awkward one: `codex mcp add` has no `--header` flag (it errors
+ * out on it), and a remote server carries its Authorization in
+ * `~/.codex/config.toml`, which is what the CLI reads back. Where this used to
+ * be a bash heredoc, it is now a single `node -e` — node is already on the
+ * machine of anyone who has these CLIs, and the same line runs in bash and in
+ * PowerShell. It is also idempotent: it rewrites the `# overclick:` block
+ * instead of appending a second one, matching what install.sh does.
+ */
+
+/** Characters a shell would eat before the command ever reaches the CLI. */
+const SHELL_HOSTILE = /[$`\\]/;
+
+function assertCrossShell(command: string): string {
+  if (SHELL_HOSTILE.test(command)) {
+    throw new Error(`onboarding command is not cross-shell: ${command}`);
+  }
+  return command;
+}
+
+const codexScript = (baseUrl: string, secret: string) => [
+  "const fs=require('fs'),os=require('os'),path=require('path');",
+  "const nl=String.fromCharCode(10),q=String.fromCharCode(34);",
+  "const dir=process.env.CODEX_HOME||path.join(os.homedir(),'.codex');",
+  "const file=path.join(dir,'config.toml');",
+  "fs.mkdirSync(dir,{recursive:true});",
+  "let kept=[],skip=false;",
+  "try{kept=fs.readFileSync(file,'utf8').split(nl).filter(line=>{",
+  "const t=line.trim();",
+  "if(t==='# overclick:start'){skip=true;return false}",
+  "if(t==='# overclick:end'){skip=false;return false}",
+  "return skip===false})}catch(e){}",
+  "while(kept.length>0&&kept[kept.length-1].trim()===''){kept.pop()}",
+  "if(kept.length>0){kept.push('')}",
+  "kept.push('# overclick:start','[mcp_servers.overclick]',",
+  `'url = '+q+'${baseUrl}'+q,`,
+  `'http_headers = { Authorization = '+q+'Bearer ${secret}'+q+' }',`,
+  "'# overclick:end','');",
+  "fs.writeFileSync(file,kept.join(nl));",
+  // 384 is 0600: the file now holds a bearer token. chmod is a no-op on
+  // Windows, hence the try.
+  "try{fs.chmodSync(file,384)}catch(e){}",
+  "console.log('overclick configured in '+file)",
+].join("");
+
+export function commandFor(cli: string, baseUrl: string, secret: string): string {
+  const header = `--header "Authorization: Bearer ${secret}"`;
+  switch (cli) {
+    case "claude-code":
+      return assertCrossShell(
+        `claude mcp add --transport http overclick ${baseUrl} ${header}`,
+      );
+    case "codex":
+      return assertCrossShell(`node -e "${codexScript(baseUrl, secret)}"`);
+    case "gemini-cli":
+      return assertCrossShell(
+        `gemini mcp add --transport http overclick ${baseUrl} ${header}`,
+      );
+    default:
+      // Not a command: `#` opens a comment in bash and in PowerShell alike, so
+      // pasting it is harmless in either.
+      return `# generic MCP over HTTP\n# url:    ${baseUrl}\n# header: Authorization: Bearer ${secret}`;
+  }
+}

--- a/apps/web/src/app/onboarding/wizard.tsx
+++ b/apps/web/src/app/onboarding/wizard.tsx
@@ -22,6 +22,7 @@ import {
   type PluginPairing,
 } from "../../components/plugin-install";
 import { dict } from "../../lib/i18n";
+import { commandFor } from "./commands";
 
 type ProjectData = {
   name: string;
@@ -36,23 +37,6 @@ const CMD_TABS = [
   { id: "gemini-cli", label: "Gemini" },
   { id: "outro", label: "Other" },
 ] as const;
-
-function commandFor(cli: string, baseUrl: string, secret: string): string {
-  const header = `--header "Authorization: Bearer ${secret}"`;
-  switch (cli) {
-    case "claude-code":
-      return `claude mcp add --transport http overclick \\\n  ${baseUrl} \\\n  ${header}`;
-    case "codex":
-      // `codex mcp add` takes no --header: the flag does not exist, and the
-      // command errors out on it. A remote server carries its Authorization in
-      // config.toml, which is exactly what the CLI reads back.
-      return `cat >> ~/.codex/config.toml <<'TOML'\n[mcp_servers.overclick]\nurl = "${baseUrl}"\nhttp_headers = { Authorization = "Bearer ${secret}" }\nTOML`;
-    case "gemini-cli":
-      return `gemini mcp add --transport http overclick ${baseUrl} \\\n  ${header}`;
-    default:
-      return `# generic MCP over HTTP\n# url:    ${baseUrl}\n# header: Authorization: Bearer ${secret}`;
-  }
-}
 
 export function Wizard({
   host,


### PR DESCRIPTION
## O quê

`commandFor()` no onboarding emitia comandos bash-only: `claude`/`gemini mcp add` quebrados em várias linhas com `\` no fim (PowerShell não entende continuação com barra, ele usa backtick) e o Codex como heredoc `cat >> ~/.codex/config.toml <<'TOML'` (PowerShell não tem heredoc, nem `~` expandido, nem `cat >>` equivalente). Quem faz onboarding no Windows tomava erro de sintaxe no primeiro passo.

## Decisão de design: uma forma só, que roda nos dois shells

Sem aba PowerShell vs bash, sem detecção de OS — o wizard não sabe em que terminal o texto vai ser colado, e uma variante errada é pior que nenhuma. Regras que os três comandos respeitam: **uma linha**, sem heredoc/`~`/`cat >>`, e nada que qualquer um dos dois shells expanda dentro de aspas duplas (`$`, backtick, `\`, `!`). `assertCrossShell()` valida isso na saída.

- **claude:** `claude mcp add --transport http overclick <URL> --header "Authorization: Bearer <token>"`
- **gemini:** idem, com `gemini`
- **codex:** `node -e "..."` — `codex mcp add` não tem `--header`, então o servidor remoto tem que ir pro `config.toml`. O `node -e` é a mesma saída que a usage recipe do board já usa (OCL-135). Ele respeita `CODEX_HOME`, cria o diretório, **reescreve** o próprio bloco `# overclick:` em vez de anexar um segundo (idempotente, igual ao install.sh) e faz chmod 600 onde isso significa algo.
- **outro:** bloco de comentário — `#` abre comentário em bash e em PowerShell.

`commandFor` saiu do client component para `onboarding/commands.ts`, para poder ser testado.

## Como confirmo

- `apps/web/src/app/onboarding/commands.test.ts` (18 testes): as regras cross-shell por CLI + o script do Codex **executado** contra um `CODEX_HOME` temporário (escreve, preserva o resto do config, não duplica em re-run).
- Suíte do web: `pnpm --filter @agent-board/web test` → 64 arquivos, 586 testes, verde.
- Execução real: os três comandos rodados em bash (arg splitting correto, config.toml final com 0600) e em **PowerShell 7.4** (container `mcr.microsoft.com/powershell`), que tokenizou o one-liner do Codex byte-a-byte idêntico.
- POSIX sem regressão: mesma `mcp add`, só que numa linha.

Sem merge — pro dono revisar e bundlar na próxima release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)