### PR TITLE
[OCL-166] reuso de sessão só é suspeito quando as janelas se cruzam

### DIFF
--- a/apps/web/src/mcp/tools.integration.test.ts
+++ b/apps/web/src/mcp/tools.integration.test.ts
@@ -1304,7 +1304,7 @@ describe("MCP tool edge cases against a test db", () => {
     });
   });
 
-  it("keeps plausible usage trusted and flags a second card reusing its session", async () => {
+  it("keeps plausible usage trusted when the same session delivers two cards back to back", async () => {
     world = await createTestWorld();
     const createCard = async (title: string) => {
       const created = await invokeTool(world.db, ctx(), "task_create", {
@@ -1321,8 +1321,11 @@ describe("MCP tool edge cases against a test db", () => {
     };
     const first = await createCard("Primeiro card da sessao");
     const second = await createCard("Segundo card da sessao");
-    const sessionId = "reused-executor-session";
+    const sessionId = "sequential-executor-session";
 
+    // Sequential: the second card is claimed only after the first is
+    // delivered, so the two execution windows never touch — reusing the
+    // session here cannot double-count anything.
     await invokeTool(world.db, ctx(), "task_claim", {
       task_id: first.id,
       executor: { cli: "codex", model: "gpt-5.6-sol", session_id: sessionId },
@@ -1350,15 +1353,89 @@ describe("MCP tool edge cases against a test db", () => {
     expect(secondDelivery.ok).toBe(true);
     if (!secondDelivery.ok) return;
     const out = TaskDeliverOutputSchema.parse(secondDelivery.value);
-    expect(out.usage_suspect).toBe(true);
-    expect(out.usage_suspect_reason).toContain("session_reused");
+    expect(out.usage_suspect).toBe(false);
+    expect(out.usage_suspect_reason).toBeNull();
 
     const [stored] = await world.db
       .select()
       .from(executionAttempt)
       .where(eq(executionAttempt.taskId, second.id));
     expect(stored?.sessionId).toBe(sessionId);
-    expect(stored?.usageSuspect).toBe(true);
+    expect(stored?.usageSuspect).toBe(false);
+  });
+
+  it("flags both cards when the same session's execution windows overlap", async () => {
+    world = await createTestWorld();
+    const createCard = async (title: string) => {
+      const created = await invokeTool(world.db, ctx(), "task_create", {
+        project_id: world.projectId,
+        title,
+        type: "feature",
+        o_que: "Um card pequeno.",
+        por_que: "Cobrir a guarda de sessao.",
+        como_confirmo: [{ step: "entrega", expected: "usage classificado" }],
+        origem,
+      });
+      if (!created.ok) throw new Error(created.error.message);
+      return TaskCreateOutputSchema.parse(created.value).task;
+    };
+    const first = await createCard("Primeiro card da sessao sobreposta");
+    const second = await createCard("Segundo card da sessao sobreposta");
+    const sessionId = "overlapping-executor-session";
+
+    // Overlapping: the second card is claimed before the first is
+    // delivered, so both cards' windows cover a shared stretch of time.
+    await invokeTool(world.db, ctx(), "task_claim", {
+      task_id: first.id,
+      executor: { cli: "codex", model: "gpt-5.6-sol", session_id: sessionId },
+    });
+    await invokeTool(world.db, ctx(), "task_claim", {
+      task_id: second.id,
+      executor: { cli: "codex", model: "gpt-5.6-sol", session_id: sessionId },
+    });
+
+    const firstDelivery = await invokeTool(world.db, ctx(), "task_deliver", {
+      task_id: first.id,
+      summary: "primeiro",
+      usage: { tokens_in: 2_000, tokens_out: 500, duration_ms: 60_000, turns: 3 },
+    });
+    expect(firstDelivery.ok).toBe(true);
+    if (!firstDelivery.ok) return;
+    // The first delivery has no earlier finished attempt to overlap with yet.
+    expect(TaskDeliverOutputSchema.parse(firstDelivery.value).usage_suspect).toBe(
+      false,
+    );
+
+    const secondDelivery = await invokeTool(world.db, ctx(), "task_deliver", {
+      task_id: second.id,
+      summary: "segundo",
+      usage: { tokens_in: 1_000, tokens_out: 200, duration_ms: 60_000, turns: 2 },
+    });
+    expect(secondDelivery.ok).toBe(true);
+    if (!secondDelivery.ok) return;
+    const out = TaskDeliverOutputSchema.parse(secondDelivery.value);
+    expect(out.usage_suspect).toBe(true);
+    expect(out.usage_suspect_reason).toContain("session_reused");
+
+    const [firstAttempt] = await world.db
+      .select()
+      .from(executionAttempt)
+      .where(eq(executionAttempt.taskId, first.id));
+    const [secondAttempt] = await world.db
+      .select()
+      .from(executionAttempt)
+      .where(eq(executionAttempt.taskId, second.id));
+
+    // Both sides of the overlap are marked, and each names the attempt it
+    // overlapped with.
+    expect(firstAttempt?.usageSuspect).toBe(true);
+    expect(firstAttempt?.usageSuspectReason).toContain(
+      `session_reused:${secondAttempt?.id}`,
+    );
+    expect(secondAttempt?.usageSuspect).toBe(true);
+    expect(secondAttempt?.usageSuspectReason).toContain(
+      `session_reused:${firstAttempt?.id}`,
+    );
   });
 
   it("persists how_to_verify on the handoff and restarts validation ticks", async () => {

--- a/apps/web/src/mcp/tools.ts
+++ b/apps/web/src/mcp/tools.ts
@@ -81,6 +81,7 @@ import {
   inArray,
   isNotNull,
   isNull,
+  lt,
   ne,
   or,
   sql,
@@ -4046,12 +4047,10 @@ async function applyUsageToLatestAttempt(
       sessionId: executor.session_id,
     })?.sessionId ??
     null;
+  const attemptFinishedAt = attempt.finishedAt ?? new Date();
   const measuredWindowMs =
     attempt.serverDurationMs ??
-    Math.max(
-      0,
-      (attempt.finishedAt ?? new Date()).getTime() - attempt.startedAt.getTime(),
-    );
+    Math.max(0, attemptFinishedAt.getTime() - attempt.startedAt.getTime());
   const guard = await usageGuardForAttempt(
     db,
     workspaceId,
@@ -4060,6 +4059,8 @@ async function applyUsageToLatestAttempt(
     sessionId,
     merged,
     measuredWindowMs,
+    attempt.startedAt,
+    attemptFinishedAt,
   );
   const prices = await loadModelPrices(db as PricesDb, workspaceId);
   const assessment = assessAttemptCost(merged.segments ?? [], prices, {
@@ -4504,6 +4505,8 @@ async function taskDeliver(
             sessionId,
             usageForCost,
             serverDurationMs,
+            openAttempt.startedAt,
+            finishedAt,
           )
         : { suspect: false, reason: null };
     const prices = await loadModelPrices(tx as PricesDb, ctx.workspaceId);
@@ -5577,7 +5580,11 @@ async function latestUsageGuardForTask(
 /**
  * The server-side guard is advisory, never a delivery veto. It compares the
  * report with the server's claim window and checks whether this exact executor
- * session had already completed a different card in the same workspace.
+ * session had already completed a different card in the same workspace whose
+ * execution window overlaps this one. The usage recipe counts from each
+ * card's own claimed_at, so two cards worked back to back by the same session
+ * measure disjoint stretches of work and cannot double-count anything —
+ * only an actual overlap can.
  */
 async function usageGuardForAttempt(
   db: McpDatabase,
@@ -5587,14 +5594,17 @@ async function usageGuardForAttempt(
   sessionId: string | null,
   usage: UsageReport,
   measuredWindowMs: number,
+  startedAt: Date,
+  finishedAt: Date,
 ): Promise<UsageGuard> {
   const window = checkUsageWindow(usage, measuredWindowMs);
   let reusedSession = false;
+  let overlappingAttemptIds: string[] = [];
   let orchestrationReuse = false;
 
   if (sessionId) {
-    const [previous] = await db
-      .select({ id: executionAttempt.id })
+    const overlapping = await db
+      .select({ id: executionAttempt.id, usageSuspectReason: executionAttempt.usageSuspectReason })
       .from(executionAttempt)
       .innerJoin(task, eq(executionAttempt.taskId, task.id))
       .innerJoin(project, eq(task.projectId, project.id))
@@ -5605,10 +5615,30 @@ async function usageGuardForAttempt(
           isNotNull(executionAttempt.finishedAt),
           ne(executionAttempt.id, attemptId),
           ne(executionAttempt.taskId, taskId),
+          lt(executionAttempt.startedAt, finishedAt),
+          gt(executionAttempt.finishedAt, startedAt),
         ),
-      )
-      .limit(1);
-    reusedSession = Boolean(previous);
+      );
+    reusedSession = overlapping.length > 0;
+    overlappingAttemptIds = overlapping.map((row) => row.id);
+
+    if (reusedSession) {
+      // The other side of the overlap never got a chance to know about this
+      // attempt when it was delivered, so it is marked retroactively here —
+      // the same both-sides pattern markOrchestrationSessionReuse uses below.
+      for (const other of overlapping) {
+        await db
+          .update(executionAttempt)
+          .set({
+            usageSuspect: true,
+            usageSuspectReason: addUsageSuspectReason(
+              other.usageSuspectReason,
+              `session_reused:${attemptId}`,
+            ),
+          })
+          .where(eq(executionAttempt.id, other.id));
+      }
+    }
 
     const orchestrationAttempts = await db
       .select({
@@ -5647,7 +5677,9 @@ async function usageGuardForAttempt(
 
   const reasons = [
     ...(window.suspect ? ["claim_window_exceeded"] : []),
-    ...(reusedSession ? ["session_reused"] : []),
+    ...(reusedSession
+      ? [`session_reused:${overlappingAttemptIds.join("+")}`]
+      : []),
     ...(orchestrationReuse ? ["session_reused_orchestration"] : []),
   ];
   return {

--- a/scripts/ocl-166-backfill-usage-suspect-overlap.ts
+++ b/scripts/ocl-166-backfill-usage-suspect-overlap.ts
@@ -1,0 +1,275 @@
+/**
+ * OCL-166 — the `usage_suspect` mark from session reuse only applies when
+ * execution windows overlap.
+ *
+ * usage_suspect and usage_suspect_reason are written once, at delivery time,
+ * by usageGuardForAttempt (apps/web/src/mcp/tools.ts). Before this card, the
+ * session_reused component fired whenever ANY other finished attempt shared
+ * the same session_id, with no regard for whether the two execution windows
+ * ever actually touched. The usage recipe counts from each card's own
+ * claimed_at, so two cards worked back to back by the same session measure
+ * disjoint stretches of work and cannot double-count anything — only an
+ * actual overlap can. Measured in production on 2026-09-01: of 293 attempts
+ * carrying the session_reused component, only 112 have a window that truly
+ * crosses another attempt of the same session.
+ *
+ * This script recomputes only the SESSION-REUSE half of the mark: for every
+ * finished attempt that has a session_id, it looks at every other finished
+ * attempt in the same workspace and session (excluding attempts of the same
+ * task — those are re-executions of the same card, not reuse across cards)
+ * and checks interval overlap: started_at < other.finished_at AND
+ * other.started_at < finished_at. When at least one overlaps, the attempt
+ * gets `session_reused:<id1>+<id2>...` naming every attempt it overlaps
+ * with; otherwise the session_reused component is dropped. Because the old
+ * rule never marked the earlier side of a pair retroactively, this backfill
+ * can both remove the mark from disjoint pairs AND add it to a first
+ * attempt that overlaps a later one and had never been touched before.
+ * claim_window_exceeded and session_reused_orchestration are carried over
+ * untouched — orchestration reuse is out of scope, the overlap there is the
+ * rule rather than the exception.
+ *
+ * Usage:
+ *   tsx scripts/ocl-166-backfill-usage-suspect-overlap.ts            # dry run (default)
+ *   tsx scripts/ocl-166-backfill-usage-suspect-overlap.ts --apply    # writes to prod
+ */
+import { execFileSync } from "node:child_process";
+
+const SSH_HOST = "gt40"; // alias from ~/.ssh/config — never the real address
+const CONTAINER = "overclick-overclick-db-1";
+const DB_USER = "overclick";
+const DB_NAME = "overclick";
+
+type AttemptRow = {
+  id: string;
+  task_id: string;
+  task_short_id: string;
+  workspace_id: string;
+  session_id: string;
+  started_at: string;
+  finished_at: string;
+  usage_suspect: boolean;
+  usage_suspect_reason: string | null;
+};
+
+/** Same stdin transport as OCL-155/156/160/165: a `-c` argument gets
+ * re-parsed by the remote shell, which corrupts any query carrying double
+ * quotes — an UPDATE with a JSON literal always does. Stdin skips that
+ * second parse. */
+function psql(query: string): string {
+  return execFileSync(
+    "ssh",
+    ["-o", "ConnectTimeout=5", SSH_HOST, `docker exec -i ${CONTAINER} psql -U ${DB_USER} -d ${DB_NAME} -t -A -v ON_ERROR_STOP=1`],
+    { encoding: "utf8", maxBuffer: 64 * 1024 * 1024, input: query },
+  );
+}
+
+function sh(cmd: string, args: string[]): string {
+  return execFileSync(cmd, args, { encoding: "utf8", maxBuffer: 64 * 1024 * 1024 });
+}
+
+function maskHost(hostAlias: string): string {
+  return `SSH alias "${hostAlias}" (real address never printed)`;
+}
+
+/** Same safety check OCL-153/155/160/165 use: refuse to touch anything that is not the real production database. */
+function assertRealProductionDb(): number {
+  const psList = sh("ssh", ["-o", "ConnectTimeout=5", SSH_HOST, "docker ps --format '{{.Names}}'"]);
+  if (!psList.includes("overclick-app-1") || !psList.includes(CONTAINER)) {
+    throw new Error(
+      `Expected containers overclick-app-1 and ${CONTAINER} both running on ${maskHost(SSH_HOST)}; got: ${psList.trim()}. Stopping instead of writing to a database nothing serves.`,
+    );
+  }
+  const countOut = psql("select count(*) from execution_attempt;");
+  const count = Number.parseInt(countOut.trim(), 10);
+  if (!Number.isFinite(count) || count < 500) {
+    throw new Error(
+      `execution_attempt has ${countOut.trim()} rows on ${maskHost(SSH_HOST)}/${CONTAINER}:${DB_NAME}. That is not the size /insights has been reporting. Stopping instead of writing to the wrong database.`,
+    );
+  }
+  return count;
+}
+
+/** Every finished attempt that carries a session_id — the only population
+ * the session-reuse component can ever apply to. Attempts with no
+ * session_id are out of scope entirely, in both the old and new rule. */
+function dumpCandidates(): AttemptRow[] {
+  const query = `
+select json_agg(row_to_json(t)) from (
+  select
+    ea.id, ea.task_id, t.short_id as task_short_id, p.workspace_id,
+    ea.session_id, ea.started_at, ea.finished_at,
+    ea.usage_suspect, ea.usage_suspect_reason
+  from execution_attempt ea
+  join task t on t.id = ea.task_id
+  join project p on p.id = t.project_id
+  where ea.finished_at is not null
+    and ea.session_id is not null
+  order by ea.started_at asc
+) t;`;
+  const out = psql(query);
+  return (JSON.parse(out.trim() || "null") ?? []) as AttemptRow[];
+}
+
+function splitReasons(reason: string | null): string[] {
+  return (reason ?? "")
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+function isSessionReusedToken(token: string): boolean {
+  return token === "session_reused" || token.startsWith("session_reused:");
+}
+
+/** Rebuilds the reason list with the session-reuse verdict recomputed and
+ * every other existing reason (claim_window_exceeded, from OCL-165;
+ * session_reused_orchestration) carried over untouched, in the same order
+ * usageGuardForAttempt writes them at delivery: window, session reuse,
+ * orchestration reuse. */
+function recomputeReasons(existing: string[], overlappingIds: string[]): string[] {
+  const hasWindow = existing.includes("claim_window_exceeded");
+  const hasOrchestration = existing.includes("session_reused_orchestration");
+  const reasons: string[] = [];
+  if (hasWindow) reasons.push("claim_window_exceeded");
+  if (overlappingIds.length > 0) reasons.push(`session_reused:${overlappingIds.join("+")}`);
+  if (hasOrchestration) reasons.push("session_reused_orchestration");
+  return reasons;
+}
+
+function overlaps(a: AttemptRow, b: AttemptRow): boolean {
+  const aStart = Date.parse(a.started_at);
+  const aEnd = Date.parse(a.finished_at);
+  const bStart = Date.parse(b.started_at);
+  const bEnd = Date.parse(b.finished_at);
+  return bStart < aEnd && aStart < bEnd;
+}
+
+/** Every other finished attempt in the same workspace + session, excluding
+ * attempts of the same task (re-executions of the same card, not reuse
+ * across cards) — the same exclusion usageGuardForAttempt applies. */
+function overlappingAttempts(attempt: AttemptRow, group: AttemptRow[]): AttemptRow[] {
+  return group.filter((other) => other.id !== attempt.id && other.task_id !== attempt.task_id && overlaps(attempt, other));
+}
+
+function sqlString(value: string): string {
+  return `'${value.replace(/'/g, "''")}'`;
+}
+
+function applyUpdate(attempt: AttemptRow, suspect: boolean, reason: string | null): void {
+  const setParts = [
+    `usage_suspect = ${suspect ? "true" : "false"}`,
+    reason ? `usage_suspect_reason = ${sqlString(reason)}` : "usage_suspect_reason = null",
+  ];
+  psql(`update execution_attempt set ${setParts.join(", ")} where id = '${attempt.id}';`);
+}
+
+function main() {
+  const apply = process.argv.includes("--apply");
+  const rowCount = assertRealProductionDb();
+  const candidates = dumpCandidates();
+
+  // Group by workspace + session: overlap only matters within the same
+  // workspace's session id, same as the app's query scopes by project.workspaceId.
+  const groups = new Map<string, AttemptRow[]>();
+  for (const attempt of candidates) {
+    const key = `${attempt.workspace_id}::${attempt.session_id}`;
+    const list = groups.get(key) ?? [];
+    list.push(attempt);
+    groups.set(key, list);
+  }
+
+  console.log(`# OCL-166 — backfill de usage_suspect com a régua de sobreposição de janela (${apply ? "APLICANDO" : "SIMULAÇÃO — nada será gravado"})`);
+  console.log("");
+  console.log(`Banco: container \`${CONTAINER}\`, banco \`${DB_NAME}\`, host ${maskHost(SSH_HOST)}. execution_attempt tem ${rowCount} linhas.`);
+  console.log(`Attempts finalizados com session_id (candidatos): ${candidates.length}`);
+  console.log(`Sessões distintas (workspace + session_id): ${groups.size}`);
+  console.log("");
+
+  type Row = {
+    attempt: AttemptRow;
+    newSuspect: boolean;
+    newReason: string | null;
+    overlappingIds: string[];
+    changed: boolean;
+    movedOut: boolean;
+    movedIn: boolean;
+  };
+  const rows: Row[] = [];
+
+  for (const attempt of candidates) {
+    const group = groups.get(`${attempt.workspace_id}::${attempt.session_id}`) ?? [];
+    const overlappingIds = overlappingAttempts(attempt, group).map((o) => o.id);
+    const existing = splitReasons(attempt.usage_suspect_reason);
+    const existingWithoutSessionReuse = existing.filter((token) => !isSessionReusedToken(token));
+    const newReasons = recomputeReasons(existingWithoutSessionReuse, overlappingIds);
+    const newSuspect = newReasons.length > 0;
+    const newReason = newReasons.length > 0 ? newReasons.join(",") : null;
+
+    const oldSuspect = attempt.usage_suspect;
+    const oldReason = attempt.usage_suspect_reason;
+    const changed = oldSuspect !== newSuspect || oldReason !== newReason;
+    const movedOut = oldSuspect && !newSuspect;
+    const movedIn = !oldSuspect && newSuspect;
+
+    rows.push({ attempt, newSuspect, newReason, overlappingIds, changed, movedOut, movedIn });
+  }
+
+  const toFix = rows.filter((r) => r.changed);
+  const movedOut = rows.filter((r) => r.movedOut);
+  const movedIn = rows.filter((r) => r.movedIn);
+  const reasonOnlyChanged = toFix.filter((r) => !r.movedOut && !r.movedIn);
+  const stillOverlapping = rows.filter((r) => r.overlappingIds.length > 0);
+
+  console.log(`## Resumo`);
+  console.log("");
+  console.log(`- Deixam de ser suspeitos: ${movedOut.length}`);
+  console.log(`- Passam a ser suspeitos (janela cruza e nunca tinha sido marcado — ex.: o lado "primeiro" de um par que se cruza): ${movedIn.length}`);
+  console.log(`- Continuam suspeitos, mas o motivo muda: ${reasonOnlyChanged.length}`);
+  console.log(`- Sem mudança nenhuma: ${rows.length - toFix.length}`);
+  console.log(`- Attempts cuja janela de fato cruza outro attempt da mesma sessão (novo total session_reused): ${stillOverlapping.length}`);
+  console.log("");
+
+  console.log(`## Deixam de ser suspeitos por reuso de sessão (${movedOut.length})`);
+  console.log("");
+  console.log("| Card | attempt | motivo antes | motivo depois |");
+  console.log("|------|---------|---------------|----------------|");
+  for (const { attempt, newReason } of movedOut) {
+    console.log(`| ${attempt.task_short_id} | ${attempt.id} | ${attempt.usage_suspect_reason ?? "null"} | ${newReason ?? "null"} |`);
+  }
+  console.log("");
+
+  console.log(`## Passam a ser suspeitos (${movedIn.length})`);
+  console.log("");
+  console.log("| Card | attempt | motivo antes | motivo depois |");
+  console.log("|------|---------|---------------|----------------|");
+  for (const { attempt, newReason } of movedIn) {
+    console.log(`| ${attempt.task_short_id} | ${attempt.id} | ${attempt.usage_suspect_reason ?? "null"} | ${newReason ?? "null"} |`);
+  }
+  console.log("");
+
+  if (reasonOnlyChanged.length > 0) {
+    console.log(`## Continuam suspeitos, motivo muda (${reasonOnlyChanged.length})`);
+    console.log("");
+    console.log("| Card | attempt | motivo antes | motivo depois |");
+    console.log("|------|---------|---------------|----------------|");
+    for (const { attempt, newReason } of reasonOnlyChanged) {
+      console.log(`| ${attempt.task_short_id} | ${attempt.id} | ${attempt.usage_suspect_reason ?? "null"} | ${newReason ?? "null"} |`);
+    }
+    console.log("");
+  }
+
+  if (!apply) {
+    console.log("Simulação apenas — nada foi gravado. Rode com --apply para escrever as mudanças acima.");
+    return;
+  }
+
+  console.log("Gravando as mudanças...");
+  for (const { attempt, newSuspect, newReason } of toFix) {
+    applyUpdate(attempt, newSuspect, newReason);
+    console.log(`- ${attempt.task_short_id} (${attempt.id}) -> usage_suspect=${newSuspect}, usage_suspect_reason=${newReason ?? "null"}`);
+  }
+  console.log("");
+  console.log(`Concluído: ${toFix.length} attempts regravados, ${rows.length - toFix.length} sem mudança.`);
+}
+
+main();


### PR DESCRIPTION
## Summary
- `usageGuardForAttempt` (apps/web/src/mcp/tools.ts) agora só marca `session_reused` quando a janela [started_at, finished_at] do attempt atual de fato cruza a de outro attempt finalizado da mesma sessão — antes bastava a sessão ser a mesma, mesmo com janelas sequenciais/disjuntas.
- Os dois lados de um cruzamento são marcados retroativamente, e o motivo passa a nomear o(s) attempt(s) com que houve sobreposição (`session_reused:<attempt_id>[+<attempt_id>...]`). Reuso de orquestração (`session_reused_orchestration`) não muda.
- Backfill rodado em produção (`scripts/ocl-166-backfill-usage-suspect-overlap.ts`, simulação antes de gravar): de 293 attempts antes marcados por reuso de sessão, 179 deixaram de ser suspeitos (janelas disjuntas), 29 passaram a ser suspeitos pela primeira vez (lado "primeiro" de um par que cruza, nunca marcado retroativamente antes), 113 continuam suspeitos com motivo atualizado. Total geral de `usage_suspect`: 295 → 145.

## Test plan
- [x] `pnpm typecheck` (repo inteiro) — verde
- [x] `pnpm test` (repo inteiro) — 647 passed, 2 skipped
- [x] Novo teste: dois cards entregues em sequência pela mesma sessão → nenhum marcado
- [x] Novo teste: dois cards com janelas sobrepostas → os dois marcados, motivo nomeia o attempt cruzado
- [x] Backfill rodado em modo simulação, revisado, depois aplicado em produção (gt40 / overclick-overclick-db-1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)