### PR TITLE
fix: pnpm typecheck passa em clone limpo, sem build prévio

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -6,7 +6,7 @@
     "dev": "NEXT_TELEMETRY_DISABLED=1 next dev",
     "build": "NEXT_TELEMETRY_DISABLED=1 next build",
     "start": "NEXT_TELEMETRY_DISABLED=1 next start --hostname 0.0.0.0 --port 3000",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc -p tsconfig.typecheck.json",
     "test": "vitest run"
   },
   "dependencies": {

--- a/apps/web/tsconfig.typecheck.json
+++ b/apps/web/tsconfig.typecheck.json
@@ -1,0 +1,16 @@
+{
+  // `tsc --noEmit` do app, e so isso. Existe separado do tsconfig.json porque o Next
+  // le tsconfig.json e transforma `paths` em alias do bundler: apontar
+  // @agent-board/mcp-core para o src la faria o `next build` resolver o pacote pelo
+  // codigo-fonte e quebrar nos imports com extensao .js do Node16.
+  // Aqui o path so vale para o typecheck, que assim roda em clone limpo, antes de
+  // qualquer `pnpm build` ter gerado packages/mcp-core/dist.
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "incremental": false,
+    "paths": {
+      "@/*": ["./src/*"],
+      "@agent-board/mcp-core": ["../../packages/mcp-core/src/index.ts"]
+    }
+  }
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -11,6 +11,11 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noUncheckedIndexedAccess": true,
-    "noEmit": true
+    "noEmit": true,
+    // mcp-core publica tipos so em dist/, gerado por `pnpm build`. Sem este path um
+    // clone limpo falha o typecheck com TS2307 antes de qualquer build.
+    "paths": {
+      "@agent-board/mcp-core": ["./packages/mcp-core/src/index.ts"]
+    }
   }
 }


### PR DESCRIPTION
## O problema

Em um clone limpo, o caminho do CONTRIBUTING (`git clone` → `pnpm install` → typecheck) quebra:

```
packages/db typecheck: src/domain/cardapio.ts(1,41): error TS2307:
  Cannot find module '@agent-board/mcp-core' or its corresponding type declarations.
```

E, com `--no-bail`, `apps/web` cai igual — ~40 erros: `TS2307` em todo import de
`@agent-board/mcp-core`, mais `TS7006`/`TS18046` em cascata, onde a perda dos tipos
derruba a inferência.

**Causa:** `packages/mcp-core` expõe tipos só por `dist/index.d.ts`, gerado por
`pnpm build`. O script `typecheck` é `tsc --noEmit` puro, sem nenhuma dependência de
build — então, sem `dist/`, o resolver não acha nada. Compare com `@agent-board/db`,
cujo `exports` aponta direto para `./src/index.ts` e por isso nunca sofre disso.

**Por que o CI está verde:** `.github/workflows/ci.yml` roda `pnpm build` antes de
`pnpm -r --if-present typecheck`. Nada de errado com o código; quem sente é quem clona
o repo pela primeira vez.

## A correção

Mapear o pacote para o próprio `src` via `paths` do TypeScript. Só afeta o `tsc`,
não mexe em resolução de runtime.

- **`tsconfig.base.json`** — `paths` para `@agent-board/mcp-core`. Resolve `packages/db`
  e qualquer pacote futuro que estenda a base.
- **`apps/web/tsconfig.typecheck.json`** (novo) + `"typecheck": "tsc -p tsconfig.typecheck.json"` —
  o path **não pode** ir no `apps/web/tsconfig.json`: o Next transforma `paths` em alias
  do bundler, e aí o `next build` passa a resolver `mcp-core` pelo código-fonte e quebra
  em série nos imports com extensão `.js` do Node16. Verifiquei na prática antes de
  separar. Num arquivo à parte, só o `tsc` lê. O `next build` continua vendo `dist/`,
  que já existe naquele ponto porque o pnpm respeita a ordem topológica.

## Verificação

Tudo abaixo com `packages/mcp-core/dist/` e `apps/web/.next/` apagados:

- `pnpm -r --if-present --no-bail typecheck` → verde nos 3 projetos (antes: 2 falhavam)
- `pnpm -r --if-present build` → verde
- `pnpm --filter @agent-board/mcp-core --filter @agent-board/db test` → verde (142 testes em db)

Não rodei a suíte de `apps/web` (precisa do Postgres do CI).

## Nota sobre a convenção

O CONTRIBUTING pede card ID em branch/commit/título (`[OCL-###]`). Não tenho card para
este achado — se quiser, abro um no board e renomeio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BWQEKg5E8R66cXZFFEGmp2